### PR TITLE
Az302 vnode handle info

### DIFF
--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -232,9 +232,7 @@ handle_info({'EXIT', Pid, Reason}, StateName, State=#state{mod=Mod,modstate=ModS
                 {next_state, StateName, State#state{modstate=NewModState},
                     State#state.inactivity_timeout};
             {stop, Reason, NewModState} ->
-                 {stop, Reason, State#state{modstate=NewModState}};
-            Else ->
-                Else
+                 {stop, Reason, State#state{modstate=NewModState}}
         end
     catch
         _ErrorType:undef ->
@@ -244,13 +242,9 @@ handle_info({'EXIT', Pid, Reason}, StateName, State=#state{mod=Mod,modstate=ModS
 handle_info(Info, StateName, State=#state{mod=Mod,modstate=ModState}) ->
     case erlang:function_exported(Mod, handle_info, 2) of
         true ->
-            case Mod:handle_info(Info, ModState) of
-                {ok, NewModState} ->
-                    {next_state, StateName, State#state{modstate=NewModState},
-                        State#state.inactivity_timeout};
-                Else ->
-                    Else
-            end;
+            {ok, NewModState} = Mod:handle_info(Info, ModState),
+            {next_state, StateName, State#state{modstate=NewModState},
+             State#state.inactivity_timeout};
         false ->
             {next_state, StateName, State, State#state.inactivity_timeout}
     end.


### PR DESCRIPTION
adds a handle_info optional callback for vnodes.  it was previously brought up that this should be wrapped in try/catch, but we should be doing that for _all_ vnode callbacks, in a separate pull request.  
