### PR TITLE
Patches/0.14

### DIFF
--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -194,8 +194,8 @@ should_handoff(#state{index=Idx, mod=Mod}) ->
         Me ->
             false;
         TargetNode ->
-            ["riak", A, "vnode"] = string:tokens(atom_to_list(Mod), "_"),
-            App = list_to_atom("riak_" ++ A),
+            [ModPrefix, ModInfix, "vnode"] = string:tokens(atom_to_list(Mod), "_"),
+            App = list_to_atom(ModPrefix ++ "_" ++ ModInfix),
             case lists:member(TargetNode, riak_core_node_watcher:nodes(App)) of
                 false  -> false;
                 true -> {true, TargetNode}


### PR DESCRIPTION
Fixed `riak_core_vnode:should_handoff` to accept VNode modules not prefixed with `riak`.

(There still exists the limitation that the name of a VNode module must have exactly
three components joined by an underscore, and the last one must be `_vnode`.)
