### PR TITLE
Bz218 ring file cleanup on leave

### DIFF
--- a/src/riak_core_gossip.erl
+++ b/src/riak_core_gossip.erl
@@ -201,7 +201,7 @@ remove_from_cluster(ExitingNode) ->
     distribute_ring(ExitRing),
 
     % Instruct the exiting node to clean up and leave the ring
-    rpc:call(ExitingNode, riak_core_ring_manager, leave_the_ring, [ExitRing]).
+    rpc:call(ExitingNode, riak_core_ring_manager, leave_the_ring, [ExitRing, Ring]).
 
 
 attempt_simple_transfer(Ring, Owners, ExitingNode) ->

--- a/src/riak_core_gossip.erl
+++ b/src/riak_core_gossip.erl
@@ -36,7 +36,7 @@
 -export([start_link/0, stop/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
--export ([send_ring/1, send_ring/2, remove_from_cluster/1]).
+-export ([distribute_ring/1, send_ring/1, send_ring/2, remove_from_cluster/1]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -45,6 +45,11 @@
 %% ===================================================================
 %% Public API
 %% ===================================================================
+
+%% distribute_ring/1 -
+%% Distribute a ring to all members of that ring.
+distribute_ring(Ring) ->
+    gen_server:cast({?MODULE, node()}, {distribute_ring, Ring}).
 
 %% send_ring/1 -
 %% Send the current node's ring to some other node.
@@ -84,6 +89,11 @@ handle_call(_, _From, State) ->
 handle_cast({send_ring_to, Node}, RingChanged) ->
     {ok, MyRing} = riak_core_ring_manager:get_my_ring(),
     gen_server:cast({?MODULE, Node}, {reconcile_ring, MyRing}),
+    {noreply, RingChanged};
+
+handle_cast({distribute_ring, Ring}, RingChanged) ->
+    Nodes = riak_core_ring:all_members(Ring),
+    gen_server:abcast(Nodes, ?MODULE, {reconcile_ring, Ring}),
     {noreply, RingChanged};
 
 handle_cast({reconcile_ring, OtherRing}, RingChanged) ->
@@ -187,11 +197,11 @@ remove_from_cluster(ExitingNode) ->
                 riak_core_claim:claim_rebalance_n(TempRing, Other)
         end,
 
-    % Update our local copy of the ring
-    riak_core_ring_manager:set_my_ring(ExitRing),
+    % Send the new ring to all nodes except the exiting node
+    distribute_ring(ExitRing),
 
-    % Send the new ring to all other rings
-    [send_ring(X) || X <- riak_core_ring:all_members(Ring)].
+    % Instruct the exiting node to clean up and leave the ring
+    rpc:call(ExitingNode, riak_core_ring_manager, leave_the_ring, [ExitRing]).
 
 
 attempt_simple_transfer(Ring, Owners, ExitingNode) ->

--- a/src/riak_core_gossip.erl
+++ b/src/riak_core_gossip.erl
@@ -200,8 +200,9 @@ remove_from_cluster(ExitingNode) ->
     % Send the new ring to all nodes except the exiting node
     distribute_ring(ExitRing),
 
-    % Instruct the exiting node to clean up and leave the ring
-    rpc:call(ExitingNode, riak_core_ring_manager, leave_the_ring, [ExitRing, Ring]).
+    % Set the new ring on the exiting node. This will trigger
+    % it to begin handoff and cleanly leave the cluster.
+    rpc:call(ExitingNode, riak_core_ring_manager, set_my_ring, [ExitRing]).
 
 
 attempt_simple_transfer(Ring, Owners, ExitingNode) ->

--- a/src/riak_core_ring_handler.erl
+++ b/src/riak_core_ring_handler.erl
@@ -58,8 +58,13 @@ code_change(_OldVsn, State, _Extra) ->
 
 ensure_vnodes_started(Ring) ->
     case riak_core:vnode_modules() of
-        [] -> ok;
-        Mods -> ensure_vnodes_started(Mods, Ring, [])
+        [] ->
+            ok;
+        Mods ->            
+            case ensure_vnodes_started(Mods, Ring, []) of
+                [] -> riak_core_ring_manager:leave_the_ring();
+                _ -> ok
+            end
     end.
 
 ensure_vnodes_started([], _Ring, Acc) ->

--- a/src/riak_core_ring_handler.erl
+++ b/src/riak_core_ring_handler.erl
@@ -59,11 +59,7 @@ code_change(_OldVsn, State, _Extra) ->
 ensure_vnodes_started(Ring) ->
     case riak_core:vnode_modules() of
         [] -> ok;
-        Mods ->
-            case ensure_vnodes_started(Mods, Ring, []) of
-                [] -> riak_core:stop("node removal completed, exiting.");
-                _ -> ok
-            end
+        Mods -> ensure_vnodes_started(Mods, Ring, [])
     end.
 
 ensure_vnodes_started([], _Ring, Acc) ->

--- a/src/riak_core_ring_handler.erl
+++ b/src/riak_core_ring_handler.erl
@@ -62,7 +62,7 @@ ensure_vnodes_started(Ring) ->
             ok;
         Mods ->            
             case ensure_vnodes_started(Mods, Ring, []) of
-                [] -> riak_core_ring_manager:leave_the_ring();
+                [] -> riak_core_ring_manager:refresh_my_ring();
                 _ -> ok
             end
     end.

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -30,7 +30,7 @@
 -export([start_link/0,
          start_link/1,
          get_my_ring/0,
-         leave_the_ring/0,
+         refresh_my_ring/0,
          set_my_ring/1,
          write_ringfile/0,
          prune_ringfiles/0,
@@ -68,9 +68,9 @@ get_my_ring() ->
         undefined -> {error, no_ring}
     end.
 
-%% @spec leave_the_ring() -> ok
-leave_the_ring() ->
-    gen_server2:call(?MODULE, leave_the_ring, infinity).
+%% @spec refresh_my_ring() -> ok
+refresh_my_ring() ->
+    gen_server2:call(?MODULE, refresh_my_ring, infinity).
 
 %% @spec set_my_ring(riak_core_ring:riak_core_ring()) -> ok
 set_my_ring(Ring) ->
@@ -192,7 +192,7 @@ init([Mode]) ->
 handle_call({set_my_ring, Ring}, _From, State) ->
     prune_write_notify_ring(Ring),
     {reply,ok,State};
-handle_call(leave_the_ring, _From, State) ->
+handle_call(refresh_my_ring, _From, State) ->
     %% This node is leaving the cluster so create a fresh ring file
     FreshRing = riak_core_ring:fresh(),
     set_ring_global(FreshRing),
@@ -313,7 +313,7 @@ set_my_ring_test() ->
     set_ring_global(Ring),
     ?assertEqual({ok, Ring}, get_my_ring()).
 
-leave_the_ring_test() ->
+refresh_my_ring_test() ->
     application:set_env(riak_core, ring_creation_size, 4),
     application:set_env(riak_core, ring_state_dir, "/tmp"),
     application:set_env(riak_core, cluster_name, "test"),
@@ -322,7 +322,7 @@ leave_the_ring_test() ->
     riak_core_vnode_sup:start_link(),
     riak_core_vnode_master:start_link(riak_core_vnode),
     riak_core_test_util:setup_mockring1(),
-    ?assertEqual(ok, riak_core_ring_manager:leave_the_ring()),
+    ?assertEqual(ok, riak_core_ring_manager:refresh_my_ring()),
     riak_core_ring_manager:stop(),
     %% Cleanup the ring file created for this test
     {ok, RingFile} = find_latest_ringfile(),

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -23,7 +23,7 @@
 %% @doc the local view of the cluster's ring configuration
 
 -module(riak_core_ring_manager).
--include_lib("eunit/include/eunit.hrl").
+
 -define(RING_KEY, riak_ring).
 -behaviour(gen_server2).
 

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -204,7 +204,7 @@ handle_call({leave_the_ring, Ring}, _From, State) ->
     %% This node is leaving the cluster so create a fresh ring file
     FreshRing = riak_core_ring:fresh(),
     set_ring_global(FreshRing),
-    riak_core_ring_events:ring_sync_update(FreshRing),
+    %% Make sure the fresh ring gets written before stopping
     do_write_ringfile(FreshRing),
 
     %% Handoff is complete and fresh ring is written

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -30,7 +30,7 @@
 -export([start_link/0,
          start_link/1,
          get_my_ring/0,
-         leave_the_ring/1,
+         leave_the_ring/2,
          set_my_ring/1,
          write_ringfile/0,
          prune_ringfiles/0,
@@ -69,8 +69,9 @@ get_my_ring() ->
     end.
 
 %% @spec leave_the_ring(riak_core_ring:riak_core_ring()) -> ok
-leave_the_ring(Ring) ->
-    gen_server2:call(?MODULE, {leave_the_ring, Ring}, infinity).
+leave_the_ring(NewRing, OldRing) ->
+    PartitionIndices = riak_core_ring:my_indices(OldRing),
+    gen_server2:call(?MODULE, {leave_the_ring, NewRing, PartitionIndices}, infinity).
 
 %% @spec set_my_ring(riak_core_ring:riak_core_ring()) -> ok
 set_my_ring(Ring) ->
@@ -192,7 +193,7 @@ init([Mode]) ->
 handle_call({set_my_ring, Ring}, _From, State) ->
     prune_write_notify_ring(Ring),
     {reply,ok,State};
-handle_call({leave_the_ring, Ring}, _From, State) ->
+handle_call({leave_the_ring, Ring, Indices}, _From, State) ->
     %% All of the following operations need to be
     %% synchronous so we can make sure they have
     %% completed before the node stops.
@@ -200,7 +201,10 @@ handle_call({leave_the_ring, Ring}, _From, State) ->
 
     %% Notify any local observers that the ring has changed (sync)
     riak_core_ring_events:ring_sync_update(Ring),
-    
+
+    %% Begin handoff of vnodes
+    handoff_vnodes(Indices),
+
     %% This node is leaving the cluster so create a fresh ring file
     FreshRing = riak_core_ring:fresh(),
     set_ring_global(FreshRing),
@@ -284,6 +288,17 @@ prune_write_notify_ring(Ring) ->
     set_ring_global(Ring),
     riak_core_ring_events:ring_update(Ring).
 
+handoff_vnodes(Indices) ->
+    [handoff_vnode(Index) || Index <- Indices].
+
+handoff_vnode(Index) ->
+    VNodePid = riak_core_vnode_master:get_vnode_pid(Index, riak_kv_vnode),
+    %% Sending a timeout event to a vnode will have the
+    %% effect of prompting it to handoff. Send the 
+    %% event synchronously since we need to ensure the 
+    %% handoff is complete so the node can shutdown. 
+    riak_core_vnode:send_sync_command(VNodePid, timeout).
+    
 
 %% ===================================================================
 %% Unit tests
@@ -321,19 +336,21 @@ set_my_ring_test() ->
     set_ring_global(Ring),
     ?assertEqual({ok, Ring}, get_my_ring()).
 
-leave_the_ring_test() ->
-    application:set_env(riak_core, ring_creation_size, 4),
-    application:set_env(riak_core, ring_state_dir, "/tmp"),
-    application:set_env(riak_core, cluster_name, "test"),
-    riak_core_ring_events:start_link(),
-    riak_core_ring_manager:start_link(test),
-    riak_core_test_util:setup_mockring1(),
-    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
-    ?assertEqual(ok, riak_core_ring_manager:leave_the_ring(Ring)),
-    riak_core_ring_manager:stop(),
-    %% Cleanup the ring file created for this test
-    {ok, RingFile} = find_latest_ringfile(),
-    file:delete(RingFile).
+%% leave_the_ring_test() ->
+%%     application:set_env(riak_core, ring_creation_size, 4),
+%%     application:set_env(riak_core, ring_state_dir, "/tmp"),
+%%     application:set_env(riak_core, cluster_name, "test"),
+%%     riak_core_ring_events:start_link(),
+%%     riak_core_ring_manager:start_link(test),
+%%     riak_core_vnode_sup:start_link(),
+%%     riak_core_vnode_master:start_link(riak_core_vnode),
+%%     riak_core_test_util:setup_mockring1(),
+%%     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+%%     ?assertEqual(ok, riak_core_ring_manager:leave_the_ring(Ring, Ring)),
+%%     riak_core_ring_manager:stop(),
+%%     %% Cleanup the ring file created for this test
+%%     {ok, RingFile} = find_latest_ringfile(),
+%%     file:delete(RingFile).
 
 -endif.
 

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -22,7 +22,6 @@
 -export([behaviour_info/1]).
 -export([start_link/2,
          send_command/2,
-         send_sync_command/2,
          send_command_after/2]).
 -export([init/1, 
          active/2, 
@@ -70,9 +69,6 @@ start_link(Mod, Index) ->
 send_command(Pid, Request) ->
     gen_fsm:send_event(Pid, ?VNODE_REQ{request=Request}).
 
-%% Send a synchronous command message for the vnode module by Pid
-send_sync_command(Pid, Request) ->
-    gen_fsm:sync_send_event(Pid, ?VNODE_REQ{request=Request}).
 
 %% Sends a command to the FSM that called it after Time 
 %% has passed.

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -22,6 +22,7 @@
 -export([behaviour_info/1]).
 -export([start_link/2,
          send_command/2,
+         send_sync_command/2,
          send_command_after/2]).
 -export([init/1, 
          active/2, 
@@ -68,6 +69,10 @@ start_link(Mod, Index) ->
 %% typically to do some deferred processing after returning yourself
 send_command(Pid, Request) ->
     gen_fsm:send_event(Pid, ?VNODE_REQ{request=Request}).
+
+%% Send a synchronous command message for the vnode module by Pid
+send_sync_command(Pid, Request) ->
+    gen_fsm:sync_send_event(Pid, ?VNODE_REQ{request=Request}).
 
 %% Sends a command to the FSM that called it after Time 
 %% has passed.

--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -250,6 +250,18 @@ prune_old_test() ->
              {big_vclock,2},{old_vclock,10000}],
     ?assert(length(prune(VC, Now, Props)) =:= 1).
 
+prune_order_test() ->
+    % vclock with two nodes of the same timestamp will be pruned down
+    % to the same node
+    Now = riak_core_util:moment(),
+    OldTime = Now - 100000,    
+    VC1 = [{<<"1">>, {1, OldTime}},
+           {<<"2">>, {2, OldTime}}],
+    VC2 = lists:reverse(VC1),
+    Props = [{small_vclock,1},{young_vclock,1},
+             {big_vclock,2},{old_vclock,10000}],
+    ?assertEqual(prune(VC1, Now, Props), prune(VC2, Now, Props)).
+
 accessor_test() ->
     VC = [{<<"1">>, {1, 1}},
           {<<"2">>, {2, 2}}],

--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -178,7 +178,9 @@ equal(VA,VB) ->
 % @doc Possibly shrink the size of a vclock, depending on current age and size.
 -spec prune(V::vclock(), Now::integer(), BucketProps::term()) -> vclock().
 prune(V,Now,BucketProps) ->
-    SortV = lists:sort(fun({_,{_,A}},{_,{_,B}}) -> A < B end, V),
+    %% This sort need to be deterministic, to avoid spurious merge conflicts later.
+    %% We achieve this by using the node ID as secondary key.
+    SortV = lists:sort(fun({N1,{_,T1}},{N2,{_,T2}}) -> {T1,N1} < {T2,N2} end, V),
     prune_vclock1(SortV,Now,BucketProps).
 % @private
 prune_vclock1(V,Now,BProps) ->


### PR DESCRIPTION
These changes fix the problem of a node not cleaning up its ring file properly when it leaves a cluster. 

The changes also fix what appears to be a race condition where a node could stop before properly distributing an updated ring file to the other nodes in the cluster. The race condition seems unlikely ever to happen in practice, but good to clean it up anyway. 
