### PR TITLE
Az113 system monitor

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -35,6 +35,7 @@
              riak_core_ring_manager,
              riak_core_ring_util,
              riak_core_sup,
+             riak_core_sysmon_handler,
              riak_core_test_util,
              riak_core_util,
              riak_core_vnode,
@@ -52,6 +53,7 @@
                   stdlib,
                   sasl,
                   crypto,
+                  riak_sysmon,
                   webmachine
                  ]},
   {mod, { riak_core_app, []}},

--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -36,6 +36,7 @@
              riak_core_ring_util,
              riak_core_sup,
              riak_core_sysmon_handler,
+             riak_core_sysmon_minder,
              riak_core_test_util,
              riak_core_util,
              riak_core_vnode,

--- a/rebar.config
+++ b/rebar.config
@@ -4,6 +4,7 @@
   {protobuffs, "0.5.1", {git, "git://github.com/basho/erlang_protobuffs",
                               {tag, "protobuffs-0.5.1"}}},
   {basho_stats, ".*", {git, "git://github.com/basho/basho_stats", "HEAD"}},
+  {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon", {branch, "master"}}},
   {webmachine, "1.8.*", {git, "git://github.com/basho/webmachine",
                               {tag, "webmachine-1.8.0"}}}
        ]}.

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -32,6 +32,9 @@
 %% ===================================================================
 
 start(_StartType, _StartArgs) ->
+    %% Add our system_monitor event handler
+    riak_core_sysmon_handler:add_handler(),
+
     %% Validate that the ring state directory exists
     riak_core_util:start_app_deps(riak_core),
     RingStateDir = app_helper:get_env(riak_core, ring_state_dir),

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -32,8 +32,9 @@
 %% ===================================================================
 
 start(_StartType, _StartArgs) ->
-    %% Add our system_monitor event handler
-    riak_core_sysmon_handler:add_handler(),
+    %% Don't add our system_monitor event handler here.  Instead, let
+    %% riak_core_sysmon_minder start it, because that process can act
+    %% on any handler crash notification, whereas we cannot.
 
     %% Validate that the ring state directory exists
     riak_core_util:start_app_deps(riak_core),

