### PR TITLE
Fix default sender

### DIFF
--- a/include/riak_core_vnode.hrl
+++ b/include/riak_core_vnode.hrl
@@ -5,13 +5,13 @@
                                                    % riak_core_vnode_master.erl
                   {fsm, undefined, pid()} |        % special case in
                                                    % riak_kv_util:make_request/2.erl
-                  ignore | noreply.
+                  ignore.
 -type partition() :: non_neg_integer().
 -type vnode_req() :: term().
 
 -record(riak_vnode_req_v1, {
           index :: partition(),
-          sender=noreply :: sender(),
+          sender=ignore :: sender(),
           request :: vnode_req()}).
 
 

--- a/src/riak_core_vnode_master.erl
+++ b/src/riak_core_vnode_master.erl
@@ -57,7 +57,7 @@ get_vnode_pid(Index, VNodeMod) ->
     gen_server:call(RegName, {Index, get_vnode}, infinity).
     
 command(Preflist, Msg, VMaster) ->
-    command(Preflist, Msg, noreply, VMaster).
+    command(Preflist, Msg, ignore, VMaster).
      
 %% Send the command to the preflist given with responses going to Sender
 command([], _Msg, _Sender, _VMaster) ->


### PR DESCRIPTION
The commit message explains.  This issue was exposed after the purification changes for the get FSM - a spawn was removed around the delete vnode call (although I'm not sure why, it should have always failed)

<pre>
=ERROR REPORT==== 10-Mar-2011::08:06:46 ===
** State machine <0.2983.0> terminating 
** Last event in was {riak_vnode_req_v1,
                         1096126227998177188652763624537212264741949407232,
                         noreply,
                         {riak_kv_delete_req_v1,{<<"b">>,<<"k">>},64628379}}
** When State == active
**      Data  == {state,1096126227998177188652763624537212264741949407232,
                        riak_kv_vnode,
                        {state,1096126227998177188652763624537212264741949407232,
                               riak_kv_bitcask_backend,
                               {#Ref<0.0.0.3984>,
                                "/data/riak/bitcask/1096126227998177188652763624537212264741949407232"},
                               {dict,0,16,16,8,80,48,
                                     {[],[],[],[],[],[],[],[],[],[],[],[],[],
                                      [],[],[]},
                                     {{[],[],[],[],[],[],[],[],[],[],[],[],[],
                                       [],[],[]}}},
                               false},
                        undefined,none,60000}
** Reason for termination = 
** {function_clause,
       [{riak_core_vnode,reply,
            [noreply,
             {del,1096126227998177188652763624537212264741949407232,
                 64628379}]},
        {riak_core_vnode,vnode_command,3},
        {gen_fsm,handle_msg,7},
        {proc_lib,init_p_do_apply,3}]}
</pre>
