### PR TITLE
Changes to support purifying KV FSMs

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -38,6 +38,7 @@
              riak_core_sup,
              riak_core_sysmon_handler,
              riak_core_sysmon_minder,
+             riak_core_tracer,
              riak_core_test_util,
              riak_core_util,
              riak_core_vnode,

--- a/src/riak_core_apl.erl
+++ b/src/riak_core_apl.erl
@@ -24,7 +24,7 @@
 %% -------------------------------------------------------------------
 -module(riak_core_apl).
 -export([active_owners/1, active_owners/2,
-         get_apl/3, get_apl/4, get_apl2/4,
+         get_apl/3, get_apl/4, get_apl_ann/4,
          get_primary_apl/3, get_primary_apl/4
         ]).
 
@@ -64,13 +64,13 @@ get_apl(DocIdx, N, Service) ->
 -spec get_apl(binary(), n_val(), ring(), [node()]) -> preflist().
 get_apl(DocIdx, N, Ring, UpNodes) ->
     [{Partition, Node} || {{Partition, Node}, _Type} <- 
-                              get_apl2(DocIdx, N, Ring, UpNodes)].
+                              get_apl_ann(DocIdx, N, Ring, UpNodes)].
 
 %% Get the active preflist taking account of which nodes are up
 %% for a given ring/upnodes list and annotate each node with type of
 %% primary/fallback
--spec get_apl2(binary(), n_val(), ring(), [node()]) -> preflist2().
-get_apl2(DocIdx, N, Ring, UpNodes) ->
+-spec get_apl_ann(binary(), n_val(), ring(), [node()]) -> preflist2().
+get_apl_ann(DocIdx, N, Ring, UpNodes) ->
     UpNodes1 = ordsets:from_list(UpNodes),
     Preflist = riak_core_ring:preflist(DocIdx, Ring),
     {Primaries, Fallbacks} = lists:split(N, Preflist),