--- a/src/riak_core_sup.erl
+++ b/src/riak_core_sup.erl
@@ -57,7 +57,8 @@ init([]) ->
                end,
 
     Children = lists:flatten(
-                 [?CHILD(riak_core_vnode_sup, supervisor),
+                 [?CHILD(riak_core_sysmon_minder, worker),
+                  ?CHILD(riak_core_vnode_sup, supervisor),
                   ?CHILD(riak_core_handoff_manager, worker),
                   ?CHILD(riak_core_handoff_listener, worker),
                   ?CHILD(riak_core_ring_events, worker),

--- a/src/riak_core_sysmon_handler.erl
+++ b/src/riak_core_sysmon_handler.erl
@@ -119,8 +119,9 @@ handle_call(_Call, State) ->
 %%                         remove_handler
 %% @end
 %%--------------------------------------------------------------------
-handle_info(die, _State) ->
-    exit(told_to_die);
+handle_info(die_for_testing_purposes_only, _State) ->
+    %% exit({told_to_die, lists:duplicate(500000, $x)});
+    exit({told_to_die, lists:duplicate(50, $x)});
 handle_info(Info, State) ->
     error_logger:info_msg("handle_info got ~p\n", [Info]),
     {ok, State}.

--- a/src/riak_core_sysmon_handler.erl
+++ b/src/riak_core_sysmon_handler.erl
@@ -1,0 +1,192 @@
+%% Copyright (c) 2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+
+%% @doc A custom event handler to the `riak_sysmon' application's
+%% `system_monitor' event manager.
+%%
+%% This module attempts to discover more information about a process
+%% that generates a system_monitor event.
+
+-module(riak_core_sysmon_handler).
+
+-behaviour(gen_event).
+
+%% API
+-export([add_handler/0]).
+%% Perhaps useful to the outside world.
+-export([format_pretty_proc_info/1, format_pretty_proc_info/2,
+         get_pretty_proc_info/1, get_pretty_proc_info/2]).
+
+%% gen_event callbacks
+-export([init/1, handle_event/2, handle_call/2, 
+         handle_info/2, terminate/2, code_change/3]).
+
+-record(state, {}).
+
+%%%===================================================================
+%%% gen_event callbacks
+%%%===================================================================
+
+add_handler() ->
+    %% Vulnerable to race conditions (installing handler multiple
+    %% times), but risk is zero in the common OTP app startup case.
+    case lists:member(?MODULE,
+                      gen_event:which_handlers(riak_sysmon_handler)) of
+        true ->
+            ok;
+        false ->
+            riak_sysmon_filter:add_custom_handler(?MODULE, [])
+    end.
+
+%%%===================================================================
+%%% gen_event callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Whenever a new event handler is added to an event manager,
+%% this function is called to initialize the event handler.
+%%
+%% @spec init(Args) -> {ok, State}
+%% @end
+%%--------------------------------------------------------------------
+init([]) ->
+    {ok, #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Whenever an event manager receives an event sent using
+%% gen_event:notify/2 or gen_event:sync_notify/2, this function is
+%% called for each installed event handler to handle the event.
+%%
+%% @spec handle_event(Event, State) ->
+%%                          {ok, State} |
+%%                          {swap_handler, Args1, State1, Mod2, Args2} |
+%%                          remove_handler
+%% @end
+%%--------------------------------------------------------------------
+handle_event({monitor, Pid, Type, Info}, State) ->
+    Pretty = format_pretty_proc_info(Pid, almost_current_function),
+    error_logger:info_msg("monitor ~w ~w ~s ~w\n",
+                          [Type, Pid, Pretty, Info]),
+    {ok, State};
+handle_event(Event, State) ->
+    error_logger:info_msg("Monitor ~p\n", [Event]),
+    {ok, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Whenever an event manager receives a request sent using
+%% gen_event:call/3,4, this function is called for the specified
+%% event handler to handle the request.
+%%
+%% @spec handle_call(Request, State) ->
+%%                   {ok, Reply, State} |
+%%                   {swap_handler, Reply, Args1, State1, Mod2, Args2} |
+%%                   {remove_handler, Reply}
+%% @end
+%%--------------------------------------------------------------------
+handle_call(_Call, State) ->
+    Reply = not_supported,
+    {ok, Reply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called for each installed event handler when
+%% an event manager receives any other message than an event or a
+%% synchronous request (or a system message).
+%%
+%% @spec handle_info(Info, State) ->
+%%                         {ok, State} |
+%%                         {swap_handler, Args1, State1, Mod2, Args2} |
+%%                         remove_handler
+%% @end
+%%--------------------------------------------------------------------
+handle_info(die, _State) ->
+    exit(told_to_die);
+handle_info(Info, State) ->
+    error_logger:info_msg("handle_info got ~p\n", [Info]),
+    {ok, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Whenever an event handler is deleted from an event manager, this
+%% function is called. It should be the opposite of Module:init/1 and
+%% do any necessary cleaning up.
+%%
+%% @spec terminate(Reason, State) -> void()
+%% @end
+%%--------------------------------------------------------------------
+terminate(_Reason, _State) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%%
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%% @end
+%%--------------------------------------------------------------------
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+format_pretty_proc_info(Pid) ->
+    format_pretty_proc_info(Pid, current_function).
+
+format_pretty_proc_info(Pid, Acf) ->
+    try
+        case get_pretty_proc_info(Pid, Acf) of
+            undefined ->
+                "";
+            Res ->
+                io_lib:format("~w", [Res])
+        end
+    catch X:Y ->
+            io_lib:format("Pid ~w, ~W ~W at ~w\n",
+                          [Pid, X, 20, Y, 20, erlang:get_stacktrace()])
+    end.
+
+get_pretty_proc_info(Pid) ->
+    get_pretty_proc_info(Pid, current_function).
+
+get_pretty_proc_info(Pid, Acf) ->
+    case process_info(Pid, [registered_name, initial_call, current_function]) of
+        undefined ->
+            undefined;
+        [] ->
+            undefined;
+        [{registered_name, RN0}, ICT1, {_, CF}] ->
+            ICT = case proc_lib:translate_initial_call(Pid) of
+                     {proc_lib, init_p, 5} ->   % not by proc_lib, see docs
+                         ICT1;
+                     ICT2 ->
+                         {initial_call, ICT2}
+                 end,
+            RNL = if RN0 == [] -> [];
+                     true      -> [{name, RN0}]
+                  end,
+            RNL ++ [ICT, {Acf, CF}]
+    end.

--- a/src/riak_core_sysmon_minder.erl
+++ b/src/riak_core_sysmon_minder.erl
@@ -1,0 +1,163 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_core: Core Riak Application
+%%
+%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_core_sysmon_minder).
+
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-record(state, {}).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Starts the server
+%%
+%% @spec start_link() -> {ok, Pid} | ignore | {error, Error}
+%% @end
+%%--------------------------------------------------------------------
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Initializes the server
+%%
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%% @end
+%%--------------------------------------------------------------------
+init([]) ->
+    %% Add our system_monitor event handler.  We do that here because
+    %% we have a process at our disposal (i.e. ourself) to receive the
+    %% notification in the very unlikely event that the
+    %% riak_core_sysmon_handler has crashed and been removed from the
+    %% riak_sysmon_handler gen_event server.  (If we had a supervisor
+    %% or app-starting process add the handler, then if the handler
+    %% crashes, nobody will act on the crash notification.)
+    riak_core_sysmon_handler:add_handler(),
+
+    {ok, #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling call messages
+%%
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_call(_Request, _From, State) ->
+    Reply = ok,
+    {reply, Reply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling cast messages
+%%
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling all non call/cast messages
+%%
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_info({gen_event_EXIT, riak_core_sysmon_handler, _}, State) ->
+    %% SASL will create an error message, no need for us to duplicate it.
+    %%
+    %% Our handler should never crash, but it did indeed crash.  If
+    %% there's a pathological condition somewhere that's generating
+    %% lots of unforseen things that crash core's custom handler, we
+    %% could make things worse by jumping back into the exploding
+    %% volcano.  Wait a little bit before jumping back.  Besides, the
+    %% system_monitor data is nice but is not critical: there is no
+    %% need to make things worse if things are indeed bad, and if we
+    %% miss a few seconds of system_monitor events, the world will not
+    %% end.
+    timer:sleep(2*1000),
+    riak_core_sysmon_handler:add_handler(),
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%%
+%% @spec terminate(Reason, State) -> void()
+%% @end
+%%--------------------------------------------------------------------
+terminate(_Reason, _State) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%%
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%% @end
+%%--------------------------------------------------------------------
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================


### PR DESCRIPTION
Reviewer: anyone.

Add a custom event handler for system_monitor messages,
based on the riak_sysmon OTP app's scheme.  Try to find
some useful but cheap extra info on each reported pid.

Add a minder process to watch for should-never-happen
crashes and reinstate the handler if it the handler does indeed
crash.
