### PR TITLE
Add async vnode worker pools

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -48,6 +48,8 @@
              riak_core_vnode,
              riak_core_vnode_master,
              riak_core_vnode_sup,
+             riak_core_vnode_worker,
+             riak_core_vnode_worker_pool,
              riak_core_web,
              riak_core_wm_urlmap,
              slide,

--- a/rebar.config
+++ b/rebar.config
@@ -6,6 +6,7 @@
 
 {deps, [
   {lager, "0.9.*", {git, "git://github.com/basho/lager", {branch, "master"}}},
+  {poolboy, "0.2", {git, "git://github.com/basho/poolboy", {branch, "master"}}},
   {protobuffs, "0.6.0", {git, "git://github.com/basho/erlang_protobuffs",
                               {tag, "protobuffs-0.6.0"}}},
   {basho_stats, ".*", {git, "git://github.com/basho/basho_stats", "HEAD"}},

--- a/src/riak_core_vnode_worker.erl
+++ b/src/riak_core_vnode_worker.erl
@@ -58,8 +58,6 @@ handle_call({work, Pool, Work, WorkFrom}, {Pid, _} = From, #state{module = Mod,
             NS;
         {noreply, NS} ->
             NS
-        %{stop, NS} ->
-            %???
     end,
     %% check the worker back into the pool
     poolboy:checkin(Pool, self()),

--- a/src/riak_core_vnode_worker.erl
+++ b/src/riak_core_vnode_worker.erl
@@ -1,0 +1,83 @@
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_vnode_worker).
+
+-behaviour(gen_server).
+
+-export([behaviour_info/1]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
+        code_change/3]).
+-export([start_link/1, handle_work/4]).
+
+-record(state, {
+        module :: atom(),
+        modstate :: any()
+    }).
+
+-spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
+behaviour_info(callbacks) ->
+    [{init_worker,3},
+     {handle_work,3}];
+behaviour_info(_Other) ->
+    undefined.
+
+start_link(Args) ->
+    WorkerMod = proplists:get_value(worker_callback_mod, Args),
+    [VNodeIndex, WorkerArgs, WorkerProps] = proplists:get_value(worker_args, Args),
+    gen_server:start(?MODULE, [WorkerMod, VNodeIndex, WorkerArgs, WorkerProps], []).
+
+handle_work(Pid, Pool, Work, From) ->
+    gen_server:call(Pid, {work, Pool, Work, From}).
+
+init([Module, VNodeIndex, WorkerArgs, WorkerProps]) ->
+    {ok, WorkerState} = Module:init_worker(VNodeIndex, WorkerArgs, WorkerProps),
+    {ok, #state{module=Module, modstate=WorkerState}}.
+
+handle_call({work, Pool, Work, WorkFrom}, {Pid, _} = From, #state{module = Mod,
+        modstate = ModState} = State) ->
+    gen_server:reply(From, ok), %% unblock the caller
+    NewModState = case Mod:handle_work(Work, WorkFrom, ModState) of
+        {reply, Reply, NS} ->
+            riak_core_vnode:reply(WorkFrom, Reply),
+            NS;
+        {noreply, NS} ->
+            NS
+        %{stop, NS} ->
+            %???
+    end,
+    %% check the worker back into the pool
+    %io:format("returning worker to the pool~n"),
+    poolboy:checkin(Pool, self()),
+    Pid ! checkin,
+    {noreply, State#state{modstate=NewModState}};
+handle_call(_Event, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(_Event, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+

--- a/src/riak_core_vnode_worker.erl
+++ b/src/riak_core_vnode_worker.erl
@@ -40,7 +40,7 @@ behaviour_info(_Other) ->
 start_link(Args) ->
     WorkerMod = proplists:get_value(worker_callback_mod, Args),
     [VNodeIndex, WorkerArgs, WorkerProps] = proplists:get_value(worker_args, Args),
-    gen_server:start(?MODULE, [WorkerMod, VNodeIndex, WorkerArgs, WorkerProps], []).
+    gen_server:start_link(?MODULE, [WorkerMod, VNodeIndex, WorkerArgs, WorkerProps], []).
 
 handle_work(Pid, Pool, Work, From) ->
     gen_server:call(Pid, {work, Pool, Work, From}).

--- a/src/riak_core_vnode_worker.erl
+++ b/src/riak_core_vnode_worker.erl
@@ -62,7 +62,6 @@ handle_call({work, Pool, Work, WorkFrom}, {Pid, _} = From, #state{module = Mod,
             %???
     end,
     %% check the worker back into the pool
-    %io:format("returning worker to the pool~n"),
     poolboy:checkin(Pool, self()),
     Pid ! checkin,
     {noreply, State#state{modstate=NewModState}};

--- a/src/riak_core_vnode_worker.erl
+++ b/src/riak_core_vnode_worker.erl
@@ -63,7 +63,7 @@ handle_call({work, Pool, Work, WorkFrom}, {Pid, _} = From, #state{module = Mod,
     end,
     %% check the worker back into the pool
     poolboy:checkin(Pool, self()),
-    Pid ! checkin,
+    gen_fsm:send_all_state_event(Pid, checkin),
     {noreply, State#state{modstate=NewModState}};
 handle_call(_Event, _From, State) ->
     {reply, ok, State}.

--- a/src/riak_core_vnode_worker_pool.erl
+++ b/src/riak_core_vnode_worker_pool.erl
@@ -28,7 +28,7 @@
 -export([ready/2, queueing/2, ready/3, queueing/3]).
 
 %% API
--export([start_link/5]).
+-export([start_link/5, handle_work/3]).
 
 -record(state, {
         queue = queue:new(),
@@ -39,8 +39,11 @@
 start_link(WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps) ->
     gen_fsm:start_link(?MODULE, [WorkerMod, PoolSize,  VNodeIndex, WorkerArgs, WorkerProps], []).
 
+handle_work(Pid, Work, From) ->
+    gen_fsm:send_event(Pid, {work, Work, From}).
+
 init([WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps]) ->
-    %io:format("~p starting worker pool with module ~p size ~p~n", [self(), WorkerMod,
+    io:format("~p starting worker pool with module ~p size ~p~n", [self(), WorkerMod,
             PoolSize]),
     {ok, Pid} = poolboy:start_link([{worker_module, riak_core_vnode_worker},
             {worker_args, [VNodeIndex, WorkerArgs, WorkerProps]},

--- a/src/riak_core_vnode_worker_pool.erl
+++ b/src/riak_core_vnode_worker_pool.erl
@@ -1,0 +1,105 @@
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_vnode_worker_pool).
+
+-behaviour(gen_fsm).
+
+%% gen_fsm callbacks
+-export([init/1, handle_event/3, handle_sync_event/4, handle_info/3,
+        terminate/3, code_change/4]).
+
+%% gen_fsm states
+-export([ready/2, queueing/2, ready/3, queueing/3]).
+
+%% API
+-export([start_link/5]).
+
+-record(state, {
+        queue = queue:new(),
+        pool :: pid()
+        %remaining = 0 :: non_neg_integer()
+    }).
+
+start_link(WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps) ->
+    gen_fsm:start_link(?MODULE, [WorkerMod, PoolSize,  VNodeIndex, WorkerArgs, WorkerProps], []).
+
+init([WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps]) ->
+    %io:format("~p starting worker pool with module ~p size ~p~n", [self(), WorkerMod,
+            PoolSize]),
+    {ok, Pid} = poolboy:start_link([{worker_module, riak_core_vnode_worker},
+            {worker_args, [VNodeIndex, WorkerArgs, WorkerProps]},
+            {worker_callback_mod, WorkerMod},
+            {size, PoolSize}, {max_overflow, 0},
+            {checkout_blocks, false}]),
+    {ok, ready, #state{pool=Pid}}.
+
+ready(_Event, _From, State) ->
+    {reply, ok, ready, State}.
+
+ready({work, Work, From} = Msg, #state{pool=Pool, queue=Q} = State) ->
+    case poolboy:checkout(Pool) of
+        full ->
+            %io:format("queued work~n"),
+            {next_state, queueing, State#state{queue=queue:in(Msg, Q)}};
+        Pid when is_pid(Pid) ->
+            %io:format("offloading work to worker ~p~n", [Pid]),
+            ok = riak_core_vnode_worker:handle_work(Pid, Pool, Work, From),
+            {next_state, ready, State}
+    end;
+ready(_Event, State) ->
+    {next_state, ready, State}.
+
+queueing(_Event, _From, State) ->
+    {reply, ok, queueing, State}.
+
+queueing({work, _Work, _From} = Msg, #state{queue=Q} = State) ->
+    %io:format("queued work~n"),
+    {next_state, queueing, State#state{queue=queue:in(Msg, Q)}};
+queueing(_Event, State) ->
+    {next_state, queueing, State}.
+
+handle_event(_Event, StateName, State) ->
+    {next_state, StateName, State}.
+
+handle_sync_event(_Event, _From, StateName, State) ->
+    {reply, {error, unknown_message}, StateName, State}.
+
+handle_info(checkin, _, #state{pool = Pool, queue=Q} = State) ->
+    %io:format("checkin -- switching back to ready~n"),
+    case queue:out(Q) of
+        {{value, {work, Work, From}}, Rem} ->
+            case poolboy:checkout(Pool) of
+                full ->
+                    {next_state, queueing, State#state{queue=Q}};
+                Pid when is_pid(Pid) ->
+                    %io:format("offloading work to worker ~p~n", [Pid]),
+                    ok = riak_core_vnode_worker:handle_work(Pid, Pool, Work, From),
+                    {next_state, queueing, State#state{queue=Rem}}
+            end;
+        {empty, Empty} ->
+            {next_state, ready, State#state{queue=Empty}}
+    end;
+handle_info(_Info, StateName, State) ->
+    {next_state, StateName, State}.
+
+terminate(_Reason, _StateName, _State) ->
+    ok.
+
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.

--- a/test/worker_pool_test.erl
+++ b/test/worker_pool_test.erl
@@ -1,0 +1,98 @@
+%% -------------------------------------------------------------------
+%%
+%% test_guarded_event_handler
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(worker_pool_test).
+
+-behaviour(riak_core_vnode_worker).
+-include_lib("eunit/include/eunit.hrl").
+
+-export([init_worker/3, handle_work/3]).
+
+init_worker(_VnodeIndex, Noreply, _WorkerProps) ->
+    {ok, Noreply}.
+
+handle_work(Work, From, true = State) ->
+    Work(),
+    riak_core_vnode:reply(From, ok),
+    {noreply, State};
+handle_work(Work, _From, false = State) ->
+    Work(),
+    {reply, ok, State}.
+
+-ifdef(TEST).
+
+receive_result(N) ->
+    receive
+        {N, ok} when N rem 2 /= 0 ->
+            true;
+        {N, {error, {worker_crash, _, _}}} when N rem 2 == 0 ->
+            true
+    after
+        0 ->
+            timeout
+    end.
+
+simple_worker_pool() ->
+    {ok, Pool} = riak_core_vnode_worker_pool:start_link(?MODULE, 3, 10, false, []),
+    [ riak_core_vnode_worker_pool:handle_work(Pool, fun() ->
+                        timer:sleep(100),
+                        1/(N rem 2)
+                end,
+                {raw, N, self()})
+            || N <- lists:seq(1, 10)],
+
+    timer:sleep(1200),
+
+    %% make sure we got all the expected responses
+
+    [ ?assertEqual(true, receive_result(N)) || N <- lists:seq(1, 10)].
+
+simple_noreply_worker_pool() ->
+    {ok, Pool} = riak_core_vnode_worker_pool:start_link(?MODULE, 3, 10, true, []),
+    [ riak_core_vnode_worker_pool:handle_work(Pool, fun() ->
+                        timer:sleep(100),
+                        1/(N rem 2)
+                end,
+                {raw, N, self()})
+            || N <- lists:seq(1, 10)],
+
+    timer:sleep(1200),
+
+    %% make sure we got all the expected responses
+
+    [ ?assertEqual(true, receive_result(N)) || N <- lists:seq(1, 10)].
+
+
+pool_test_() ->
+    {setup,
+        fun() ->
+                error_logger:tty(false)
+        end,
+        fun(_) ->
+                error_logger:tty(true)
+        end,
+        [
+            fun simple_worker_pool/0,
+            fun simple_noreply_worker_pool/0
+        ]
+    }.
+
+-endif.

--- a/test/worker_pool_test.erl
+++ b/test/worker_pool_test.erl
@@ -1,7 +1,5 @@
 %% -------------------------------------------------------------------
 %%
-%% test_guarded_event_handler
-%%
 %% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,


### PR DESCRIPTION
Initial support for vnode worker pools, using the poolboy library.

A good way to test them is to modify riak_kv_vnode to return a poolspec and then use one of the pool pids printed to the console to do something like this:

[ riak_core_vnode_worker_pool:handle_work(Pid, fun() -> io:format("hello ~p~n", [N]), timer:sleep(5000), 1/(N rem 2) end, {raw, N, self()}) || N <- lists:seq(1, 10)].

This will submit 10 jobs to the worker pool, half of which will crash. If your pool is smaller than 10, you will see the other jobs wait their turn to be worked on. You will also get the reply back to the shell, which you can inspect using flush().

An example modification to the riak_kv_vnode can be seen here: https://gist.github.com/5911fd3dde5b019ad28b
