### PR TITLE
Bz823 handoff processing

### DIFF
--- a/src/riak_core_handoff_listener.erl
+++ b/src/riak_core_handoff_listener.erl
@@ -37,7 +37,16 @@ start_link() ->
 
 init([PortNum]) -> 
     register(?MODULE, self()),
+
+    %% This exit() call shouldn't be necessary, AFAICT the VM's EXIT
+    %% propagation via linking should do the right thing, but BZ 823
+    %% suggests otherwise.  However, the exit() call should fall into
+    %% the "shouldn't hurt", especially since the next line will
+    %% explicitly try to spawn a new proc that will try to register
+    %% the riak_kv_handoff_listener name.
+    catch exit(whereis(riak_kv_handoff_listener), kill),
     process_proxy:start_link(riak_kv_handoff_listener, ?MODULE),
+
     {ok, #state{portnum=PortNum}}.
 
 sock_opts() -> [binary, {packet, 4}, {reuseaddr, true}, {backlog, 64}].


### PR DESCRIPTION
Reviewer: whoever's free.

As mentioned in the BZ 823 comments, this one seems quite odd.
BZ 719 fixed the function_clause error that triggered the first cascade,
but it isn't clear why the riak_kv_handoff_listener would still be alive
4 full seconds after a proc that it linked to had crashed.
