### PR TITLE
Missing parameter in call to error_logger:error_msg/2 when handoff exits abnormally

### DIFF
--- a/src/riak_core_handoff_receiver.erl
+++ b/src/riak_core_handoff_receiver.erl
@@ -63,7 +63,7 @@ handle_info({tcp, Socket, Data}, State) ->
     case catch(process_message(MsgType, MsgData, State)) of
         {'EXIT', Reason} ->
             error_logger:error_msg("Handoff receiver for partition ~p exiting abnormally after "
-                                   "processing ~p objects: ~p\n", [State#state.count, Reason]),
+                                   "processing ~p objects: ~p\n", [State#state.partition, State#state.count, Reason]),
             {stop, normal, State};
         NewState when is_record(NewState, state) ->
             inet:setopts(Socket, [{active, once}]),


### PR DESCRIPTION
The resulting spew from riak_err tends to mask the root problem.  Many graciases for the merging of the Abby Normal fixes.

--Ryan
