### PR TITLE
merkerl: fixes potential clobbering when turning a leaf into an inner

### DIFF
--- a/src/merkerl.erl
+++ b/src/merkerl.erl
@@ -156,12 +156,10 @@ mi_insert({Offset,MI},Tree) ->
 		Key -> % replacing!
 		    mkleaf(MI);
 		_ -> % turning a leaf into an inner
-		    K0 = orddict:new(),
-		    K1 = orddict:store(offset_key(Offset,Key),
-				       mkleaf(MI),K0),
-		    TKey = Tree#merk.key,
-		    Kids = orddict:store(offset_key(Offset,TKey),Tree,K1),
-		    mkinner(Offset,Kids)
+		    Kid = orddict:store(offset_key(Offset,Tree#merk.key),
+		   	       Tree,orddict:new()),	 
+		    NewInner = mkinner(Offset,Kid),
+		    mi_insert1({Offset,MI},NewInner)
 	    end;
 	inner ->
 	    mi_insert1({Offset,MI},Tree)
@@ -362,6 +360,9 @@ merkle_test() ->
     ?assertEqual([one], diff(C2,undefined)),
     STree1 = build_tree([{"hello", "hi"},{"and", "what"}]),
     STree2 = build_tree([{"hello", "hi"},{"goodbye", "bye"}]),
-    ?assertEqual(lists:usort(["and", "goodbye"]), diff(STree1, STree2)).
+    ?assertEqual(lists:usort(["and", "goodbye"]), diff(STree1, STree2)),
+    I = [{<<"riak.com42">>,sha("should not")},{<<"riak.com452">>,sha("clobber")}],
+    I2 = build_tree(I),
+    ?assertEqual(2, length(allkeys(I2))).
 
 


### PR DESCRIPTION
When adding several values to a tree, I occasionally noticed that some values didn't get picked up.  After looking at the clause for inserting an MI into a "leaf" (line #158), the code that inserted the leaves into an orddict via their offset_key/2 results looked suspicious.  Indeed, if those two results were identical, the orddict values would clobber.  The solution is to simply create the inner using _only_ the initial leaf and then to subsequently call the mi_insert1 function providing the newly created inner as its Tree arg.

I added a test that demonstrates what would otherwise be a clobbered value (assuming the offset is either 0 or 8).  Its keys, <<"riak.com42">> and <<"riak.com452">>, respectively "sha" to:
<<21,236,177,213,57,7,41,130,41,112,195,213,10,85,84,31,115,84,156,40>>
<<21,236,167,160,142,11,39,35,69,14,183,49,144,41,75,9,17,141,189,202>>

Interested in your thoughts.

thanks!
-andy
