### PR TITLE
Bz882 cluster info

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -19,6 +19,7 @@
              riak_core_app,
              riak_core_bucket,
              riak_core_cinfo_basic,
+             riak_core_cinfo_core,
              riak_core_claim,
              riak_core_gossip,
              riak_core_handoff_listener,

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -49,6 +49,7 @@ start(_StartType, _StartArgs) ->
     %% Register our cluster_info app callback modules, with catch if
     %% the app is missing or packaging is broken.
     catch cluster_info:register_app(riak_core_cinfo_basic),
+    catch cluster_info:register_app(riak_core_cinfo_core),
 
     %% Spin up the supervisor; prune ring files as necessary
     case riak_core_sup:start_link() of

--- a/src/riak_core_cinfo_core.erl
+++ b/src/riak_core_cinfo_core.erl
@@ -1,0 +1,58 @@
+%% -------------------------------------------------------------------
+%%
+%% Riak: A lightweight, decentralized key-value store.
+%%
+%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_cinfo_core).
+
+-export([cluster_info_init/0, cluster_info_generator_funs/0]).
+
+%% @spec () -> term()
+%% @doc Required callback function for cluster_info: initialization.
+%%
+%% This function doesn't have to do anything.
+
+cluster_info_init() ->
+    ok.
+
+%% @spec () -> list({string(), fun()})
+%% @doc Required callback function for cluster_info: return list of
+%%      {NameForReport, FunOfArity_1} tuples to generate ASCII/UTF-8
+%%      formatted reports.
+
+cluster_info_generator_funs() ->
+    [
+     {"Riak Core vnode modules", fun vnode_modules/1},
+     {"Riak Core ring", fun get_my_ring/1},
+     {"Riak Core latest ring file", fun latest_ringfile/1}
+    ].
+
+vnode_modules(CPid) -> % CPid is the data collector's pid.
+    cluster_info:format(CPid, "~p\n", [riak_core:vnode_modules()]).
+
+get_my_ring(CPid) ->
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    cluster_info:format(CPid, "~p\n", [Ring]).
+
+latest_ringfile(CPid) ->
+    {ok, Path} = riak_core_ring_manager:find_latest_ringfile(),
+    {ok, Contents} = file:read_file(Path),
+    cluster_info:format(CPid, "Latest ringfile: ~s\n", [Path]),
+    cluster_info:format(CPid, "File contents:\n~p\n", [binary_to_term(Contents)]).
+


### PR DESCRIPTION
Reviewer: anyone interested

Update packaging for cluster_info, which is now under the basho org @ github.
Add a really basic set of info doodads for riak_core.  Arguably, some of
the cluster_info goop that I've added for riak_kv really belong to riak_core?
But as I've implemented the goop now, riak_core's info doesn't (I hope) call
any riak_kv code.
