### PR TITLE
Correct riak_core_bucket's eunit test

### DIFF
--- a/src/riak_core_bucket.erl
+++ b/src/riak_core_bucket.erl
@@ -101,6 +101,11 @@ get_bucket(Name, Ring) ->
 
 simple_set_test() ->
     application:load(riak_core),
+    %% appending an empty list of defaults makes up for the fact that
+    %% riak_core_app:start/2 is not called during eunit runs
+    %% (that's where the usual defaults are set at startup),
+    %% while also not adding any trash that might affect other tests
+    append_bucket_defaults([]),
     riak_core_ring_events:start_link(),
     riak_core_ring_manager:start_link(test),
     ok = set_bucket(a_bucket,[{key,value}]),


### PR DESCRIPTION
This test fixes riak-core_bucket's eunit test case by making sure that riak_core's application environment default_bucket_props is defined to at least be the empty list.  In a recent change, the riak_core application starts up with that env undefined, and then sets it in riak_core_app:start/2, but that function is not run during eunit.

Reviewer: Scott (the reporter)
