### PR TITLE
Bz971 stats latency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,7 @@
 {deps, [
   {protobuffs, "0.5.1", {git, "git://github.com/basho/erlang_protobuffs",
                               {tag, "protobuffs-0.5.1"}}},
+  {basho_stats, ".*", {git, "git://github.com/basho/basho_stats", "HEAD"}},
   {webmachine, "1.8.*", {git, "git://github.com/basho/webmachine",
                               {tag, "webmachine-1.8.0"}}}
        ]}.

--- a/src/slide.erl
+++ b/src/slide.erl
@@ -151,7 +151,12 @@ sum(#slide{dir=Dir}, Moment, Seconds) ->
     sum_blobs(Blobs, Moment, Cutoff).
 
 private_dir() ->
-    lists:flatten(io_lib:format("~s/~s", [?DIR, os:getpid()])).
+    case application:get_env(riak_core, slide_private_dir) of
+        undefined ->
+            lists:flatten(io_lib:format("~s/~s", [?DIR, os:getpid()]));
+        {ok, Dir} ->
+            Dir
+    end.
 
 sync(_S) ->
     todo.


### PR DESCRIPTION
Pull request 3 of 3 for bz971

I expect this one to be controversial.  The changes to slide.erl require some place to put temp files on disk.  There is no global config option right now for the data dir, and you can't rely on your OS proc's cwd to be the data directory or even that cwd is writable by the "riak" user.  For 1M operations/min, these temp files use about 15MB of space per slide.

The spiral change may also be controversial, but I'm sticking to my guns: we aren't using any stats beyond 1 minute, so we shouldn't maintain them.  And there's genuine evidence that the extra spiral data maintenance is causing latency problems (see bz971 and related ZenDesk ticket).  Therefore, the surgery to remove minute, hour, and day stats is justified.  The defense rests.
