### PR TITLE
Bz520 double wrap req

### DIFF
--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -196,16 +196,16 @@ handle_sync_event({handoff_data,BinObj}, _From, StateName,
 handle_info(_Info, StateName, State) ->
     {next_state, StateName, State, State#state.inactivity_timeout}.
 
-terminate(Reason, _StateName, #state{mod=Mod, modstate=ModState} = State) ->
+terminate(Reason, _StateName, State=#state{mod=Mod, modstate=ModState}) ->
     impure(State, {mod, Mod}, terminate, [Reason, ModState]),
     ok.
 
 code_change(_OldVsn, StateName, State, _Extra) ->
     {ok, StateName, State}.
 
-should_handoff(#state{index=Idx, mod=Mod} = S) ->
-    {ok, Ring} = impure(S, riak_core_ring_manager, get_my_ring, []),
-    Me = impure(S, erlang, node, []),
+should_handoff(State=#state{index=Idx, mod=Mod}) ->
+    {ok, Ring} = impure(State, riak_core_ring_manager, get_my_ring, []),
+    Me = impure(State, erlang, node, []),
     case riak_core_ring:index_owner(Ring, Idx) of
         Me ->
             false;
@@ -215,7 +215,7 @@ should_handoff(#state{index=Idx, mod=Mod} = S) ->
                     [First, "vnode"]          -> First
                 end,
             App = list_to_atom("riak_" ++ A),
-            AppNodes = impure(S, riak_core_node, watcher_nodes, [App]),
+            AppNodes = impure(State, riak_core_node_watcher, nodes, [App]),
             case lists:member(TargetNode, AppNodes) of
                 false  -> false;
                 true -> {true, TargetNode}

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -274,9 +274,9 @@ make_vnode_request(Request) ->
 
 %% Impure handling stuff
 
-imp_interp(Fun, Arg) when not is_tuple(Fun), is_function(Fun, 1) ->
+impure_mod_call(Fun, Arg) when not is_tuple(Fun), is_function(Fun, 1) ->
     Fun(Arg);
-imp_interp(Else, _) ->
+impure_mod_call(Else, _) ->
     Else.
 
 impure(#state{pure_p = false}, {mod, Mod}, Func, ArgList) ->
@@ -284,7 +284,7 @@ impure(#state{pure_p = false}, {mod, Mod}, Func, ArgList) ->
 impure(#state{pure_p = false}, Mod, Func, ArgList) ->
     erlang:apply(Mod, Func, ArgList);
 impure(#state{pure_opts = PureOpts}, {mod, _Mod}, Func, ArgList) ->
-    imp_interp(proplists:get_value({mod, Func}, PureOpts), ArgList);
+    impure_mod_call(proplists:get_value({mod, Func}, PureOpts), ArgList);
 impure(#state{pure_opts = PureOpts}, Mod, Func, ArgList) ->
-    imp_interp(proplists:get_value({Mod, Func}, PureOpts), ArgList).
+    impure_mod_call(proplists:get_value({Mod, Func}, PureOpts), ArgList).
 

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -118,7 +118,7 @@ vnode_command(Sender, Request, State=#state{mod=Mod, modstate=ModState}) ->
             {stop, Reason, State#state{modstate=NewModState}}
     end.
 
-vnode_handoff_command(Sender, Request, State=#state{index=Index,
+vnode_handoff_command(Sender, Request, WrapperReq, State=#state{index=Index,
                                                     mod=Mod, 
                                                     modstate=ModState, 
                                                     handoff_node=HN}) ->
@@ -132,7 +132,7 @@ vnode_handoff_command(Sender, Request, State=#state{index=Index,
         {forward, NewModState} ->
             RegName = impure(State, riak_core_vnode_master, reg_name, [Mod]),
             impure(State, riak_core_vnode_master, command, 
-                   [{Index, HN}, Request, Sender, RegName]),
+                   [{Index, HN}, WrapperReq, Sender, RegName]),
             continue(State, NewModState);
         {drop, NewModState} ->
             continue(State, NewModState);
@@ -156,8 +156,8 @@ active(timeout, State=#state{mod=Mod, modstate=ModState}) ->
 active(?VNODE_REQ{sender=Sender, request=Request},
        State=#state{handoff_node=HN}) when HN =:= none ->
     vnode_command(Sender, Request, State);
-active(?VNODE_REQ{sender=Sender, request=Request},State) ->
-    vnode_handoff_command(Sender, Request, State);
+active(VR=?VNODE_REQ{sender=Sender, request=Request},State) ->
+    vnode_handoff_command(Sender, Request, VR, State);
 active(handoff_complete, State=#state{mod=Mod, 
                                       modstate=ModState,
                                       index=Idx, 

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -110,7 +110,7 @@ vnode_command(Sender, Request, State=#state{mod=Mod, modstate=ModState}) ->
     case impure(State, {mod, Mod}, handle_command,
                 [Request, Sender, ModState]) of
         {reply, Reply, NewModState} ->
-            impure(State, {mod, Mod}, reply, [Sender, Reply]),
+            impure(State, {mod, ?MODULE}, reply, [Sender, Reply]),
             continue(State, NewModState);
         {noreply, NewModState} ->
             continue(State, NewModState);
@@ -125,7 +125,7 @@ vnode_handoff_command(Sender, Request, State=#state{index=Index,
     case impure(State, {mod, Mod}, handle_handoff_command,
                 [Request, Sender, ModState]) of
         {reply, Reply, NewModState} ->
-            reply(Sender, Reply),
+            impure(State, {mod, ?MODULE}, reply, [Sender, Reply]),
             continue(State, NewModState);
         {noreply, NewModState} ->
             continue(State, NewModState);

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -187,7 +187,8 @@ handle_sync_event({handoff_data,BinObj}, _From, StateName,
             {reply, ok, StateName, State#state{modstate=NewModState},
              State#state.inactivity_timeout};
         {reply, {error, Err}, NewModState} ->
-            error_logger:error_msg("Error storing handoff obj: ~p~n", [Err]),            
+            impure(State, error_logger, error_msg,
+                   ["Error storing handoff obj: ~p~n", [Err]]),
             {reply, {error, Err}, StateName, State#state{modstate=NewModState}, 
              State#state.inactivity_timeout}
     end.

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -118,7 +118,7 @@ vnode_command(Sender, Request, State=#state{mod=Mod, modstate=ModState}) ->
             {stop, Reason, State#state{modstate=NewModState}}
     end.
 
-vnode_handoff_command(Sender, Request, WrapperReq, State=#state{index=Index,
+vnode_handoff_command(Sender, Request, State=#state{index=Index,
                                                     mod=Mod, 
                                                     modstate=ModState, 
                                                     handoff_node=HN}) ->
@@ -132,7 +132,7 @@ vnode_handoff_command(Sender, Request, WrapperReq, State=#state{index=Index,
         {forward, NewModState} ->
             RegName = impure(State, riak_core_vnode_master, reg_name, [Mod]),
             impure(State, riak_core_vnode_master, command, 
-                   [{Index, HN}, WrapperReq, Sender, RegName]),
+                   [{Index, HN}, Request, Sender, RegName]),
             continue(State, NewModState);
         {drop, NewModState} ->
             continue(State, NewModState);
@@ -156,8 +156,8 @@ active(timeout, State=#state{mod=Mod, modstate=ModState}) ->
 active(?VNODE_REQ{sender=Sender, request=Request},
        State=#state{handoff_node=HN}) when HN =:= none ->
     vnode_command(Sender, Request, State);
-active(VR=?VNODE_REQ{sender=Sender, request=Request},State) ->
-    vnode_handoff_command(Sender, Request, VR, State);
+active(?VNODE_REQ{sender=Sender, request=Request},State) ->
+    vnode_handoff_command(Sender, Request, State);
 active(handoff_complete, State=#state{mod=Mod, 
                                       modstate=ModState,
                                       index=Idx, 

--- a/test/gen_fsm_test_driver.erl
+++ b/test/gen_fsm_test_driver.erl
@@ -1,0 +1,148 @@
+%%
+%% Copyright (c) 2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(gen_fsm_test_driver).
+
+-define(INFINITE_TIMEOUT, 99999999999).
+
+%% API for gen_fsm
+-export([start/3
+         % ,
+         % send_event/2, sync_send_event/2, sync_send_event/3,
+         % send_all_state_event/2,
+         % sync_send_all_state_event/2, sync_send_all_state_event/3,
+         % reply/2
+        ]).
+
+%% API for our extensions
+-export([run_to_completion/4, destroy_id/1,
+         get_state/1, get_statedata/1, get_trace/1,
+         save_state/2, save_statedata/2,
+         add_trace/2
+        ]).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+start(FsmID, Mod, Args) ->
+    io:format("Start: ~p\n", [FsmID]),
+    destroy_id(FsmID),
+    erlang:put(make_key(FsmID, trace), []),
+    simplify_init(Mod:init(Args)).
+
+run_to_completion(FsmID, Mod, InitIter, Events) ->
+    run_iterations(FsmID, Mod, InitIter, Events).
+
+get_state(FsmID) ->
+    erlang:get(make_key(FsmID, state)).
+
+get_statedata(FsmID) ->
+    erlang:get(make_key(FsmID, statedata)).
+
+%% NOTE: For external use only: reverse() can make life difficult!
+
+get_trace(FsmID) ->
+    lists:reverse(case erlang:get(make_key(FsmID, trace)) of
+                      undefined -> [];
+                      Else      -> Else
+                  end).
+
+save_state(FsmID, State) ->
+    erlang:put(make_key(FsmID, state), State).
+
+save_statedata(FsmID, StateData) ->
+    erlang:put(make_key(FsmID, statedata), StateData).
+
+add_trace(Options, TraceEvent) when is_list(Options) ->
+    add_trace(proplists:get_value(my_ref, Options), TraceEvent);
+add_trace(FsmID, TraceEvent) ->
+    Traces = erlang:get(make_key(FsmID, trace)),
+    erlang:put(make_key(FsmID, trace), [TraceEvent|Traces]).
+
+destroy_id(FsmID) ->
+    erlang:erase(make_key(FsmID, trace)),
+    erlang:erase(make_key(FsmID, state)),
+    erlang:erase(make_key(FsmID, statedata)),
+    ok.
+
+make_key(FsmID, Type) ->
+    {?MODULE, FsmID, Type}.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+run_iterations(FsmID, Mod, {next_state, StateName, StateData, 0}, Events) ->
+    NextI = Mod:StateName(timeout, StateData),
+    run_iterations(FsmID, Mod, simplify(FsmID, unused, NextI), Events);
+run_iterations(_FsmID, _Mod, {next_state, StateName, StateData, _}, []) ->
+    {need_events, StateName, StateData};
+run_iterations(_FsmID, _Mod, {stop, StateName, StateData}, UnconsumedEvents) ->
+    {stopped, StateName, StateData, UnconsumedEvents};
+run_iterations(FsmID, Mod, {next_state, StateName, StateData, _}, [E|Es]) ->
+    case E of
+        {send_event, Event} ->
+            NextI = Mod:StateName(Event, StateData),
+            run_iterations(FsmID, Mod, simplify(FsmID, unused, NextI), Es);
+        {send_all_state_event, Event} ->
+            NextI = Mod:handle_event(Event, StateName, StateData),
+            run_iterations(FsmID, Mod, simplify(FsmID, unused, NextI), Es);
+        {sync_send_event, From, Event} ->
+            NextI = Mod:StateName(Event, From, StateData),
+            run_iterations(FsmID, Mod, simplify(FsmID, From, NextI), Es);
+        {sync_send_all_state_event, From, Event} ->
+            NextI = Mod:handle_sync_event(Event, From, StateName, StateData),
+            run_iterations(FsmID, Mod, simplify(FsmID, From, NextI), Es)
+    end.
+
+%% return {next_state, StateName, StateData, integer()} |
+%%        exit()
+
+simplify_init({stop, Reason}) ->
+    exit({stop_not_supported, Reason});
+simplify_init(ignore) ->
+    exit(ignore_not_supported);
+simplify_init({ok, StateName, StateData}) ->
+    {next_state, StateName, StateData, ?INFINITE_TIMEOUT};
+simplify_init({ok, StateName, StateData, Timeout}) ->
+    {next_state, StateName, StateData, simplify_timeout(Timeout)}.
+
+%% return {stop, Reason, StateData} |
+%%        {next_state, StateName, StateData, Timeout}
+
+simplify(_FsmID, _From, {stop, _Reason, _StateData} = X) ->
+    X;
+simplify(FsmID, From, {stop, Reason, Reply, StateData}) ->
+    add_trace(FsmID, {reply, From, Reply}),
+    {stop, Reason, StateData};
+simplify(_FsmID, _From, {next_state, StateName, StateData}) ->
+    {next_state, StateName, StateData, ?INFINITE_TIMEOUT};
+simplify(_FsmID, _From, {next_state, StateName, StateData, Timeout}) ->
+    {next_state, StateName, StateData, simplify_timeout(Timeout)};
+simplify(FsmID, From, {reply, Reply, StateName, StateData}) ->
+    add_trace(FsmID, {reply, From, Reply}),
+    {next_state, StateName, StateData, ?INFINITE_TIMEOUT};
+simplify(FsmID, From, {reply, Reply, StateName, StateData, Timeout}) ->
+    add_trace(FsmID, {reply, From, Reply}),
+    {next_state, StateName, StateData, simplify_timeout(Timeout)}.
+
+simplify_timeout(infinity) ->
+    ?INFINITE_TIMEOUT;
+simplify_timeout(hibernate) ->
+    ?INFINITE_TIMEOUT;
+simplify_timeout(Int) when is_integer(Int) ->
+    Int.
+

--- a/test/gen_fsm_test_driver.erl
+++ b/test/gen_fsm_test_driver.erl
@@ -40,7 +40,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 start(FsmID, Mod, Args) ->
-    io:format("Start: ~p\n", [FsmID]),
+    %% io:format("Start: ~p\n", [FsmID]),
     destroy_id(FsmID),
     erlang:put(make_key(FsmID, trace), []),
     simplify_init(Mod:init(Args)).

--- a/test/mock_vnode.erl
+++ b/test/mock_vnode.erl
@@ -33,7 +33,9 @@
          latereply/1,
          stop/1]).
 -export([init/1,
+         delete/1,
          handle_command/3,
+         handoff_finished/2,
          terminate/2]).
 
 -record(state, {index, counter}).
@@ -67,7 +69,6 @@ latereply(Preflist) ->
 stop(Preflist) ->
     riak_core_vnode_master:sync_command(Preflist, stop, ?MASTER).
 
-
 %% Callbacks
 
 init([Index]) ->
@@ -94,6 +95,12 @@ handle_command(latereply, Sender, State = #state{counter=Counter}) ->
                   riak_core_vnode:reply(Sender, latereply)
           end),
     {noreply, State#state{counter = Counter + 1}}.
+
+delete(State) ->
+    {ok, State}.
+
+handoff_finished(_TargetNode, State) ->
+    {ok, State}.
 
 terminate(_Reason, _State) ->
     ok.

--- a/test/vnode_test1.erl
+++ b/test/vnode_test1.erl
@@ -41,7 +41,7 @@ verify_bz520_test() ->
     MyPart = 42,                                % 42 is a nice partition #....
     OtherNode = other@node,
     OtherOpts = [{partition_owners, [{42, OtherNode}]}],
-    BZ520_request_is_this = verify_bz520,
+    BZ520_request_is_this = bz520_request_is_a_single_atom_not_tuple,
     PureOpts = [
                 %% Setup should_handoff(): OtherNode is up
                 {{riak_core_node_watcher, nodes},

--- a/test/vnode_test1.erl
+++ b/test/vnode_test1.erl
@@ -94,6 +94,8 @@ verify_bz520_test() ->
         ?PURE_DRIVER:run_to_completion(FsmID, ?MUT, InitIter, Events),
     Trace = ?PURE_DRIVER:get_trace(FsmID),
     CapturedRequest = proplists:get_value(verify_req, Trace),
+    %% If the BZ 520 bug is present, then CapturedRequest will be a tuple
+    %% representing an inappropriately-wrapped request.
     {got, BZ520_request_is_this} = {got, CapturedRequest},
     [{res, X},
      {trace, Trace}].

--- a/test/vnode_test1.erl
+++ b/test/vnode_test1.erl
@@ -1,0 +1,46 @@
+%%
+%% Copyright (c) 2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(vnode_test1).
+
+-compile(export_all).
+
+-define(PURE_DRIVER, gen_fsm_test_driver).
+-define(MUT, riak_core_vnode).
+
+pure_1st_trivial_test() ->
+    FsmID = trivial_1st,
+    NumParts = 8,
+    SeedNode = r1@node,
+    MyPart = 42,
+    Ring = {NumParts, [{Idx, SeedNode} ||
+                          Idx <- lists:seq(0, NumParts*MyPart-1, MyPart)]},
+    ChState = {chstate, SeedNode, [], Ring, dict:new()}, % ugly hack
+    PureOpts = [{debug, true},
+                {node, SeedNode},
+                {get_my_ring, ChState},
+                {node_watcher_nodes, [SeedNode]}
+               ],
+    
+    InitIter = ?MUT:pure_start(FsmID, mock_vnode, MyPart, PureOpts),
+    Events = [],
+    {need_events, _, _} = X =
+        ?PURE_DRIVER:run_to_completion(FsmID, ?MUT, InitIter, Events),
+    [{res, X},
+     {trace, ?PURE_DRIVER:get_trace(FsmID)}].

--- a/test/vnode_test1.erl
+++ b/test/vnode_test1.erl
@@ -41,6 +41,16 @@ pure_1st_trivial_test() ->
                  fun([riak_core, vnode_inactivity_timeout, _Default]) ->
                          9999999999
                  end},
+                {{error_logger, error_msg},
+                 fun([Fmt, Args]) -> Str = io_lib:format(Fmt, Args),
+                                     ?PURE_DRIVER:add_trace(
+                                        FsmID, {error_logger, error_msg,
+                                                lists:flatten(Str)})
+                 end},
+                {{mod, reply},
+                 fun([Sender, Reply]) -> ?PURE_DRIVER:add_trace(
+                                            FsmID, {reply, Sender, Reply})
+                 end},
                 {{mod, init}, {ok, foo_mod_state}},
                 {{mod, handle_command}, NoReplyFun},
                 {{mod, handle_handoff_command}, NoReplyFun},

--- a/test/vnode_test1.erl
+++ b/test/vnode_test1.erl
@@ -47,6 +47,12 @@ pure_1st_trivial_test() ->
                                         FsmID, {error_logger, error_msg,
                                                 lists:flatten(Str)})
                  end},
+                {{error_logger, info_msg},
+                 fun([Fmt, Args]) -> Str = io_lib:format(Fmt, Args),
+                                     ?PURE_DRIVER:add_trace(
+                                        FsmID, {error_logger, info_msg,
+                                                lists:flatten(Str)})
+                 end},
                 {{mod, reply},
                  fun([Sender, Reply]) -> ?PURE_DRIVER:add_trace(
                                             FsmID, {reply, Sender, Reply})


### PR DESCRIPTION
Reviewer: anyone interested in purifying FSMs for better testing.
Reviewing the new code is probably best done looking at the
final files than at all the diffs in between.

This is the first stab at trying to purify a FSM for testing purposes.
I'm thinking that the new module, gen_fsm_test_driver.erl, should
be pulled out of riak_core/test because I'm thinking it will be
immediately useful for testing KV FSMs (I've already started on
the get & put FSMs).  So, some thought about where to put it
(in yet another repo? {shrug}) would be helpful.

The unit test for verifying 520's fix got a bit more involved than I'd
originally thought it'd be.  See the comment in the middle about
adding -ifdef(TEST)-only code for simplifying testing.

Also, it's possible that more complicated testing scenarios may
require more flexibility, e.g. return value X the first time that an
impure-function-simulated-as-pure is called but return Y a 2nd time.
It isn't clear to me how'd be best to do that: use meck or other
more traditional code mocking tool, resort to relying on stateful
3rd-party processes to interact with (thus tainting otherwise
beautiful purity), or something else.

Note on the use of erlang:apply() ... it isn't as slow as it used to be,
and it _really_ makes the code a lot, lot, lot shorter and easier to
read.  For contrast, see changeset 97caae5c3e55065ceffe2de8e70b0ed793764157
for what the code looked like before switching to using erlang:apply().
Or see the diff from moving to the not-yet-finished purification
using the old scheme -> new apply scheme:
https://github.com/basho/riak_core/commit/93f49d19f1b20f0fd3cda56ec0094e93ff453377
