### PR TITLE
Bz891 disable nagle

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -91,6 +91,9 @@
          %% Number of VNodes allowed to do handoff concurrently.
          {handoff_concurrency, 4},
 
+         %% Disable Nagle on HTTP sockets
+         {disable_http_nagle, false},
+
          %% Handoff IP/port
          {handoff_port, 8099},
          {handoff_ip, "0.0.0.0"}

--- a/src/riak_core_web.erl
+++ b/src/riak_core_web.erl
@@ -72,20 +72,24 @@ binding_config(Scheme, Binding) ->
   
 spec_from_binding(http, Name, Binding) ->
   {Ip, Port} = Binding,
+  NoDelay = app_helper:get_env(riak_core, disable_http_nagle, false),
   lists:flatten([{name, Name},
                   {ip, Ip},
-                  {port, Port}],
+                  {port, Port},
+                  {nodelay, NoDelay}],
                   common_config());
 
 spec_from_binding(https, Name, Binding) ->
   {Ip, Port} = Binding,
   SslOpts = app_helper:get_env(riak_core, ssl,
                      [{certfile, "etc/cert.pem"}, {keyfile, "etc/key.pem"}]),
+  NoDelay = app_helper:get_env(riak_core, disable_http_nagle, false),
   lists:flatten([{name, Name},
                   {ip, Ip},
                   {port, Port},
                   {ssl, true},
-                  {ssl_opts, SslOpts}],
+                  {ssl_opts, SslOpts},
+                  {nodelay, NoDelay}],
                   common_config()).
 
 spec_name(Scheme, Ip, Port) ->


### PR DESCRIPTION
Adding an option to disable nagle on HTTP bindings. Note that this option is global across all bindings, for the moment. Default is to leave Nagle enabled.
