### PR TITLE
AZ 307: SSL encryption of riak_core handoff traffic

### DIFF
--- a/src/riak_core_handoff_listener.erl
+++ b/src/riak_core_handoff_listener.erl
@@ -36,7 +36,7 @@
 start_link() ->
     PortNum = app_helper:get_env(riak_core, handoff_port),
     IpAddr = app_helper:get_env(riak_core, handoff_ip),
-    SslOpts = app_helper:get_env(riak_core, handoff_ssl_options, []),
+    SslOpts = riak_core_handoff_sender:get_handoff_ssl_options(),
     gen_nb_server:start_link(?MODULE, IpAddr, PortNum, [PortNum, SslOpts]).
 
 init([PortNum, SslOpts]) ->


### PR DESCRIPTION
Added basics for SSL options for handoff sender & receiver.  It has been
lightly tested using SSL (it works), and the non-SSL case still appears to
work fine.  Because basho_expect can't easily patch stuff that isn't a .beam
file, e.g. etc config files, boot scripts, I haven't given this a full workout
with basho_expect yet.

Verification of SSL encryption: use Wireshark to record traffic on ports
8101 and 8102 directly, or use "tcpdump -w /path/to/file -i lo0 -s 9999
port 8101 or port 8102" and then use Wireshark to analyze as SSL.
