### PR TITLE
Az577 riak control, track handoff

### DIFF
--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -214,6 +214,7 @@ active(handoff_complete, State=#state{mod=Mod,
                                       handoff_token=HT}) ->
     %% ?debugFmt("Finished HO: ~p :: ~p -> ~p~n", [Idx, Prev, New]),
     riak_core_handoff_manager:release_handoff_lock({Mod, Idx}, HT),
+    riak_core_handoff_manager:remove_handoff(Mod, Idx),
     Mod:handoff_finished(HN, ModState),
     finish_handoff(State);
 active({handoff_error, _Err, _Reason}, State=#state{mod=Mod, 
@@ -221,6 +222,7 @@ active({handoff_error, _Err, _Reason}, State=#state{mod=Mod,
                                                     index=Idx, 
                                                     handoff_token=HT}) ->
     riak_core_handoff_manager:release_handoff_lock({Mod, Idx}, HT),
+    riak_core_handoff_manager:remove_handoff(Mod, Idx),
     %% it would be nice to pass {Err, Reason} to the vnode but the 
     %% API doesn't currently allow for that.
     Mod:handoff_cancelled(ModState),
@@ -361,6 +363,7 @@ start_handoff(State=#state{index=Idx, mod=Mod, modstate=ModState}, TargetNode) -
                                            handoff_token=HandoffToken,
                                            handoff_node=TargetNode},
                     {ok, HandoffPid} = riak_core_handoff_sender:start_link(TargetNode, Mod, Idx),
+                    riak_core_handoff_manager:add_handoff(Mod, Idx, TargetNode),
                     continue(NewState#state{handoff_pid=HandoffPid})
             end
     end.

--- a/src/riak_core_vnode_master.erl
+++ b/src/riak_core_vnode_master.erl
@@ -25,7 +25,7 @@
 -module(riak_core_vnode_master).
 -include_lib("riak_core_vnode.hrl").
 -behaviour(gen_server).
--export([start_link/1, start_link/2, get_vnode_pid/2,
+-export([start_link/1, start_link/2, get_vnode_pid/2, is_vnode_pid/2,
          start_vnode/2, command/3, command/4, sync_command/3,
          coverage/5,
          command_return_vnode/4,
@@ -58,6 +58,10 @@ start_vnode(Index, VNodeMod) ->
 get_vnode_pid(Index, VNodeMod) ->
     RegName = reg_name(VNodeMod),
     gen_server:call(RegName, {Index, get_vnode}, infinity).
+
+is_vnode_pid(Index, VNodeMod) ->
+    RegName = reg_name(VNodeMod),
+    gen_server:call(RegName, {Index, is_vnode}, infinity).
 
 command(Preflist, Msg, VMaster) ->
     command(Preflist, Msg, ignore, VMaster).
@@ -206,6 +210,13 @@ handle_call(all_nodes, _From, State) ->
 handle_call({Partition, get_vnode}, _From, State) ->
     Pid = get_vnode(Partition, State),
     {reply, {ok, Pid}, State};
+handle_call({Partition, is_vnode}, _From, State) ->
+    Reply = case idx2vnode(Partition, State) of
+                no_match ->
+                    false;
+                Pid -> {true, Pid}
+            end,
+    {reply, Reply, State};
 handle_call(Other, From, State=#state{legacy=Legacy}) when Legacy =/= undefined ->
     case catch Legacy:rewrite_call(Other, From) of
         {ok, ?VNODE_REQ{}=Req} ->


### PR DESCRIPTION
Add code to riak_core_vnode_master and riak_core_handoff_manager so that the state of a vnode can be ascertained without asking the vnode (specifically avoiding calls to get_mod_index.)
