### PR TITLE
Fix tests

### DIFF
--- a/src/riak_core_claim.erl
+++ b/src/riak_core_claim.erl
@@ -265,7 +265,7 @@ wants_claim_test() ->
     riak_core_ring_manager:start_link(test),
     riak_core_test_util:setup_mockring1(),
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
-    ?assertEqual(yes, erlang:element(1,default_wants_claim(Ring))),
+    ?assertEqual(no, default_wants_claim(Ring)),
     riak_core_ring_manager:stop().
 
 find_biggest_hole_test() ->


### PR DESCRIPTION
This patch fixes the only constantly failing test. 

The actual result of this test is opposite to what was expected. We're trying to know whether or nor we need to rebalance current list of nodes [{nonode@nohost,4}, {othernode2@otherhost2,6}, {othernode@otherhost,6}]. The expected number of partitions is 5, so no need to re-balance yet.
