### PR TITLE
Merging default_bucket_props from app.config

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -76,14 +76,6 @@
          {wants_claim_fun, {riak_core_claim, default_wants_claim}},
          {choose_claim_fun, {riak_core_claim, default_choose_claim}},
 
-         %% Default bucket props
-         {default_bucket_props, [{n_val,3},
-                                 {allow_mult,false},
-                                 {last_write_wins,false},
-                                 {precommit, []},
-                                 {postcommit, []},
-                                 {chash_keyfun, {riak_core_util, chash_std_keyfun}}]},
-
          %% Vnode inactivity timeout (how often to check if fallback vnodes
          %% should return their data) in ms.
          {vnode_inactivity_timeout, 60000},

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -51,6 +51,16 @@ start(_StartType, _StartArgs) ->
     catch cluster_info:register_app(riak_core_cinfo_basic),
     catch cluster_info:register_app(riak_core_cinfo_core),
 
+    %% add these defaults now to supplement the set that may have been
+    %% configured in app.config
+    riak_core_bucket:append_bucket_defaults(
+      [{n_val,3},
+       {allow_mult,false},
+       {last_write_wins,false},
+       {precommit, []},
+       {postcommit, []},
+       {chash_keyfun, {riak_core_util, chash_std_keyfun}}]),
+
     %% Spin up the supervisor; prune ring files as necessary
     case riak_core_sup:start_link() of
         {ok, Pid} ->

--- a/src/riak_core_bucket.erl
+++ b/src/riak_core_bucket.erl
@@ -64,7 +64,8 @@ set_bucket(Name, BucketProps) ->
 %% @doc Merge two sets of bucket props.  If duplicates exist, the
 %%      entries in Overriding are chosen before those in Other.
 merge_props(Overriding, Other) ->
-    lists:ukeymerge(1, lists:sort(Overriding), lists:sort(Other)).
+    lists:ukeymerge(1, lists:ukeysort(1, Overriding),
+                    lists:ukeysort(1, Other)).
 
 %% @spec get_bucket(riak_object:bucket()) ->
 %%         {ok, BucketProps :: riak_core_bucketprops()}

--- a/src/riak_core_bucket.erl
+++ b/src/riak_core_bucket.erl
@@ -36,7 +36,8 @@
 
 %% @doc Add a list of defaults to global list of defaults for new buckets.
 append_bucket_defaults(Items) when is_list(Items) ->
-    NewDefaults = app_helper:get_env(riak_core, default_bucket_props) ++ Items,
+    NewDefaults =
+        app_helper:get_env(riak_core, default_bucket_props, []) ++ Items,
     application:set_env(riak_core, default_bucket_props, NewDefaults).
 
 

--- a/src/riak_core_bucket.erl
+++ b/src/riak_core_bucket.erl
@@ -34,10 +34,16 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
-%% @doc Add a list of defaults to global list of defaults for new buckets.
+%% @doc Add a list of defaults to global list of defaults for new
+%%      buckets.  If any item is in Items is already set in the
+%%      current defaults list, the new setting is omitted, and the old
+%%      setting is kept.  Omitting the new setting is intended
+%%      behavior, to allow settings from app.config to override any
+%%      hard-coded values.
 append_bucket_defaults(Items) when is_list(Items) ->
+    OldDefaults = app_helper:get_env(riak_core, default_bucket_props, []),
     NewDefaults =
-        app_helper:get_env(riak_core, default_bucket_props, []) ++ Items,
+        lists:ukeymerge(1, lists:sort(OldDefaults), lists:sort(Items)),
     application:set_env(riak_core, default_bucket_props, NewDefaults).
 
 


### PR DESCRIPTION
The first of these patches fixes the problem where specifying default bucket properties in app.config is an all-or-nothing venture.  Anything specified in app.config is now merged with the defaults specified in riak_core_app.erl (the same defaults as before, just in a more accessible place).  The settings in app.config override the hard-coded ones in the source, of course.

The second patch fixes the problem where app.config bucket properties might cause duplicate property entries in the list.  This fixes some confusion and fragility.

The third patch just cleans up and standardizes the prop-merging code.
