### PR TITLE
Remove "riak" prefix requirement for vnodes

### DIFF
--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -227,8 +227,9 @@ should_handoff(#state{index=Idx, mod=Mod}) ->
         Me ->
             false;
         TargetNode ->
-            ["riak", A, "vnode"] = string:tokens(atom_to_list(Mod), "_"),
-            App = list_to_atom("riak_" ++ A),
+            L = string:tokens(atom_to_list(Mod), "_"),
+            A = string:join(lists:sublist(L, length(L) - 1), "_"),
+            App = list_to_atom(A),
             case lists:member(TargetNode, riak_core_node_watcher:nodes(App)) of
                 false  -> false;
                 true -> {true, TargetNode}


### PR DESCRIPTION
I see no reason to force a "riak_" prefix on all vnodes.  My guess is
this was just leftover from the original separation from riak_kv.

Without this patch one is forced to prefix his/her vnode module w/ `riak_`.