--- a/src/riak_core_tracer.erl
+++ b/src/riak_core_tracer.erl
@@ -89,13 +89,13 @@ get_fsm_events({trace, _Pid, call,
                  [ReqId,B,K,_R,_T,_ReplyTo]}}) ->
     [{get_start, ReqId, {B, K}}];
 get_fsm_events({trace, _Pid, call,
-                {riak_kv_get_fsm, send_reply,
-                 [_Client, ReqId, Reply]}}) ->
-    [{get_finished, ReqId, Reply}].
+                {riak_kv_get_fsm, client_reply,
+                 [Reply, State]}}) ->
+    [{get_finished, element(8, State), Reply}].
 
 log_get_fsm() ->
     riak_core_tracer:filter([{riak_kv_get_fsm, start},
-                   {riak_kv_get_fsm, send_reply}],
+                   {riak_kv_get_fsm, client_reply}],
                   fun get_fsm_events/1).
 
 put_fsm_events({trace, _Pid, call,

--- a/src/riak_core_tracer.erl
+++ b/src/riak_core_tracer.erl
@@ -1,0 +1,256 @@
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_tracer).
+
+-behaviour(gen_server).
+-include_lib("riak_kv/include/riak_kv_vnode.hrl").
+
+%% API
+-export([start_link/0,
+         reset/0,
+         filter/2,
+         collect/0, collect/1, collect/2,
+         results/0]).
+-export([log_get_fsm/0,
+         log_put_fsm/0]).
+-export([test_get/0,
+         test_put/0,
+         test_get_put/0,
+         test_all_events/1]).
+
+-export([all_events/1, get_fsm_events/1]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-define(SERVER, ?MODULE). 
+
+-record(state, {trace=[],
+                filters=[],
+                mfs=[],
+                stop_tref}).
+
+%%===================================================================
+%% API
+%%===================================================================
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+reset() ->
+    gen_server:call(?SERVER, reset).
+
+%% Set up a filter on trace messages to the list of [{M, F}]s.  The
+%% tracer function should return a list of events to log
+filter(MFs, Filter) ->
+    gen_server:call(?SERVER, {filter, MFs, Filter}).
+
+%% Collect traces
+collect() ->
+    collect(100).
+
+collect(Duration) ->
+    collect(Duration, nodes()).
+
+collect(Duration, Nodes) ->
+    gen_server:call(?SERVER, {collect, Duration,  Nodes}).
+
+%% Return the trace
+results() ->
+    gen_server:call(?SERVER, results).
+
+all_events({trace, Pid, call, {M,F,A}}) ->
+    [{node(Pid), {M,F,A}}].
+
+%%===================================================================
+%% Pre-canned examples - tracing of riak_kv, but not compile time
+%% coupling.
+%%===================================================================
+
+get_fsm_events({trace, _Pid, call,
+                {riak_kv_get_fsm,start,
+                 [ReqId,B,K,_R,_T,_ReplyTo]}}) ->
+    [{get_start, ReqId, {B, K}}];
+get_fsm_events({trace, _Pid, call,
+                {riak_kv_get_fsm, send_reply,
+                 [_Client, ReqId, Reply]}}) ->
+    [{get_finished, ReqId, Reply}].
+
+log_get_fsm() ->
+    riak_core_tracer:filter([{riak_kv_get_fsm, start},
+                   {riak_kv_get_fsm, send_reply}],
+                  fun get_fsm_events/1).
+
+put_fsm_events({trace, _Pid, call,
+               {riak_kv_put_fsm,start,
+                [ReqId,Obj, _W, _DW,_T,_ReplyTo,[]]}}) ->
+    [{put_start, ReqId, Obj}];
+put_fsm_events({trace, _Pid, call,
+                {riak_kv_put_fsm, send_reply,
+                 [_Client, ReqId, Reply]}}) ->
+    [{put_finished, ReqId, Reply}].
+
+log_put_fsm() ->
+    riak_core_tracer:filter([{riak_kv_put_fsm, start},
+                   {riak_kv_put_fsm, send_reply}],
+                  fun put_fsm_events/1).
+ 
+%% Some functions to execute
+test_get() ->
+    riak_core_tracer:start_link(),
+    riak_core_tracer:reset(),
+    log_get_fsm(),
+    riak_core_tracer:collect(5000),
+    {ok, C} = riak:local_client(),
+    C:get(<<"b">>,<<"k1">>),
+    C:get(<<"b">>,<<"k2">>),
+    C:get(<<"b">>,<<"k3">>),
+    timer:sleep(100),
+    riak_core_tracer:results().
+
+test_put() ->
+    riak_core_tracer:start_link(),
+    riak_core_tracer:reset(),
+    log_put_fsm(),
+    riak_core_tracer:collect(5000),
+    {ok, C} = riak:local_client(),
+    C:put(riak_object:new(<<"b">>,<<"k1">>,<<"v1">>)),
+    C:put(riak_object:new(<<"b">>,<<"k2">>,<<"v2">>)),
+    C:put(riak_object:new(<<"b">>,<<"k3">>,<<"v3">>)),
+    timer:sleep(100),
+    riak_core_tracer:results().
+
+test_get_put() ->
+    riak_core_tracer:start_link(),
+    riak_core_tracer:reset(),
+    log_get_fsm(),
+    riak_core_tracer:collect(5000),
+    {ok, C} = riak:local_client(),
+    C:get(<<"b">>,<<"k1">>),
+    C:put(riak_object:new(<<"b">>,<<"k1">>,<<"v1">>)),
+    C:get(<<"b">>,<<"k2">>),
+    C:put(riak_object:new(<<"b">>,<<"k1">>,<<"v1">>)),
+    timer:sleep(100),
+    riak_core_tracer:results().
+
+
+test_all_events(Ms) ->
+    riak_core_tracer:start_link(),
+    riak_core_tracer:reset(),
+    riak_core_tracer:filter(Ms, fun all_events/1),
+    riak_core_tracer:collect(5000).
+
+%%===================================================================
+%% gen_server callbacks
+%%===================================================================
+
+init([]) ->
+    {ok, #state{}}.
+
+handle_call(reset, _From, State) ->
+    cancel_timer(State#state.stop_tref),
+    {reply, ok, #state{}};
+handle_call({filter, MFs, Filter}, _From, State) ->
+    {reply, ok, State#state{mfs=MFs ++ State#state.mfs,
+                            filters = [Filter | State#state.filters]}};
+handle_call({collect, Duration, Nodes}, _From, State) ->
+    cancel_timer(State#state.stop_tref),
+    Tref = timer:send_after(Duration, stop),
+    dbg:tracer(process, {fun (Msg, Pid) ->
+                                 %io:format("~p ! ~p\n", [Pid, Msg]),
+                                 Entries = lists:flatten(
+                                             [begin
+                                                  case catch F(Msg) of
+                                                      {'EXIT', _} ->
+                                                          [];
+                                                      E ->
+                                                          E
+                                                  end
+                                              end || F <- State#state.filters]),
+                                 case Entries of
+                                     [] ->
+                                         ok;
+                                     _ ->
+                                         {Mega, Secs, Micro} = now(),
+                                         Ts = 1000000 * (1000000 * Mega + Secs) + Micro,
+                                         TsEntries = [{Ts, E} || E <- Entries],
+                                         gen_server:call(Pid,  {traces, TsEntries})
+                                 end,
+                                 Pid
+                         end, self()}),
+    dbg:p(all, call),
+    [{ok, N} = dbg:n(N) || N <- Nodes],
+    add_tracers(State#state.mfs),
+    {reply, ok, State#state{trace=[], stop_tref = Tref}};
+handle_call({traces, Entries}, _From, State) ->
+    {reply, ok, State#state{trace=Entries ++ State#state.trace}};
+handle_call(results, _From, State) ->
+    case lists:sort(State#state.trace) of
+        [] ->
+            R = [];
+        STrace ->
+            {MinTs,_} = hd(STrace),
+            R = zero_ts(MinTs, STrace, [])
+    end,
+    {reply, R, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(stop, State) ->
+    dbg:stop_clear(),
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+     {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+add_tracers([]) ->
+    ok;
+add_tracers([{M, F} | Rest]) ->
+    dbg:tpl(M, F, [{'_',[],[{message,{return_trace}}]}]),
+     add_tracers(Rest);
+add_tracers([M | Rest]) ->
+    dbg:tpl(M,[{'_',[],[{message,{return_trace}}]}]),
+    add_tracers(Rest).
+
+cancel_timer(undefined) ->
+    ok;
+cancel_timer(Tref) ->
+    catch timer:cancel(Tref),
+    receive
+        stop ->
+            ok
+    after
+        0 ->
+            ok
+    end.
+
+zero_ts(_Offset, [], Acc) ->
+    lists:reverse(Acc);
+zero_ts(Offset, [{Ts,Trace}|Rest], Acc) ->
+    zero_ts(Offset, Rest, [{Ts - Offset, Trace} | Acc]).
+

--- a/src/riak_core_vnode_master.erl
+++ b/src/riak_core_vnode_master.erl
@@ -62,6 +62,9 @@ command(Preflist, Msg, VMaster) ->
 %% Send the command to the preflist given with responses going to Sender
 command([], _Msg, _Sender, _VMaster) ->
     ok;
+command([{Index, Pid}|Rest], Msg, Sender, VMaster) when is_pid(Pid) ->
+    gen_fsm:send_event(Pid, make_request(Msg, Sender, Index)),
+    command(Rest, Msg, Sender, VMaster);
 command([{Index,Node}|Rest], Msg, Sender, VMaster) ->
     gen_server:cast({VMaster, Node}, make_request(Msg, Sender, Index)),
     command(Rest, Msg, Sender, VMaster);


### PR DESCRIPTION
 I've spent some time refactoring the get FSM today in preparation for changes and thought I'd share progress to see if we think this is a viable approach.  I've created branches in riak_core and riak_kv called jdm-purify-fsms and have pushed my latest and greatest including some code I forgot to commit end of Wednesday.

Here's the broad strokes of what I've done:
- split the initialized state into prepare and execute.  Any side effects are isolated to the prepare function.
- added an alternate start function that takes a proplist to fudge the state and drops into the execute state.
- refactored the vnode response handling into a single function
- refactored the reply-to-client decision into a function
- replaced the preference list code with the riak_core_vnode_master based commands and added an alternate variant of the preflist code that provides the vnode type of primary/fallback (needed for deletes, but will be vital for adding RP-responses-from-primaries condition).
- taught the vnode_master commands to recognize Pids in the preference list and send messages there directly instead of going through a vnode master.
- taught riak_kv_vnode:put to accept bucket properties in options so it didn't try and get the ring while in 'pure' mode
- made read repair supply bucket properties.
- cleaned up the strange spawning/individual sync deletes - I don't believe they provide any additional protection against races.  We need to add conditional matching on the vclock soon anyway.

The refactored code still passes all the original quickcheck tests and I've added a couple of examples of how it can be used in 'pure' mode without any other parts of the system spun up.

./rebar eunit app=riak_kv suite=riak_kv_get_fsm if you'd like to see it run.

riak_kv_put_fsm is causing problems with running the whole test suite, I'll clean that up when I refactor the put FSM.

Looking for comments on
- if this seems like a good approach
- reasons why any of the changes are bad or breaks something
- if the delete change is acceptable
- if the readrepair change is acceptable, and if we think it is ok in production or if it needs to be conditional for testing.  It will mean more data sent per read repair.
