### PR TITLE
vclock: Make merge stable

### DIFF
--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -95,17 +95,18 @@ merge([AClock|VClocks],NClock) ->
 merge([], [], AccClock) -> lists:reverse(AccClock);
 merge([], [Left|Rest], AccClock) -> merge([], Rest, [Left|AccClock]);
 merge(Left, [], AccClock) -> merge([], Left, AccClock);
-merge(V=[{Node1,{Ctr1,TS1}}|VClock],
-      N=[{Node2,{Ctr2,TS2}}|NClock], AccClock) ->
+merge(V=[{Node1,{Ctr1,TS1}=CT1}|VClock],
+      N=[{Node2,{Ctr2,TS2}=CT2}|NClock], AccClock) ->
     if Node1 < Node2 ->
-            merge(VClock, N, [{Node1,{Ctr1,TS1}}|AccClock]);
+            merge(VClock, N, [{Node1,CT1}|AccClock]);
        Node1 > Node2 ->
-            merge(V, NClock, [{Node2,{Ctr2,TS2}}|AccClock]);
+            merge(V, NClock, [{Node2,CT2}|AccClock]);
        true ->
-            ({_Ctr,_TS} = C1) = if Ctr1 > Ctr2 -> {Ctr1,TS1};
-                          true        -> {Ctr2,TS2}
-                       end,
-            merge(VClock, NClock, [{Node1,C1}|AccClock])
+            ({_Ctr,_TS} = CT) = if Ctr1 > Ctr2 -> CT1;
+                                   Ctr1 < Ctr2 -> CT2;
+                                   true        -> {Ctr1, erlang:max(TS1,TS2)}
+                                end,
+            merge(VClock, NClock, [{Node1,CT}|AccClock])
     end.
 
 % @doc Get the counter value in VClock set from Node.


### PR DESCRIPTION
Use max of timestamps in the case where the counters are identical - cf bz://1061.
