### PR TITLE
Az630: Add legacy gossip mode + rolling upgrade between gossip versions

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -14,6 +14,7 @@
              merkerl,
              priority_queue,
              process_proxy,
+             riak_core_gossip_legacy,
              riak_core,
              riak_core_apl,
              riak_core_app,

--- a/include/riak_core_ring.hrl
+++ b/include/riak_core_ring.hrl
@@ -1,0 +1,2 @@
+-define(LEGACY_RING_VSN, 1).
+-define(CURRENT_RING_VSN, 2).

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -77,7 +77,9 @@ start(_StartType, _StartArgs) ->
                             lager:critical("Failed to read ring file: ~p",
                                 [lager:posix_error(Reason)]),
                             throw({error, Reason});
-                        Ring ->
+                        Ring0 ->
+                            %% Upgrade the ring data structure if necessary.
+                            Ring = riak_core_ring:upgrade(Ring0),
                             riak_core_ring_manager:set_my_ring(Ring)
                     end;
                 {error, not_found} ->

--- a/src/riak_core_claim.erl
+++ b/src/riak_core_claim.erl
@@ -71,7 +71,8 @@
 default_wants_claim(Ring) ->
     default_wants_claim(Ring, node()).
 
-default_wants_claim(Ring, Node) ->
+default_wants_claim(Ring0, Node) ->
+    Ring = riak_core_ring:upgrade(Ring0),
     %% Determine how many nodes are involved with the ring; if the requested
     %% node is not yet part of the ring, include it in the count.
     AllMembers = riak_core_ring:claiming_members(Ring),
@@ -103,7 +104,8 @@ default_wants_claim(Ring, Node) ->
 default_choose_claim(Ring) ->
     default_choose_claim(Ring, node()).
 
-default_choose_claim(Ring, Node) ->
+default_choose_claim(Ring0, Node) ->
+    Ring = riak_core_ring:upgrade(Ring0),
     TargetN = app_helper:get_env(riak_core, target_n_val),
     case meets_target_n(Ring, TargetN) of
         {true, TailViolations} ->
@@ -231,7 +233,8 @@ find_biggest_hole(Mine) ->
                 none,
                 lists:zip(Mine, tl(Mine)++[hd(Mine)])).
 
-claim_rebalance_n(Ring, Node) ->
+claim_rebalance_n(Ring0, Node) ->
+    Ring = riak_core_ring:upgrade(Ring0),
     %% diagonal stripes guarantee most disperse data
     Nodes = lists:usort([Node|riak_core_ring:claiming_members(Ring)]),
     Partitions = lists:sort([ I || {I, _} <- riak_core_ring:all_owners(Ring) ]),
@@ -248,9 +251,10 @@ claim_rebalance_n(Ring, Node) ->
                 Ring,
                 Zipped).
 
-random_choose_claim(Ring) ->
+random_choose_claim(Ring0) ->
+    Ring = riak_core_ring:upgrade(Ring0),
     riak_core_ring:transfer_node(riak_core_ring:random_other_index(Ring),
-                            node(), Ring).
+                                 node(), Ring).
 
 %% @spec never_wants_claim(riak_core_ring()) -> no
 %% @doc For use by nodes that should not claim any partitions.

--- a/src/riak_core_gossip.erl
+++ b/src/riak_core_gossip.erl
@@ -322,7 +322,9 @@ handle_cast({rejoin, RingIn}, State) ->
                        riak_core_ring:cluster_name(OtherRing)),
     case SameCluster of
         true ->
-            riak_core:join(riak_core_ring:owner_node(OtherRing)),
+            Legacy = check_legacy_gossip(Ring, State),
+            OtherNode = riak_core_ring:owner_node(OtherRing),
+            riak_core:join(Legacy, node(), OtherNode),
             {noreply, State};
         false ->
             {noreply, State}

--- a/src/riak_core_gossip_legacy.erl
+++ b/src/riak_core_gossip_legacy.erl
@@ -1,0 +1,261 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_core: Core Riak Application
+%%
+%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc riak_core_gossip takes care of the mechanics of shuttling a from one
+%% node to another upon request by other Riak processes.
+%%
+%% Additionally, it occasionally checks to make sure the current node has its
+%% fair share of partitions, and also sends a copy of the ring to some other
+%% random node, ensuring that all nodes eventually synchronize on the same
+%% understanding of the Riak cluster. This interval is configurable, but
+%% defaults to once per minute.
+
+-module(riak_core_gossip_legacy).
+
+-behaviour(gen_server).
+
+-export([start_link/0, stop/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+-export ([distribute_ring/1, send_ring/1, send_ring/2, remove_from_cluster/1]).
+
+-include_lib("riak_core_ring.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+%% distribute_ring/1 -
+%% Distribute a ring to all members of that ring.
+distribute_ring(Ring) ->
+    gen_server:cast({?MODULE, node()}, {distribute_ring, Ring}).
+
+%% send_ring/1 -
+%% Send the current node's ring to some other node.
+send_ring(ToNode) -> send_ring(node(), ToNode).
+
+%% send_ring/2 -
+%% Send the ring from one node to another node.
+%% Does nothing if the two nodes are the same.
+send_ring(Node, Node) ->
+    ok;
+send_ring(FromNode, ToNode) ->
+    gen_server:cast({?MODULE, FromNode}, {send_ring_to, ToNode}).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+stop() ->
+    gen_server:cast(?MODULE, stop).
+
+
+%% ===================================================================
+%% gen_server behaviour
+%% ===================================================================
+
+%% @private
+init(_State) ->
+    schedule_next_gossip(),
+    {ok, true}.
+
+
+%% @private
+handle_call(_, _From, State) ->
+    {reply, ok, State}.
+
+
+%% @private
+handle_cast({send_ring_to, Node}, RingChanged) ->
+    {ok, MyRing} = riak_core_ring_manager:get_my_ring(),
+    gen_server:cast({?MODULE, Node}, {reconcile_ring, MyRing}),
+    {noreply, RingChanged};
+
+handle_cast({distribute_ring, Ring}, RingChanged) ->
+    Nodes = riak_core_ring:all_members(Ring),
+    gen_server:abcast(Nodes, ?MODULE, {reconcile_ring, Ring}),
+    {noreply, RingChanged};
+
+handle_cast({reconcile_ring, OtherRing}, RingChanged) ->
+    % Compare the two rings, see if there is anything that
+    % must be done to make them equal...
+    {ok, MyRing0} = riak_core_ring_manager:get_my_ring(),
+    MyRing = riak_core_ring:downgrade(?LEGACY_RING_VSN, MyRing0),
+    case riak_core_ring:legacy_reconcile(OtherRing, MyRing) of
+        {no_change, _} ->
+            {noreply, RingChanged};
+
+        {new_ring, ReconciledRing} ->
+            % Rebalance the new ring and save it
+            BalancedRing = claim_until_balanced(ReconciledRing),
+            riak_core_ring_manager:set_my_ring(BalancedRing),
+
+            BalancedRing2 = riak_core_ring:upgrade(BalancedRing),
+            riak_core_gossip:random_gossip(BalancedRing2),
+            {noreply, true}
+    end;
+
+handle_cast(gossip_ring, _RingChanged) ->
+    % First, schedule the next round of gossip...
+    schedule_next_gossip(),
+
+    % Gossip the ring to some random other node...
+    {ok, MyRing} = riak_core_ring_manager:get_my_ring(),
+    case riak_core_ring:random_other_node(MyRing) of
+        no_node -> % must be single node cluster
+            ok;
+        RandomNode ->
+            send_ring(node(), RandomNode)
+    end,
+    {noreply, false};
+
+handle_cast(_, State) ->
+    {noreply, State}.
+
+%% @private
+handle_info(_Info, State) -> {noreply, State}.
+
+%% @private
+terminate(_Reason, _State) ->
+    ok.
+
+%% @private
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+
+schedule_next_gossip() ->
+    MaxInterval = app_helper:get_env(riak_core, gossip_interval),
+    Interval = random:uniform(MaxInterval),
+    timer:apply_after(Interval, gen_server, cast, [?MODULE, gossip_ring]).
+
+claim_until_balanced(Ring) ->
+    {WMod, WFun} = app_helper:get_env(riak_core, wants_claim_fun),
+    NeedsIndexes = apply(WMod, WFun, [Ring]),
+    case NeedsIndexes of
+        no ->
+            Ring;
+        {yes, _NumToClaim} ->
+            {CMod, CFun} = app_helper:get_env(riak_core, choose_claim_fun),
+            NewRing0 = CMod:CFun(Ring),
+            NewRing = riak_core_ring:downgrade(?LEGACY_RING_VSN, NewRing0),
+            claim_until_balanced(NewRing)
+    end.
+
+
+remove_from_cluster(ExitingNode) ->
+    % Set the remote node to stop claiming.
+    % Ignore return of rpc as this should succeed even if node is offline
+    rpc:call(ExitingNode, application, set_env,
+             [riak_core, wants_claim_fun, {riak_core_claim, never_wants_claim}]),
+
+    % Get a list of indices owned by the ExitingNode...
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    AllOwners = riak_core_ring:all_owners(Ring),
+
+    % Transfer indexes to other nodes...
+    ExitRing0 =
+        case attempt_simple_transfer(Ring, AllOwners, ExitingNode) of
+            {ok, NR} ->
+                NR;
+            target_n_fail ->
+                %% re-diagonalize
+                %% first hand off all claims to *any* one else,
+                %% just so rebalance doesn't include exiting node
+                Members = riak_core_ring:all_members(Ring),
+                Other = hd(lists:delete(ExitingNode, Members)),
+                TempRing = lists:foldl(
+                             fun({I,N}, R) when N == ExitingNode ->
+                                     riak_core_ring:transfer_node(I, Other, R);
+                                (_, R) -> R
+                             end,
+                             Ring,
+                             AllOwners),
+                TempRing2 = riak_core_ring:downgrade(?LEGACY_RING_VSN,
+                                                     TempRing),
+                TempRing3 = riak_core_claim:claim_rebalance_n(TempRing2, Other),
+                riak_core_ring:upgrade(TempRing3)
+        end,
+
+    ExitRing = riak_core_ring:downgrade(?LEGACY_RING_VSN, ExitRing0),
+
+    % Send the new ring to all nodes except the exiting node
+    riak_core_gossip:distribute_ring(ExitRing0),
+
+    % Set the new ring on the exiting node. This will trigger
+    % it to begin handoff and cleanly leave the cluster.
+    rpc:call(ExitingNode, riak_core_ring_manager, set_my_ring, [ExitRing]),
+
+    ok.
+
+
+attempt_simple_transfer(Ring, Owners, ExitingNode) ->
+    TargetN = app_helper:get_env(riak_core, target_n_val),
+    attempt_simple_transfer(Ring, Owners,
+                            TargetN,
+                            ExitingNode, 0,
+                            [{O,-TargetN} || O <- riak_core_ring:all_members(Ring),
+                                             O /= ExitingNode]).
+attempt_simple_transfer(Ring, [{P, Exit}|Rest], TargetN, Exit, Idx, Last) ->
+    %% handoff
+    case [ N || {N, I} <- Last, Idx-I >= TargetN ] of
+        [] ->
+            target_n_fail;
+        Candidates ->
+            %% these nodes don't violate target_n in the reverse direction
+            StepsToNext = fun(Node) ->
+                                  length(lists:takewhile(
+                                           fun({_, Owner}) -> Node /= Owner end,
+                                           Rest))
+                          end,
+            case lists:filter(fun(N) -> 
+                                 Next = StepsToNext(N),
+                                 (Next+1 >= TargetN)
+                                          orelse (Next == length(Rest))
+                              end,
+                              Candidates) of
+                [] ->
+                    target_n_fail;
+                Qualifiers ->
+                    %% these nodes don't violate target_n forward
+                    Chosen = lists:nth(random:uniform(length(Qualifiers)),
+                                       Qualifiers),
+                    %% choose one, and do the rest of the ring
+                    attempt_simple_transfer(
+                      riak_core_ring:transfer_node(P, Chosen, Ring),
+                      Rest, TargetN, Exit, Idx+1,
+                      lists:keyreplace(Chosen, 1, Last, {Chosen, Idx}))
+            end
+    end;
+attempt_simple_transfer(Ring, [{_, N}|Rest], TargetN, Exit, Idx, Last) ->
+    %% just keep track of seeing this node
+    attempt_simple_transfer(Ring, Rest, TargetN, Exit, Idx+1,
+                            lists:keyreplace(N, 1, Last, {N, Idx}));
+attempt_simple_transfer(Ring, [], _, _, _, _) ->
+    {ok, Ring}.

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -1518,11 +1518,12 @@ membership_test() ->
     {_, RingA7} = reconcile(RingB2, RingA6),
     ?assertEqual([nodeA, nodeB, nodeC], all_members(RingA7)),
 
-    Priority = [{invalid,1}, {valid,2}, {exiting,3}, {leaving,4}],
+    Priority = [{invalid,1}, {down,2}, {joining,3}, {valid,4}, {exiting,5},
+                {leaving,6}],
     RingX1 = fresh(nodeA),
     RingX2 = add_member(nodeA, RingX1, nodeB),
     RingX3 = add_member(nodeA, RingX2, nodeC),
-    ?assertEqual(valid, member_status(RingX3, nodeC)),
+    ?assertEqual(joining, member_status(RingX3, nodeC)),
 
     %% Parallel/sibling status changes merge based on priority
     [begin

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -53,9 +53,15 @@
          update_meta/3]).
 
 -export([cluster_name/1,
+         legacy_ring/1,
+         legacy_reconcile/2,
+         upgrade/1,
+         downgrade/2,
          claimant/1,
          member_status/2,
          all_member_status/1,
+         update_member_meta/5,
+         get_member_meta/3,
          add_member/3,
          remove_member/3,
          leave_member/3,
@@ -77,6 +83,8 @@
          ring_ready/1,
          ring_ready_info/1,
          ring_changed/2,
+         set_cluster_name/2,
+         reconcile_names/2,
          reconcile_members/2]).
 
 -export_type([riak_core_ring/0]).
@@ -89,7 +97,8 @@
 %%-define(ROUT(S,A),?debugFmt(S,A)).
 %%-define(ROUT(S,A),io:format(S,A)).
 
--record(chstate, {
+-define(CHSTATE, #chstate_v2).
+-record(chstate_v2, {
     nodename :: node(),          % the Node responsible for this chstate
     vclock   :: vclock:vclock(), % for this chstate object, entries are
                                  % {Node, Ctr}
@@ -99,10 +108,18 @@
 
     clustername :: {node(), term()}, 
     next     :: [{integer(), node(), node(), [module()], awaiting | complete}],
-    members  :: [{node(), {member_status(), vclock:vclock()}}],
+    members  :: [{node(), {member_status(), vclock:vclock(), []}}],
     claimant :: node(),
     seen     :: [{node(), vclock:vclock()}],
     rvsn     :: vclock:vclock()
+}). 
+
+%% Legacy chstate
+-record(chstate, {
+    nodename :: node(), % the Node responsible for this chstate
+    vclock,   % for this chstate object, entries are {Node, Ctr}
+    chring :: chash:chash(),   % chash ring of {IndexAsInt, Node} mappings
+    meta      % dict of cluster-wide other data (primarily bucket N-value, etc)
 }). 
 
 -type member_status() :: valid | invalid | leaving | exiting.
@@ -116,7 +133,7 @@
 }).
 
 %% riak_core_ring() is the opaque data type used for partition ownership
--type riak_core_ring() :: #chstate{}.
+-type riak_core_ring() :: ?CHSTATE{}.
 -type chstate() :: riak_core_ring().
 
 -type pending_change() :: {Owner :: node(),
@@ -128,19 +145,68 @@
 %% Public API
 %% ===================================================================
 
+%% @doc Returns true if the given ring is a legacy ring.
+legacy_ring(#chstate{}) ->
+    true;
+legacy_ring(_) ->
+    false.
+
+%% @doc Upgrade old ring structures to the latest format.
+upgrade(Old=?CHSTATE{}) ->
+    Old;
+upgrade(Old=#chstate{}) ->
+    #chstate{nodename=Node,
+             vclock=VC,
+             chring=Ring,
+             meta=Meta} = Old,
+    New1 = ?CHSTATE{nodename=Node,
+                    vclock=VC,
+                    chring=Ring,
+                    meta=Meta,
+                    clustername=undefined,
+                    next=[],
+                    members=[],
+                    claimant=undefined,
+                    seen=[],
+                    rvsn=VC},
+    MemberVC = vclock:increment(Node, vclock:fresh()),
+    Members = [{Member, {valid, MemberVC, []}}
+               || Member <- chash:members(Ring)],
+    New2 = New1?CHSTATE{members=Members},
+    case node() of
+        Node ->
+            GVsn = riak_core_gossip:gossip_version(),
+            update_member_meta(Node, New2, Node,
+                               gossip_vsn, GVsn, same_vclock);
+        _ ->
+            New2
+    end.
+
+%% @doc Downgrade the latest ring structure to a specified version.
+downgrade(1,?CHSTATE{nodename=Node,
+                     vclock=VC,
+                     chring=Ring,
+                     meta=Meta}) ->
+    #chstate{nodename=Node,
+             vclock=VC,
+             chring=Ring,
+             meta=Meta};
+downgrade(2,State=?CHSTATE{}) ->
+    State.
+
 %% @doc Produce a list of all nodes that are members of the cluster
 -spec all_members(State :: chstate()) -> [Node :: term()].
-all_members(#chstate{members=Members}) ->
+all_members(?CHSTATE{members=Members}) ->
     get_members(Members).
 
 %% @doc Produce a list of all active (not marked as down) cluster members
-active_members(#chstate{members=Members}) ->
+active_members(?CHSTATE{members=Members}) ->
     get_members(Members, [joining, valid, leaving, exiting]).
 
 %% @doc Provide all ownership information in the form of {Index,Node} pairs.
 -spec all_owners(State :: chstate()) -> [{Index :: integer(), Node :: term()}].
 all_owners(State) ->
-    chash:nodes(State#chstate.chring).
+    chash:nodes(State?CHSTATE.chring).
 
 %% @doc Provide every preflist in the ring, truncated at N.
 -spec all_preflists(State :: chstate(), N :: integer()) ->
@@ -158,7 +224,7 @@ diff_nodes(State1,State2) ->
     lists:usort(lists:flatten(AllDiff)).
 
 -spec equal_rings(chstate(), chstate()) -> boolean().
-equal_rings(_A=#chstate{chring=RA,meta=MA},_B=#chstate{chring=RB,meta=MB}) ->
+equal_rings(_A=?CHSTATE{chring=RA,meta=MA},_B=?CHSTATE{chring=RB,meta=MB}) ->
     MDA = lists:sort(dict:to_list(MA)),
     MDB = lists:sort(dict:to_list(MB)),
     case MDA =:= MDB of
@@ -183,9 +249,10 @@ fresh(NodeName) ->
 -spec fresh(RingSize :: integer(), NodeName :: term()) -> chstate().
 fresh(RingSize, NodeName) ->
     VClock=vclock:increment(NodeName, vclock:fresh()),
-    #chstate{nodename=NodeName,
+    GossipVsn = riak_core_gossip:gossip_version(),
+    ?CHSTATE{nodename=NodeName,
              clustername={NodeName, erlang:now()},
-             members=[{NodeName, {valid, VClock}}],
+             members=[{NodeName, {valid, VClock, [{gossip_vsn, GossipVsn}]}}],
              chring=chash:fresh(RingSize, NodeName),
              next=[],
              claimant=NodeName,
@@ -198,7 +265,7 @@ fresh(RingSize, NodeName) ->
 -spec get_meta(Key :: term(), State :: chstate()) -> 
     {ok, term()} | undefined.
 get_meta(Key, State) -> 
-    case dict:find(Key, State#chstate.meta) of
+    case dict:find(Key, State?CHSTATE.meta) of
         error -> undefined;
         {ok, M} -> {ok, M#meta_entry.value}
     end.
@@ -216,18 +283,18 @@ my_indices(State) ->
 %% @doc Return the number of partitions in this Riak ring.
 -spec num_partitions(State :: chstate()) -> integer().
 num_partitions(State) ->
-    chash:size(State#chstate.chring).
+    chash:size(State?CHSTATE.chring).
 
 %% @doc Return the node that is responsible for a given chstate.
 -spec owner_node(State :: chstate()) -> Node :: term().
 owner_node(State) ->
-    State#chstate.nodename.
+    State?CHSTATE.nodename.
 
 %% @doc For a given object key, produce the ordered list of
 %%      {partition,node} pairs that could be responsible for that object.
 -spec preflist(Key :: binary(), State :: chstate()) ->
                                [{Index :: integer(), Node :: term()}].
-preflist(Key, State) -> chash:successors(Key, State#chstate.chring).
+preflist(Key, State) -> chash:successors(Key, State?CHSTATE.chring).
 
 %% @doc Return a randomly-chosen node from amongst the owners.
 -spec random_node(State :: chstate()) -> Node :: term().
@@ -289,10 +356,10 @@ reconcile(ExternState, MyState) ->
 %% @doc  Rename OldNode to NewNode in a Riak ring.
 -spec rename_node(State :: chstate(), OldNode :: atom(), NewNode :: atom()) ->
             chstate().
-rename_node(State=#chstate{chring=Ring, nodename=ThisNode, members=Members,
+rename_node(State=?CHSTATE{chring=Ring, nodename=ThisNode, members=Members,
                            seen=Seen}, OldNode, NewNode) 
   when is_atom(OldNode), is_atom(NewNode)  ->
-    State#chstate{
+    State?CHSTATE{
       chring=lists:foldl(
                fun({Idx, Owner}, AccIn) ->
                        case Owner of
@@ -304,32 +371,32 @@ rename_node(State=#chstate{chring=Ring, nodename=ThisNode, members=Members,
       members=proplists:substitute_aliases([{OldNode, NewNode}], Members),
       seen=proplists:substitute_aliases([{OldNode, NewNode}], Seen),
       nodename=case ThisNode of OldNode -> NewNode; _ -> ThisNode end,
-      vclock=vclock:increment(NewNode, State#chstate.vclock)}.
+      vclock=vclock:increment(NewNode, State?CHSTATE.vclock)}.
 
 %% @doc Determine the integer ring index responsible
 %%      for a chash key.
 -spec responsible_index(chash:index(), chstate()) -> integer().
-responsible_index(ChashKey, #chstate{chring=Ring}) ->
+responsible_index(ChashKey, ?CHSTATE{chring=Ring}) ->
     <<IndexAsInt:160/integer>> = ChashKey,
     chash:next_index(IndexAsInt, Ring).
 
 -spec transfer_node(Idx :: integer(), Node :: term(), MyState :: chstate()) ->
            chstate().
 transfer_node(Idx, Node, MyState) ->
-    case chash:lookup(Idx, MyState#chstate.chring) of
+    case chash:lookup(Idx, MyState?CHSTATE.chring) of
         Node ->
             MyState;
         _ ->
-            Me = MyState#chstate.nodename,
-            VClock = vclock:increment(Me, MyState#chstate.vclock),
-            CHRing = chash:update(Idx, Node, MyState#chstate.chring),
-            MyState#chstate{vclock=VClock,chring=CHRing}
+            Me = MyState?CHSTATE.nodename,
+            VClock = vclock:increment(Me, MyState?CHSTATE.vclock),
+            CHRing = chash:update(Idx, Node, MyState?CHSTATE.chring),
+            MyState?CHSTATE{vclock=VClock,chring=CHRing}
     end.
 
 % @doc Set a key in the cluster metadata dict
 -spec update_meta(Key :: term(), Val :: term(), State :: chstate()) -> chstate().
 update_meta(Key, Val, State) ->
-    Change = case dict:find(Key, State#chstate.meta) of
+    Change = case dict:find(Key, State?CHSTATE.meta) of
                  {ok, OldM} ->
                      Val /= OldM#meta_entry.value;
                  error ->
@@ -341,31 +408,45 @@ update_meta(Key, Val, State) ->
                           calendar:universal_time()),
               value = Val
              },
-            VClock = vclock:increment(State#chstate.nodename,
-                                      State#chstate.vclock),
-            State#chstate{vclock=VClock,
-                          meta=dict:store(Key, M, State#chstate.meta)};
+            VClock = vclock:increment(State?CHSTATE.nodename,
+                                      State?CHSTATE.vclock),
+            State?CHSTATE{vclock=VClock,
+                          meta=dict:store(Key, M, State?CHSTATE.meta)};
        true ->
             State
     end.
 
 %% @doc Return the current claimant.
 -spec claimant(State :: chstate()) -> node().
-claimant(#chstate{claimant=Claimant}) ->
+claimant(?CHSTATE{claimant=Claimant}) ->
     Claimant.
 
 %% @doc Returns the unique identifer for this cluster.
 -spec cluster_name(State :: chstate()) -> term().
 cluster_name(State) ->
-    State#chstate.clustername.
+    State?CHSTATE.clustername.
 
+%% @doc Sets the unique identifer for this cluster.
+set_cluster_name(State, Name) ->
+    State?CHSTATE{clustername=Name}.
+
+reconcile_names(RingA=?CHSTATE{clustername=NameA},
+                RingB=?CHSTATE{clustername=NameB}) ->
+    case (NameA =:= undefined) or (NameB =:= undefined) of
+        true ->
+            {RingA?CHSTATE{clustername=undefined},
+             RingB?CHSTATE{clustername=undefined}};
+        false ->
+            {RingA, RingB}
+    end.
+    
 %% @doc Returns the current membership status for a node in the cluster.
 -spec member_status(State :: chstate(), Node :: node()) -> member_status().
-member_status(#chstate{members=Members}, Node) ->
+member_status(?CHSTATE{members=Members}, Node) ->
     member_status(Members, Node);
 member_status(Members, Node) ->
     case orddict:find(Node, Members) of
-        {ok, {Status, _}} ->
+        {ok, {Status, _, _}} ->
             Status;
         _ ->
             invalid
@@ -373,9 +454,43 @@ member_status(Members, Node) ->
 
 %% @doc Returns the current membership status for all nodes in the cluster.
 -spec all_member_status(State :: chstate()) -> [{node(), member_status()}].
-all_member_status(#chstate{members=Members}) ->
-    [{Node, Status} || {Node, {Status, _VC}} <- Members, Status /= invalid].
+all_member_status(?CHSTATE{members=Members}) ->
+    [{Node, Status} || {Node, {Status, _VC, _}} <- Members, Status /= invalid].
+
+get_member_meta(State, Member, Key) ->
+    case orddict:find(Member, State?CHSTATE.members) of
+        error -> undefined;
+        {ok, {_, _, Meta}} ->
+            case orddict:find(Key, Meta) of
+                error ->
+                    undefined;
+                {ok, Value} ->
+                    Value
+            end
+    end.
     
+%% @doc Set a key in the member metadata orddict
+update_member_meta(Node, State, Member, Key, Val) ->
+    VClock = vclock:increment(Node, State?CHSTATE.vclock),
+    State2 = update_member_meta(Node, State, Member, Key, Val, same_vclock),
+    State2?CHSTATE{vclock=VClock}.
+
+update_member_meta(Node, State, Member, Key, Val, same_vclock) ->
+    Members = State?CHSTATE.members,
+    case orddict:is_key(Member, Members) of
+        true ->
+            Members2 = orddict:update(Member,
+                                      fun({Status, VC, MD}) ->
+                                              {Status,
+                                               vclock:increment(Node, VC),
+                                               orddict:store(Key, Val, MD)}
+                                      end,
+                                      Members),
+            State?CHSTATE{members=Members2};
+        false ->
+            State
+    end.
+
 add_member(PNode, State, Node) ->
     set_member(PNode, State, Node, joining).
 
@@ -394,18 +509,18 @@ down_member(PNode, State, Node) ->
 %% @doc Return a list of all members of the cluster that are eligible to
 %%      claim partitions.
 -spec claiming_members(State :: chstate()) -> [Node :: node()].
-claiming_members(#chstate{members=Members}) ->
+claiming_members(?CHSTATE{members=Members}) ->
     get_members(Members, [joining, valid, down]).
 
 %% @doc Return a list of all members of the cluster that are marked as down.
 -spec down_members(State :: chstate()) -> [Node :: node()].
-down_members(#chstate{members=Members}) ->
+down_members(?CHSTATE{members=Members}) ->
     get_members(Members, [down]).
 
 %% @doc Set the node that is responsible for a given chstate.
 -spec set_owner(State :: chstate(), Node :: node()) -> chstate().
 set_owner(State, Node) ->
-    State#chstate{nodename=Node}.
+    State?CHSTATE{nodename=Node}.
 
 %% @doc Return all partition indices owned by a node.
 -spec indices(State :: chstate(), Node :: node()) -> [integer()].
@@ -422,18 +537,18 @@ future_indices(State, Node) ->
 
 %% @doc Return all indices that a node is scheduled to give to another.
 disowning_indices(State, Node) ->
-    [Idx || {Idx, Owner, _NextOwner, _Mods, _Status} <- State#chstate.next,
+    [Idx || {Idx, Owner, _NextOwner, _Mods, _Status} <- State?CHSTATE.next,
             Owner =:= Node].
 
 %% @doc Returns a list of all pending ownership transfers.
 pending_changes(State) ->
     %% For now, just return next directly.
-    State#chstate.next.
+    State?CHSTATE.next.
 
 %% @doc Return details for a pending partition ownership change.
 -spec next_owner(State :: chstate(), Idx :: integer()) -> pending_change().
 next_owner(State, Idx) ->
-    case lists:keyfind(Idx, 1, State#chstate.next) of
+    case lists:keyfind(Idx, 1, State?CHSTATE.next) of
         false ->
             {undefined, undefined, undefined};
         NInfo ->
@@ -444,7 +559,7 @@ next_owner(State, Idx) ->
 -spec next_owner(State :: chstate(), Idx :: integer(),
                  Mod :: module()) -> pending_change().
 next_owner(State, Idx, Mod) ->
-    case lists:keyfind(Idx, 1, State#chstate.next) of
+    case lists:keyfind(Idx, 1, State?CHSTATE.next) of
         false ->
             {undefined, undefined, undefined};
         {_, Owner, NextOwner, _Transfers, complete} ->
@@ -463,9 +578,9 @@ next_owner(State, Idx, Mod) ->
 ring_ready(State0) ->
     Owner = owner_node(State0),
     State = update_seen(Owner, State0),
-    Seen = State#chstate.seen,
-    Members = get_members(State#chstate.members, [valid, leaving]),
-    VClock = State#chstate.vclock,
+    Seen = State?CHSTATE.seen,
+    Members = get_members(State?CHSTATE.members, [valid, leaving]),
+    VClock = State?CHSTATE.vclock,
     R = [begin
              case orddict:find(Node, Seen) of
                  error ->
@@ -484,8 +599,8 @@ ring_ready() ->
 ring_ready_info(State0) ->
     Owner = owner_node(State0),
     State = update_seen(Owner, State0),
-    Seen = State#chstate.seen,
-    Members = get_members(State#chstate.members, [valid, leaving]),
+    Seen = State?CHSTATE.seen,
+    Members = get_members(State?CHSTATE.members, [valid, leaving]),
     RecentVC =
         orddict:fold(fun(_, VC, Recent) ->
                              case vclock:descends(VC, Recent) of
@@ -494,7 +609,7 @@ ring_ready_info(State0) ->
                                  false ->
                                      Recent
                              end
-                     end, State#chstate.vclock, Seen),
+                     end, State?CHSTATE.vclock, Seen),
     Outdated =
         orddict:filter(fun(Node, VC) ->
                                (not vclock:equal(VC, RecentVC))
@@ -510,6 +625,77 @@ handoff_complete(State, Idx, Mod) ->
 
 ring_changed(Node, State) ->
     internal_ring_changed(Node, State).
+
+%% ===================================================================
+%% Legacy reconciliation
+%% ===================================================================
+
+%% @doc Incorporate another node's state into our view of the Riak world.
+legacy_reconcile(ExternState, MyState) ->
+    case vclock:equal(MyState#chstate.vclock, vclock:fresh()) of
+        true -> 
+            {new_ring, #chstate{nodename=MyState#chstate.nodename,
+                                vclock=ExternState#chstate.vclock,
+                                chring=ExternState#chstate.chring,
+                                meta=ExternState#chstate.meta}};
+        false ->
+            case ancestors([ExternState, MyState]) of
+                [OlderState] ->
+                    case vclock:equal(OlderState#chstate.vclock,
+                                      MyState#chstate.vclock) of
+                        true ->
+                            {new_ring,
+                             #chstate{nodename=MyState#chstate.nodename,
+                                      vclock=ExternState#chstate.vclock,
+                                      chring=ExternState#chstate.chring,
+                                      meta=ExternState#chstate.meta}};
+                        false -> {no_change, MyState}
+                    end;
+                [] -> 
+                    case legacy_equal_rings(ExternState,MyState) of
+                        true -> {no_change, MyState};
+                        false -> {new_ring,
+                                  legacy_reconcile(MyState#chstate.nodename,
+                                                   ExternState, MyState)}
+                    end
+            end
+    end.
+
+%% @private
+ancestors(RingStates) ->
+    Ancest = [[O2 || O2 <- RingStates,
+     vclock:descends(O1#chstate.vclock,O2#chstate.vclock),
+     (vclock:descends(O2#chstate.vclock,O1#chstate.vclock) == false)]
+ || O1 <- RingStates],
+    lists:flatten(Ancest).
+
+%% @private
+legacy_equal_rings(_A=#chstate{chring=RA,meta=MA},
+                   _B=#chstate{chring=RB,meta=MB}) ->
+    MDA = lists:sort(dict:to_list(MA)),
+    MDB = lists:sort(dict:to_list(MB)),
+    case MDA =:= MDB of
+        false -> false;
+        true -> RA =:= RB
+    end.
+
+%% @private
+% @doc If two states are mutually non-descendant, merge them anyway.
+%      This can cause a bit of churn, but should converge.
+% @spec reconcile(MyNodeName :: term(),
+%                 StateA :: chstate(), StateB :: chstate())
+%              -> chstate()
+legacy_reconcile(MyNodeName, StateA, StateB) ->
+    % take two states (non-descendant) and merge them
+    VClock = vclock:increment(MyNodeName,
+        vclock:merge([StateA#chstate.vclock,
+                StateB#chstate.vclock])),
+    CHRing = chash:merge_rings(StateA#chstate.chring,StateB#chstate.chring),
+    Meta = merge_meta(StateA#chstate.meta, StateB#chstate.meta),
+    #chstate{nodename=MyNodeName,
+             vclock=VClock,
+             chring=CHRing,
+             meta=Meta}.
 
 %% =========================================================================
 %% Claimant rebalance/reassign logic
@@ -543,7 +729,7 @@ internal_ring_changed(Node, CState0) ->
             %%   -- Starts when next changes from empty to non-empty
             %%   -- Stops when next changes from non-empty to empty
             %%
-            IsClaimant = (CState5#chstate.claimant =:= Node),
+            IsClaimant = (CState5?CHSTATE.claimant =:= Node),
             WasPending = ([] /= pending_changes(CState)),
             IsPending  = ([] /= pending_changes(CState5)),
 
@@ -567,10 +753,24 @@ internal_ring_changed(Node, CState0) ->
                     ok
             end,
 
+            %% Set cluster name if it is undefined
+            case {IsClaimant, cluster_name(CState5)} of
+                {true, undefined} ->
+                    ClusterName = {Node, erlang:now()},
+                    riak_core_util:rpc_every_member(riak_core_ring_manager,
+                                                    set_cluster_name,
+                                                    [ClusterName],
+                                                    1000),
+                    ok;
+                _ ->
+                    ClusterName = cluster_name(CState5),
+                    ok
+            end,
+
             case Changed of
                 true ->
-                    VClock = vclock:increment(Node, CState5#chstate.vclock),
-                    CState5#chstate{vclock=VClock};
+                    VClock = vclock:increment(Node, CState5?CHSTATE.vclock),
+                    CState5?CHSTATE{vclock=VClock, clustername=ClusterName};
                 false ->
                     CState5
             end
@@ -578,9 +778,9 @@ internal_ring_changed(Node, CState0) ->
 
 %% @private
 maybe_update_claimant(Node, CState) ->
-    Members = get_members(CState#chstate.members, [valid, leaving]),
-    Claimant = CState#chstate.claimant,
-    RVsn = CState#chstate.rvsn,
+    Members = get_members(CState?CHSTATE.members, [valid, leaving]),
+    Claimant = CState?CHSTATE.claimant,
+    RVsn = CState?CHSTATE.rvsn,
     NextClaimant = hd(Members ++ [undefined]),
     ClaimantMissing = not lists:member(Claimant, Members),
 
@@ -589,7 +789,7 @@ maybe_update_claimant(Node, CState) ->
             %% Become claimant
             %%?assert(Node /= Claimant),
             RVsn2 = vclock:increment(Claimant, RVsn),
-            CState2 = CState#chstate{claimant=Node, rvsn=RVsn2},
+            CState2 = CState?CHSTATE{claimant=Node, rvsn=RVsn2},
             {true, CState2};
         _ ->
             {false, CState}
@@ -597,7 +797,7 @@ maybe_update_claimant(Node, CState) ->
 
 %% @private
 maybe_update_ring(Node, CState) ->
-    Claimant = CState#chstate.claimant,
+    Claimant = CState?CHSTATE.claimant,
     case Claimant of
         Node ->
             case claiming_members(CState) of
@@ -617,10 +817,10 @@ maybe_update_ring(Node, CState) ->
 
 %% @private
 maybe_remove_exiting(Node, CState) ->
-    Claimant = CState#chstate.claimant,
+    Claimant = CState?CHSTATE.claimant,
     case Claimant of
         Node ->
-            Exiting = get_members(CState#chstate.members, [exiting]),
+            Exiting = get_members(CState?CHSTATE.members, [exiting]),
             Changed = (Exiting /= []),
             CState2 =
                 lists:foldl(fun(ENode, CState0) ->
@@ -638,10 +838,10 @@ maybe_remove_exiting(Node, CState) ->
 
 %% @private
 maybe_handle_joining(Node, CState) ->
-    Claimant = CState#chstate.claimant,
+    Claimant = CState?CHSTATE.claimant,
     case Claimant of
         Node ->
-            Joining = get_members(CState#chstate.members, [joining]),
+            Joining = get_members(CState?CHSTATE.members, [joining]),
             Changed = (Joining /= []),
             CState2 =
                 lists:foldl(fun(JNode, CState0) ->
@@ -655,26 +855,26 @@ maybe_handle_joining(Node, CState) ->
 
 %% @private
 update_ring(CNode, CState) ->
-    Next0 = CState#chstate.next,
+    Next0 = CState?CHSTATE.next,
 
-    ?ROUT("Members: ~p~n", [CState#chstate.members]),
+    ?ROUT("Members: ~p~n", [CState?CHSTATE.members]),
     ?ROUT("Updating ring :: next0 : ~p~n", [Next0]),
 
     %% Remove tuples from next for removed nodes
-    InvalidMembers = get_members(CState#chstate.members, [invalid]),
+    InvalidMembers = get_members(CState?CHSTATE.members, [invalid]),
     Next2 = lists:filter(fun(NInfo) ->
                                  {_, NextOwner, _} = next_owner(NInfo),
                                  not lists:member(NextOwner, InvalidMembers)
                          end, Next0),
-    CState2 = CState#chstate{next=Next2},
+    CState2 = CState?CHSTATE{next=Next2},
 
     %% Transfer ownership after completed handoff
     {RingChanged1, CState3} = transfer_ownership(CState2),
-    ?ROUT("Updating ring :: next1 : ~p~n", [CState3#chstate.next]),
+    ?ROUT("Updating ring :: next1 : ~p~n", [CState3?CHSTATE.next]),
 
     %% Ressign leaving/inactive indices
     {RingChanged2, CState4} = reassign_indices(CState3),
-    ?ROUT("Updating ring :: next2 : ~p~n", [CState4#chstate.next]),
+    ?ROUT("Updating ring :: next2 : ~p~n", [CState4?CHSTATE.next]),
 
     %% Rebalance the ring as necessary
     Next3 = rebalance_ring(CNode, CState4),
@@ -690,15 +890,15 @@ update_ring(CNode, CState) ->
             NewS = ordsets:from_list([{Idx,O,NO} || {Idx,O,NO,_,_} <- Next4]),
             Diff = ordsets:subtract(NewS, OldS),
             [log(next, NChange) || NChange <- Diff],
-            RVsn2 = vclock:increment(CNode, CState4#chstate.rvsn),
+            RVsn2 = vclock:increment(CNode, CState4?CHSTATE.rvsn),
             ?ROUT("Updating ring :: next3 : ~p~n", [Next4]),
-            {true, CState4#chstate{next=Next4, rvsn=RVsn2}};
+            {true, CState4?CHSTATE{next=Next4, rvsn=RVsn2}};
         false ->
             {false, CState}
     end.
 
 %% @private
-transfer_ownership(CState=#chstate{next=Next}) ->
+transfer_ownership(CState=?CHSTATE{next=Next}) ->
     %% Remove already completed and transfered changes
     Next2 = lists:filter(fun(NInfo={Idx, _, _, _, _}) ->
                                  {_, NewOwner, S} = next_owner(NInfo),
@@ -721,18 +921,18 @@ transfer_ownership(CState=#chstate{next=Next}) ->
     NextChanged = (Next2 /= Next),
     RingChanged = (all_owners(CState) /= all_owners(CState2)),
     Changed = (NextChanged or RingChanged),
-    {Changed, CState2#chstate{next=Next2}}.
+    {Changed, CState2?CHSTATE{next=Next2}}.
 
 %% @private
-reassign_indices(CState=#chstate{next=Next}) ->
-    Invalid = get_members(CState#chstate.members, [invalid]),
+reassign_indices(CState=?CHSTATE{next=Next}) ->
+    Invalid = get_members(CState?CHSTATE.members, [invalid]),
     CState2 =
         lists:foldl(fun(Node, CState0) ->
                             remove_node(CState0, Node, invalid)
                     end, CState, Invalid),
     CState3 = case Next of
                   [] ->
-                      Leaving = get_members(CState#chstate.members, [leaving]),
+                      Leaving = get_members(CState?CHSTATE.members, [leaving]),
                       lists:foldl(fun(Node, CState0) ->
                                           remove_node(CState0, Node, leaving)
                                   end, CState2, Leaving);
@@ -742,11 +942,11 @@ reassign_indices(CState=#chstate{next=Next}) ->
     Owners1 = all_owners(CState),
     Owners2 = all_owners(CState3),
     RingChanged = (Owners1 /= Owners2),
-    NextChanged = (Next /= CState3#chstate.next),
+    NextChanged = (Next /= CState3?CHSTATE.next),
     {RingChanged or NextChanged, CState3}.
 
 %% @private
-rebalance_ring(_CNode, CState=#chstate{next=[]}) ->
+rebalance_ring(_CNode, CState=?CHSTATE{next=[]}) ->
     Members = claiming_members(CState),
     CState2 = lists:foldl(fun(Node, Ring0) ->
                                   riak_core_gossip:claim_until_balanced(Ring0,
@@ -759,13 +959,13 @@ rebalance_ring(_CNode, CState=#chstate{next=[]}) ->
             || {{Idx, PrevOwner}, {Idx, NewOwner}} <- Owners3,
                PrevOwner /= NewOwner],
     Next;
-rebalance_ring(_CNode, _CState=#chstate{next=Next}) ->
+rebalance_ring(_CNode, _CState=?CHSTATE{next=Next}) ->
     Next.
 
 %% @private
 handle_down_nodes(CState, Next) ->
-    LeavingMembers = get_members(CState#chstate.members, [leaving, invalid]),
-    DownMembers = get_members(CState#chstate.members, [down]),
+    LeavingMembers = get_members(CState?CHSTATE.members, [leaving, invalid]),
+    DownMembers = get_members(CState?CHSTATE.members, [down]),
     Next2 = [begin
                  OwnerLeaving = lists:member(O, LeavingMembers),
                  NextDown = lists:member(NO, DownMembers),
@@ -785,7 +985,7 @@ handle_down_nodes(CState, Next) ->
     Next3.
 
 %% @private
-all_next_owners(#chstate{next=Next}) ->
+all_next_owners(?CHSTATE{next=Next}) ->
     [{Idx, NextOwner} || {Idx, _, NextOwner, _, _} <- Next].
 
 %% @private
@@ -826,9 +1026,9 @@ remove_node(CState, Node, Status, Indices) ->
 
     %% Unlike rebalance_ring, remove_node can be called when Next is non-empty,
     %% therefore we need to merge the values. Original Next has priority.
-    Next2 = lists:ukeysort(1, CState#chstate.next ++ Next),
+    Next2 = lists:ukeysort(1, CState?CHSTATE.next ++ Next),
     CState2 = change_owners(CState, Reassign),
-    CState2#chstate{next=Next2}.
+    CState2?CHSTATE{next=Next2}.
 
 %% ====================================================================
 %% Internal functions
@@ -851,67 +1051,87 @@ internal_reconcile(State, OtherState) ->
     State2 = update_seen(VNode, State),
     OtherState2 = update_seen(VNode, OtherState),
     Seen = reconcile_seen(State2, OtherState2),
-    State3 = State2#chstate{seen=Seen},
-    OtherState3 = OtherState2#chstate{seen=Seen},
+    State3 = State2?CHSTATE{seen=Seen},
+    OtherState3 = OtherState2?CHSTATE{seen=Seen},
     SeenChanged = not equal_seen(State, State3),
 
     %% Try to reconcile based on vector clock, chosing the most recent state.
-    VC1 = State3#chstate.vclock,
-    VC2 = OtherState3#chstate.vclock,
-    VC3 = vclock:merge([VC1, VC2]),
+    VC1 = State3?CHSTATE.vclock,
+    VC2 = OtherState3?CHSTATE.vclock,
+    %% vclock:merge has different results depending on order of input vclocks
+    %% when input vclocks have same counter but different timestamps. We need
+    %% merge to be deterministic here, hence the additional logic.
+    VMerge1 = vclock:merge([VC1, VC2]),
+    VMerge2 = vclock:merge([VC2, VC1]),
+    case {vclock:equal(VMerge1, VMerge2), VMerge1 < VMerge2} of
+        {true, _} ->
+            VC3 = VMerge1;
+        {_, true} ->
+            VC3 = VMerge1;
+        {_, false} ->
+            VC3 = VMerge2
+    end,
+
     Newer = vclock:descends(VC1, VC2),
     Older = vclock:descends(VC2, VC1),
     Equal = equal_cstate(State3, OtherState3),
     case {Equal, Newer, Older} of
         {_, true, false} ->
-            {SeenChanged, State3#chstate{vclock=VC3}};
+            {SeenChanged, State3?CHSTATE{vclock=VC3}};
         {_, false, true} ->
-            {true, OtherState3#chstate{nodename=VNode, vclock=VC3}};
+            {true, OtherState3?CHSTATE{nodename=VNode, vclock=VC3}};
         {true, _, _} ->
-            {SeenChanged, State3#chstate{vclock=VC3}};
+            {SeenChanged, State3?CHSTATE{vclock=VC3}};
         {_, true, true} ->
-            throw("Equal vclocks, but cstate unequal");
+            %% Exceptional condition that should only occur during
+            %% rolling upgrades and manual setting of the ring.
+            %% Merge as a divergent case.
+            State4 = reconcile_divergent(VNode, State3, OtherState3),
+            {true, State4?CHSTATE{nodename=VNode}};
         {_, false, false} ->
             %% Unable to reconcile based on vector clock, merge rings.
             State4 = reconcile_divergent(VNode, State3, OtherState3),
-            {true, State4#chstate{nodename=VNode}}
+            {true, State4?CHSTATE{nodename=VNode}}
     end.
 
 %% @private
 reconcile_divergent(VNode, StateA, StateB) ->
-    VClock = vclock:increment(VNode, vclock:merge([StateA#chstate.vclock,
-                                                   StateB#chstate.vclock])),
+    VClock = vclock:increment(VNode, vclock:merge([StateA?CHSTATE.vclock,
+                                                   StateB?CHSTATE.vclock])),
     Members = reconcile_members(StateA, StateB),
-    Meta = merge_meta(StateA#chstate.meta, StateB#chstate.meta),
+    Meta = merge_meta(StateA?CHSTATE.meta, StateB?CHSTATE.meta),
     NewState = reconcile_ring(StateA, StateB, get_members(Members)),
-    NewState#chstate{vclock=VClock, members=Members, meta=Meta}.
+    NewState?CHSTATE{vclock=VClock, members=Members, meta=Meta}.
 
 %% @private
 %% @doc Merge two members list using status vector clocks when possible,
 %%      and falling back to manual merge for divergent cases.
 reconcile_members(StateA, StateB) ->
     orddict:merge(
-      fun(_K, {Valid1, VC1}, {Valid2, VC2}) ->
+      fun(_K, {Valid1, VC1, Meta1}, {Valid2, VC2, Meta2}) ->
               New1 = vclock:descends(VC1, VC2),
               New2 = vclock:descends(VC2, VC1),
               MergeVC = vclock:merge([VC1, VC2]),
               case {New1, New2} of
                   {true, false} ->
-                      {Valid1, MergeVC};
+                      MergeMeta = lists:ukeysort(1, Meta1 ++ Meta2),
+                      {Valid1, MergeVC, MergeMeta};
                   {false, true} ->
-                      {Valid2, MergeVC};
+                      MergeMeta = lists:ukeysort(1, Meta2 ++ Meta1),
+                      {Valid2, MergeVC, MergeMeta};
                   {_, _} ->
-                      {merge_status(Valid1, Valid2), MergeVC}
+                      MergeMeta = lists:ukeysort(1, Meta1 ++ Meta2),
+                      {merge_status(Valid1, Valid2), MergeVC, MergeMeta}
               end
       end,
-      StateA#chstate.members,
-      StateB#chstate.members).
+      StateA?CHSTATE.members,
+      StateB?CHSTATE.members).
 
 %% @private
 reconcile_seen(StateA, StateB) ->
     orddict:merge(fun(_, VC1, VC2) ->
                           vclock:merge([VC1, VC2])
-                  end, StateA#chstate.seen, StateB#chstate.seen).
+                  end, StateA?CHSTATE.seen, StateB?CHSTATE.seen).
 
 %% @private
 merge_next_status(complete, _) ->
@@ -965,8 +1185,8 @@ substitute(Idx, TL1, TL2) ->
               end, TL1).
 
 %% @private
-reconcile_ring(StateA=#chstate{claimant=Claimant1, rvsn=VC1, next=Next1},
-               StateB=#chstate{claimant=Claimant2, rvsn=VC2, next=Next2},
+reconcile_ring(StateA=?CHSTATE{claimant=Claimant1, rvsn=VC1, next=Next1},
+               StateB=?CHSTATE{claimant=Claimant2, rvsn=VC2, next=Next2},
                Members) ->
     %% Try to reconcile based on the ring version (rvsn) vector clock.
     V1Newer = vclock:descends(VC1, VC2),
@@ -974,15 +1194,14 @@ reconcile_ring(StateA=#chstate{claimant=Claimant1, rvsn=VC1, next=Next1},
     EqualVC = (vclock:equal(VC1, VC2) and (Claimant1 =:= Claimant2)),
     case {EqualVC, V1Newer, V2Newer} of
         {true, _, _} ->
-            %%?assertEqual(StateA#chstate.chring, StateB#chstate.chring),
             Next = reconcile_next(Next1, Next2),
-            StateA#chstate{next=Next};
+            StateA?CHSTATE{next=Next};
         {_, true, false} ->
             Next = reconcile_divergent_next(Next1, Next2),
-            StateA#chstate{next=Next};
+            StateA?CHSTATE{next=Next};
         {_, false, true} ->
             Next = reconcile_divergent_next(Next2, Next1),
-            StateB#chstate{next=Next};
+            StateB?CHSTATE{next=Next};
         {_, _, _} ->
             %% Ring versions were divergent, so fall back to reconciling based
             %% on claimant. Under normal operation, divergent ring versions
@@ -995,10 +1214,10 @@ reconcile_ring(StateA=#chstate{claimant=Claimant1, rvsn=VC1, next=Next1},
             case {CValid1, CValid2} of
                 {true, false} ->
                     Next = reconcile_divergent_next(Next1, Next2),
-                    StateA#chstate{next=Next};
+                    StateA?CHSTATE{next=Next};
                 {false, true} ->
                     Next = reconcile_divergent_next(Next2, Next1),
-                    StateB#chstate{next=Next};
+                    StateB?CHSTATE{next=Next};
                 {false, false} ->
                     %% This can occur when removed/down nodes are still
                     %% up and gossip to each other. We need to pick a
@@ -1008,10 +1227,10 @@ reconcile_ring(StateA=#chstate{claimant=Claimant1, rvsn=VC1, next=Next1},
                     case Claimant1 < Claimant2 of
                         true ->
                             Next = reconcile_divergent_next(Next1, Next2),
-                            StateA#chstate{next=Next};
+                            StateA?CHSTATE{next=Next};
                         false ->
                             Next = reconcile_divergent_next(Next2, Next1),
-                            StateB#chstate{next=Next}
+                            StateB?CHSTATE{next=Next}
                     end;
                 {true, true} ->
                     %% This should never happen in normal practice.
@@ -1019,10 +1238,10 @@ reconcile_ring(StateA=#chstate{claimant=Claimant1, rvsn=VC1, next=Next1},
                     case Claimant1 < Claimant2 of
                         true ->
                             Next = reconcile_divergent_next(Next1, Next2),
-                            StateA#chstate{next=Next};
+                            StateA?CHSTATE{next=Next};
                         false ->
                             Next = reconcile_divergent_next(Next2, Next1),
-                            StateB#chstate{next=Next}
+                            StateB?CHSTATE{next=Next}
                     end
             end
     end.
@@ -1056,7 +1275,7 @@ merge_status(_, _) ->
     invalid.
 
 %% @private
-transfer_complete(CState=#chstate{next=Next, vclock=VClock}, Idx, Mod) ->
+transfer_complete(CState=?CHSTATE{next=Next, vclock=VClock}, Idx, Mod) ->
     {Idx, Owner, NextOwner, Transfers, Status} = lists:keyfind(Idx, 1, Next),
     Transfers2 = ordsets:add_element(Mod, Transfers),
     VNodeMods =
@@ -1072,7 +1291,7 @@ transfer_complete(CState=#chstate{next=Next, vclock=VClock}, Idx, Mod) ->
     Next2 = lists:keyreplace(Idx, 1, Next,
                              {Idx, Owner, NextOwner, Transfers2, Status2}),
     VClock2 = vclock:increment(Owner, VClock),
-    CState#chstate{next=Next2, vclock=VClock2}.
+    CState?CHSTATE{next=Next2, vclock=VClock2}.
 
 %% @private
 next_owner({_, Owner, NextOwner, _Transfers, Status}) ->
@@ -1084,49 +1303,49 @@ get_members(Members) ->
 
 %% @private
 get_members(Members, Types) ->
-    [Node || {Node, {V, _}} <- Members, lists:member(V, Types)].
+    [Node || {Node, {V, _, _}} <- Members, lists:member(V, Types)].
 
 %% @private
 set_member(Node, CState, Member, Status) ->
-    VClock = vclock:increment(Node, CState#chstate.vclock),
+    VClock = vclock:increment(Node, CState?CHSTATE.vclock),
     CState2 = set_member(Node, CState, Member, Status, same_vclock),
-    CState2#chstate{vclock=VClock}.
+    CState2?CHSTATE{vclock=VClock}.
 
 %% @private
 set_member(Node, CState, Member, Status, same_vclock) ->
     Members2 = orddict:update(Member,
-                              fun({_, VC}) ->
-                                      {Status, vclock:increment(Node, VC)}
+                              fun({_, VC, MD}) ->
+                                      {Status, vclock:increment(Node, VC), MD}
                               end,
                               {Status, vclock:increment(Node,
-                                                        vclock:fresh())},
-                              CState#chstate.members),
-    CState#chstate{members=Members2}.
+                                                        vclock:fresh()), []},
+                              CState?CHSTATE.members),
+    CState?CHSTATE{members=Members2}.
 
 %% @private
-update_seen(Node, CState=#chstate{vclock=VClock, seen=Seen}) ->
+update_seen(Node, CState=?CHSTATE{vclock=VClock, seen=Seen}) ->
     Seen2 = orddict:update(Node,
                            fun(SeenVC) ->
                                    vclock:merge([SeenVC, VClock])
                            end,
                            VClock, Seen),
-    CState#chstate{seen=Seen2}.
+    CState?CHSTATE{seen=Seen2}.
 
 %% @private
 equal_cstate(StateA, StateB) ->
     equal_cstate(StateA, StateB, false).
 
 equal_cstate(StateA, StateB, Verbose) ->
-    T1 = equal_members(StateA#chstate.members, StateB#chstate.members),
-    T2 = vclock:equal(StateA#chstate.rvsn, StateB#chstate.rvsn),
+    T1 = equal_members(StateA?CHSTATE.members, StateB?CHSTATE.members),
+    T2 = vclock:equal(StateA?CHSTATE.rvsn, StateB?CHSTATE.rvsn),
     T3 = equal_seen(StateA, StateB),
     T4 = equal_rings(StateA, StateB),
 
     %% Clear fields checked manually and test remaining through equality.
     %% Note: We do not consider cluster name in equality.
-    StateA2=StateA#chstate{nodename=ok, members=ok, vclock=ok, rvsn=ok,
+    StateA2=StateA?CHSTATE{nodename=ok, members=ok, vclock=ok, rvsn=ok,
                            seen=ok, chring=ok, meta=ok, clustername=ok},
-    StateB2=StateB#chstate{nodename=ok, members=ok, vclock=ok, rvsn=ok,
+    StateB2=StateB?CHSTATE{nodename=ok, members=ok, vclock=ok, rvsn=ok,
                            seen=ok, chring=ok, meta=ok, clustername=ok},
     T5 = (StateA2 =:= StateB2),
 
@@ -1137,7 +1356,7 @@ equal_cstate(StateA, StateB, Verbose) ->
             Failed =
                 lists:filter(fun({Test,_}) -> Test =:= false end,
                              [{T1, members},
-                              {T2, vclock},
+                              {T2, rvsn},
                               {T3, seen},
                               {T4, ring},
                               {T5, other}]),
@@ -1146,9 +1365,10 @@ equal_cstate(StateA, StateB, Verbose) ->
 
 %% @private
 equal_members(M1, M2) ->
-    L = orddict:merge(fun(_, {Status1, VC1}, {Status2, VC2}) ->
+    L = orddict:merge(fun(_, {Status1, VC1, Meta1}, {Status2, VC2, Meta2}) ->
                               (Status1 =:= Status2) andalso
-                                  vclock:equal(VC1, VC2)
+                                  vclock:equal(VC1, VC2) andalso
+                                  (Meta1 =:= Meta2)
                       end, M1, M2),
     {_, R} = lists:unzip(L),
     lists:all(fun(X) -> X =:= true end, R).
@@ -1164,8 +1384,8 @@ equal_seen(StateA, StateB) ->
     lists:all(fun(X) -> X =:= true end, R).
 
 %% @private
-filtered_seen(State=#chstate{seen=Seen}) ->
-    case get_members(State#chstate.members) of
+filtered_seen(State=?CHSTATE{seen=Seen}) ->
+    case get_members(State?CHSTATE.members) of
         [] ->
             Seen;
         Members ->
@@ -1192,11 +1412,11 @@ sequence_test() ->
     I1 = 365375409332725729550921208179070754913983135744,
     I2 = 730750818665451459101842416358141509827966271488,
     A = fresh(4,a),
-    B1 = A#chstate{nodename=b},
+    B1 = A?CHSTATE{nodename=b},
     B2 = transfer_node(I1, b, B1),
     ?assertEqual(B2, transfer_node(I1, b, B2)),
     {no_change, A1} = reconcile(B1,A),
-    C1 = A#chstate{nodename=c},
+    C1 = A?CHSTATE{nodename=c},
     C2 = transfer_node(I1, c, C1),
     {new_ring, A2} = reconcile(C2,A1),
     {new_ring, A3} = reconcile(B2,A2),
@@ -1204,8 +1424,8 @@ sequence_test() ->
     {new_ring, C4} = reconcile(A3,C3),
     {new_ring, A4} = reconcile(C4,A3),
     {new_ring, B3} = reconcile(A4,B2),
-    ?assertEqual(A4#chstate.chring, B3#chstate.chring),
-    ?assertEqual(B3#chstate.chring, C4#chstate.chring).
+    ?assertEqual(A4?CHSTATE.chring, B3?CHSTATE.chring),
+    ?assertEqual(B3?CHSTATE.chring, C4?CHSTATE.chring).
 
 param_fresh_test() ->
     application:set_env(riak_core,ring_creation_size,4),
@@ -1230,7 +1450,7 @@ reconcile_test() ->
                  equal_cstate(Ring1, Ring2, true)),
     RingB0 = fresh(2,node()),
     RingB1 = transfer_node(0,x,RingB0),
-    RingB2 = RingB1#chstate{nodename=b},
+    RingB2 = RingB1?CHSTATE{nodename=b},
     ?assertMatch({no_change,_},reconcile(Ring1,RingB2)),
     {no_change, RingB3} = reconcile(Ring1,RingB2),
     ?assert(equal_cstate(RingB2, RingB3)).
@@ -1239,18 +1459,18 @@ metadata_inequality_test() ->
     Ring0 = fresh(2,node()),
     Ring1 = update_meta(key,val,Ring0),
     ?assertNot(equal_rings(Ring0,Ring1)),
-    ?assertEqual(Ring1#chstate.meta,
-                 merge_meta(Ring0#chstate.meta,Ring1#chstate.meta)),
+    ?assertEqual(Ring1?CHSTATE.meta,
+                 merge_meta(Ring0?CHSTATE.meta,Ring1?CHSTATE.meta)),
     timer:sleep(1001), % ensure that lastmod is at least a second later
     Ring2 = update_meta(key,val2,Ring1),
     ?assertEqual(get_meta(key,Ring2),
-                 get_meta(key,#chstate{meta=
-                            merge_meta(Ring1#chstate.meta,
-                                       Ring2#chstate.meta)})),
+                 get_meta(key,?CHSTATE{meta=
+                            merge_meta(Ring1?CHSTATE.meta,
+                                       Ring2?CHSTATE.meta)})),
     ?assertEqual(get_meta(key,Ring2),
-                 get_meta(key,#chstate{meta=
-                            merge_meta(Ring2#chstate.meta,
-                                       Ring1#chstate.meta)})).
+                 get_meta(key,?CHSTATE{meta=
+                            merge_meta(Ring2?CHSTATE.meta,
+                                       Ring1?CHSTATE.meta)})).
 rename_test() ->
     Ring0 = fresh(2, node()),
     Ring = rename_node(Ring0, node(), 'new@new'),
@@ -1336,38 +1556,38 @@ ring_version_test() ->
     Ring2 = add_member(node(), Ring1, nodeA),
     Ring3 = add_member(node(), Ring2, nodeB),
     ?assertEqual(nodeA, claimant(Ring3)),
-    #chstate{rvsn=RVsn, vclock=VClock} = Ring3,
+    ?CHSTATE{rvsn=RVsn, vclock=VClock} = Ring3,
 
     RingA1 = transfer_node(0, nodeA, Ring3),
-    RingA2 = RingA1#chstate{vclock=vclock:increment(nodeA, VClock)},
+    RingA2 = RingA1?CHSTATE{vclock=vclock:increment(nodeA, VClock)},
     RingB1 = transfer_node(0, nodeB, Ring3),
-    RingB2 = RingB1#chstate{vclock=vclock:increment(nodeB, VClock)},
+    RingB2 = RingB1?CHSTATE{vclock=vclock:increment(nodeB, VClock)},
 
     %% RingA1 has most recent ring version
-    {_, RingT1} = reconcile(RingA2#chstate{rvsn=vclock:increment(nodeA, RVsn)},
+    {_, RingT1} = reconcile(RingA2?CHSTATE{rvsn=vclock:increment(nodeA, RVsn)},
                             RingB2),
     ?assertEqual(nodeA, index_owner(RingT1,0)),
 
     %% RingB1 has most recent ring version
     {_, RingT2} = reconcile(RingA2,
-                            RingB2#chstate{rvsn=vclock:increment(nodeB, RVsn)}),
+                            RingB2?CHSTATE{rvsn=vclock:increment(nodeB, RVsn)}),
     ?assertEqual(nodeB, index_owner(RingT2,0)),
 
     %% Divergent ring versions, merge based on claimant
-    {_, RingT3} = reconcile(RingA2#chstate{rvsn=vclock:increment(nodeA, RVsn)},
-                            RingB2#chstate{rvsn=vclock:increment(nodeB, RVsn)}),
+    {_, RingT3} = reconcile(RingA2?CHSTATE{rvsn=vclock:increment(nodeA, RVsn)},
+                            RingB2?CHSTATE{rvsn=vclock:increment(nodeB, RVsn)}),
     ?assertEqual(nodeA, index_owner(RingT3,0)),
 
     %% Divergent ring versions, one valid claimant. Merge on claimant.
-    RingA3 = RingA2#chstate{claimant=nodeA},
+    RingA3 = RingA2?CHSTATE{claimant=nodeA},
     RingA4 = remove_member(nodeA, RingA3, nodeB),
-    RingB3 = RingB2#chstate{claimant=nodeB},
+    RingB3 = RingB2?CHSTATE{claimant=nodeB},
     RingB4 = remove_member(nodeB, RingB3, nodeA),
-    {_, RingT4} = reconcile(RingA4#chstate{rvsn=vclock:increment(nodeA, RVsn)},
-                            RingB3#chstate{rvsn=vclock:increment(nodeB, RVsn)}),
+    {_, RingT4} = reconcile(RingA4?CHSTATE{rvsn=vclock:increment(nodeA, RVsn)},
+                            RingB3?CHSTATE{rvsn=vclock:increment(nodeB, RVsn)}),
     ?assertEqual(nodeA, index_owner(RingT4,0)),
-    {_, RingT5} = reconcile(RingA3#chstate{rvsn=vclock:increment(nodeA, RVsn)},
-                            RingB4#chstate{rvsn=vclock:increment(nodeB, RVsn)}),
+    {_, RingT5} = reconcile(RingA3?CHSTATE{rvsn=vclock:increment(nodeA, RVsn)},
+                            RingB4?CHSTATE{rvsn=vclock:increment(nodeB, RVsn)}),
     ?assertEqual(nodeB, index_owner(RingT5,0)).
 
 reconcile_next_test() ->
@@ -1391,5 +1611,5 @@ reconcile_next_test() ->
              {1, nodeA, nodeB, [], awaiting},
              {2, nodeA, nodeB, [riak_kv_vnode, riak_pipe_vnode], complete}],
     ?assertEqual(Next6, reconcile_divergent_next(Next4, Next5)).
-    
+
 -endif.

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -863,7 +863,8 @@ update_ring(CNode, CState) ->
     %% Remove tuples from next for removed nodes
     InvalidMembers = get_members(CState?CHSTATE.members, [invalid]),
     Next2 = lists:filter(fun(NInfo) ->
-                                 {_, NextOwner, _} = next_owner(NInfo),
+                                 {Owner, NextOwner, _} = next_owner(NInfo),
+                                 not lists:member(Owner, InvalidMembers) and
                                  not lists:member(NextOwner, InvalidMembers)
                          end, Next0),
     CState2 = CState?CHSTATE{next=Next2},

--- a/src/riak_core_ring_handler.erl
+++ b/src/riak_core_ring_handler.erl
@@ -63,11 +63,14 @@ ensure_vnodes_started(Ring) ->
         AppMods ->
             case ensure_vnodes_started(AppMods, Ring, []) of
                 [] ->
+                    Legacy = riak_core_gossip:legacy_gossip(),
                     Ready = riak_core_ring:ring_ready(Ring),
                     FutureIndices = riak_core_ring:future_indices(Ring, node()),
                     Status = riak_core_ring:member_status(Ring, node()),
-                    case {Ready, FutureIndices, Status} of
-                        {true, [], leaving} ->
+                    case {Legacy, Ready, FutureIndices, Status} of
+                        {true, _, _, _} ->
+                            riak_core_ring_manager:refresh_my_ring();
+                        {_, true, [], leaving} ->
                             riak_core_ring_manager:ring_trans(
                               fun(Ring2, _) -> 
                                       Ring3 = riak_core_ring:exit_member(node(), Ring2, node()),
@@ -80,12 +83,12 @@ ensure_vnodes_started(Ring) ->
                                 _ ->
                                     ok
                             end;
-                        {_, _, invalid} ->
+                        {_, _, _, invalid} ->
                             riak_core_ring_manager:refresh_my_ring();
-                        {_, _, exiting} ->
+                        {_, _, _, exiting} ->
                             %% Deliberately do nothing.
                             ok;
-                        {_, _, _} ->
+                        {_, _, _, _} ->
                             ok
                     end;
                 _ -> ok

--- a/src/riak_core_status.erl
+++ b/src/riak_core_status.erl
@@ -121,7 +121,8 @@ ring_status() ->
 get_rings() ->
     {RawRings, Down} = riak_core_util:rpc_every_member(
                          riak_core_ring_manager, get_my_ring, [], 30000),
-    Rings = orddict:from_list([{riak_core_ring:owner_node(R), R} || {ok, R} <- RawRings]),
+    RawRings2 = [riak_core_ring:upgrade(R) || {ok, R} <- RawRings],
+    Rings = orddict:from_list([{riak_core_ring:owner_node(R), R} || R <- RawRings2]),
     {lists:sort(Down), Rings}.
 
 %% Produce a hash of the 'chash' portion of the ring

--- a/test/join_eqc.erl
+++ b/test/join_eqc.erl
@@ -1525,7 +1525,8 @@ update_ring(State, _RRing, CNode, CState) ->
     %% Remove tuples from next for removed nodes
     InvalidMembers = get_members(CState?CHSTATE.members, [invalid]),
     Next2 = lists:filter(fun(NInfo) ->
-                                 {_, NextOwner, _} = next_owner(State, NInfo),
+                                 {Owner, NextOwner, _} = next_owner(State, NInfo),
+                                 not lists:member(Owner, InvalidMembers) and
                                  not lists:member(NextOwner, InvalidMembers)
                          end, Next0),
     CState2 = CState?CHSTATE{next=Next2},

--- a/test/join_eqc.erl
+++ b/test/join_eqc.erl
@@ -20,7 +20,8 @@
 -define(RING, 8). %% Must be a power of two.
 -define(N, 3).
 
--record(chstate, {
+-define(CHSTATE, #chstate_v2).
+-record(chstate_v2, {
     nodename :: node(),          % the Node responsible for this chstate
     vclock   :: vclock:vclock(), % for this chstate object, entries are
                                  % {Node, Ctr}
@@ -30,7 +31,7 @@
 
     clustername :: {node(), term()}, 
     next     :: [{integer(), node(), node(), [module()], awaiting | complete}],
-    members  :: [{node(), {member_status(), vclock:vclock()}}],
+    members  :: [{node(), {member_status(), vclock:vclock(), []}}],
     claimant :: node(),
     seen     :: [{node(), vclock:vclock()}],
     rvsn     :: vclock:vclock()
@@ -40,7 +41,7 @@
 
 %% Node state
 -record(nstate, {
-          chstate = #chstate{} :: #chstate{},
+          chstate = ?CHSTATE{} :: ?CHSTATE{},
           partitions = [] :: orddict:orddict(atom(), ordsets:ordsets(integer())),
           has_data = [] :: orddict:orddict(atom(), ordsets:ordsets(integer())),
           joined_to :: integer()
@@ -212,36 +213,36 @@ make_default_ring(Size, Nodes) ->
 vnode_modules(_State, _Node) ->
     [riak_kv, riak_pipe].
 
-all_owners(#chstate{chring=Ring}) ->
+all_owners(?CHSTATE{chring=Ring}) ->
     chash:nodes(Ring).
 
-all_members(#chstate{members=Members}) ->
+all_members(?CHSTATE{members=Members}) ->
     get_members(Members).
 
-claiming_members(#chstate{members=Members}) ->
+claiming_members(?CHSTATE{members=Members}) ->
     get_members(Members, [joining, valid, down]).
 
-gossip_members(#chstate{members=Members}) ->
+gossip_members(?CHSTATE{members=Members}) ->
     get_members(Members, [joining, valid, leaving, exiting]).
 
 indices(CState, Node) ->
     AllOwners = all_owners(CState),
     [Idx || {Idx, Owner} <- AllOwners, Owner =:= Node].
 
-owner(#chstate{chring=Ring}, Idx) ->
+owner(?CHSTATE{chring=Ring}, Idx) ->
     chash:lookup(Idx, Ring).
 
 owner_node(CState) ->
-    CState#chstate.nodename.
+    CState?CHSTATE.nodename.
 
 init_node_state(State, Node) ->
     Ring = chash:fresh(State#state.ring_size, Node),
-    Indices = indices(#chstate{chring=Ring}, Node),
+    Indices = indices(?CHSTATE{chring=Ring}, Node),
     RVsn=vclock:increment(Node, vclock:fresh()),
     VClock=vclock:increment(Node, vclock:fresh()),
-    CState = #chstate{nodename=Node,
+    CState = ?CHSTATE{nodename=Node,
                       clustername={Node, erlang:now()},
-                      members=[{Node, {valid, VClock}}],
+                      members=[{Node, {valid, VClock, []}}],
                       chring=Ring,
                       next=[],
                       claimant=Node,
@@ -255,7 +256,7 @@ init_node_state(State, Node) ->
 init_node_state(State, Node, CState) ->
     Indices = indices(CState, Node),
     VNodes = start_vnodes(State, Node, Indices),
-    #nstate{chstate=CState#chstate{nodename=Node},
+    #nstate{chstate=CState?CHSTATE{nodename=Node},
             partitions=VNodes,
             has_data=VNodes}.
 
@@ -446,12 +447,12 @@ maybe_inconsistent(State, Node) ->
     case {JoinedTo, JTStatus} of
         {undefined, _} ->
             false;
-        {_, {invalid, _}} ->
-            ClaimantCS = get_cstate(State, CState#chstate.claimant),
-            not lists:member(Node, get_members(ClaimantCS#chstate.members));
+        {_, {invalid, _, _}} ->
+            ClaimantCS = get_cstate(State, CState?CHSTATE.claimant),
+            not lists:member(Node, get_members(ClaimantCS?CHSTATE.members));
         _ ->
             JoinCS = get_cstate(State, JoinedTo),
-            not lists:member(Node, get_members(JoinCS#chstate.members))
+            not lists:member(Node, get_members(JoinCS?CHSTATE.members))
     end.
 
 %% If the model breaks during test case generation, Quickcheck is unable
@@ -571,7 +572,7 @@ postcondition(State, Cmd, _) ->
 
 check_rvsn(State) ->
     dict:map(fun(_, NState) ->
-                     RVsn = NState#nstate.chstate#chstate.rvsn,
+                     RVsn = NState#nstate.chstate?CHSTATE.rvsn,
                      (RVsn /= undefined) orelse throw(rvsn),
                      NState
              end,
@@ -614,7 +615,7 @@ check_members(State) ->
 
 check_sorted_members(State) ->
     L1 = [begin
-              M = NS#nstate.chstate#chstate.members,
+              M = NS#nstate.chstate?CHSTATE.members,
               (M /= []) andalso
                   (M == lists:ukeysort(1, M))
           end || {_, NS} <- dict:to_list(State#state.nstates)],
@@ -670,12 +671,12 @@ s_initial_cluster(State, Members, Others, RandomRing) ->
                        chash:fresh(State#state.ring_size, undefined),
                        make_default_ring(State#state.ring_size, Members2)),
     Claimant = hd(Members2),
-    Members3 = [{M, {valid, vclock:increment(M, vclock:fresh())}}
+    Members3 = [{M, {valid, vclock:increment(M, vclock:fresh()), []}}
                 || M <- Members2],
     RVsn=vclock:increment(Claimant, vclock:fresh()),
     VClock = vclock:increment(Claimant, vclock:fresh()),
     Seen = [{M, VClock} || M <- Members2],
-    CState = #chstate{clustername={Claimant, erlang:now()},
+    CState = ?CHSTATE{clustername={Claimant, erlang:now()},
                       members=Members3,
                       chring=Ring,
                       next=[],
@@ -700,8 +701,8 @@ s_random_gossip(State, Node, NState, OtherNode, OtherCS) ->
 s_gossip(State, {Node, NState}, OtherNode, OtherCS) ->
     CState = NState#nstate.chstate,
     Members = reconcile_members(CState, OtherCS),
-    WrongCluster = (CState#chstate.clustername /= OtherCS#chstate.clustername),
-    {PreStatus, _} = orddict:fetch(OtherNode, Members),
+    WrongCluster = (CState?CHSTATE.clustername /= OtherCS?CHSTATE.clustername),
+    {PreStatus, _, _} = orddict:fetch(OtherNode, Members),
     IgnoreGossip = (WrongCluster or
                     (PreStatus =:= invalid) or
                     (PreStatus =:= down)),
@@ -782,9 +783,9 @@ s_comm_join(State, Node1, Node2) ->
 
 s_join(State, Node, NState, PNode) ->
     JoinCS = get_cstate(State, PNode),
-    case orddict:find(Node, JoinCS#chstate.members) of
+    case orddict:find(Node, JoinCS?CHSTATE.members) of
         %% Don't allow a node to rejoin while it's still exiting.
-        {ok, {exiting, _}} ->
+        {ok, {exiting, _, _}} ->
             State;
         _ ->
             Primary2 = lists:usort([Node | State#state.primary]),
@@ -796,8 +797,8 @@ s_join(State, Node, NState, PNode) ->
                     Rejoin2 = State#state.rejoin
             end,
             JoinCS2 = add_member(Node, JoinCS, Node),
-            %% ?debugFmt("J: ~p~n", [JoinCS2#chstate.members]),
-            JoinCS3 = JoinCS2#chstate{nodename=Node},
+            %% ?debugFmt("J: ~p~n", [JoinCS2?CHSTATE.members]),
+            JoinCS3 = JoinCS2?CHSTATE{nodename=Node},
             State2 = update_cstate(State, PNode, JoinCS2),
             Partitions = start_vnodes(State, Node, []),
             State3 = update_nstate(State2, Node,
@@ -824,8 +825,8 @@ s_leave(State, Node) ->
 
 s_down(State, Node, PNode) ->
     DownCS = get_cstate(State, PNode),
-    case orddict:find(Node, DownCS#chstate.members) of
-        {ok, {valid, _}} ->
+    case orddict:find(Node, DownCS?CHSTATE.members) of
+        {ok, {valid, _, _}} ->
             Down2 = [Node|State#state.down],
             DownCS2 = set_member(PNode, DownCS, Node, down),
             State2 = update_cstate(State, PNode, DownCS2),
@@ -844,7 +845,7 @@ all_pending(State, Node) ->
     Pending = dict:fold(fun(_, NState, Pending0) ->
                                 CState = NState#nstate.chstate,
                                 PendingIdx =
-                                    [Idx || {Idx, _, NextOwner, _, _} <- CState#chstate.next,
+                                    [Idx || {Idx, _, NextOwner, _, _} <- CState?CHSTATE.next,
                                             NextOwner =:= Node],
                                 Pending0 ++ PendingIdx
                         end, [], State#state.nstates),
@@ -853,10 +854,10 @@ all_pending(State, Node) ->
 s_remove(State, Node, PNode, Shutdown) ->
     PNodeCS = get_cstate(State, PNode),
     NodeCS = get_cstate(State, Node),
-    case orddict:find(Node, PNodeCS#chstate.members) of
-        {ok, {invalid, _}} ->
+    case orddict:find(Node, PNodeCS?CHSTATE.members) of
+        {ok, {invalid, _, _}} ->
             State;
-        {ok, {_, _}} ->
+        {ok, {_, _, _}} ->
             Removed2 = [Node|State#state.removed],
             PNodeCS2 = remove_member(PNode, PNodeCS, Node),
             State2 = update_cstate(State, PNode, PNodeCS2),
@@ -885,19 +886,19 @@ remove_member(PNode, CState, Node) ->
     set_member(PNode, CState, Node, invalid).
 
 set_member(Node, CState, Member, Status) ->
-    VClock = vclock:increment(Node, CState#chstate.vclock),
+    VClock = vclock:increment(Node, CState?CHSTATE.vclock),
     CState2 = set_member(Node, CState, Member, Status, same_vclock),
-    CState2#chstate{vclock=VClock}.
+    CState2?CHSTATE{vclock=VClock}.
 
 set_member(Node, CState, Member, Status, same_vclock) ->
     Members2 = orddict:update(Member,
-                              fun({_, VC}) ->
-                                      {Status, vclock:increment(Node, VC)}
+                              fun({_, VC, _}) ->
+                                      {Status, vclock:increment(Node, VC), []}
                               end,
                               {Status, vclock:increment(Node,
-                                                        vclock:fresh())},
-                              CState#chstate.members),
-    CState#chstate{members=Members2}.
+                                                        vclock:fresh()), []},
+                              CState?CHSTATE.members),
+    CState?CHSTATE{members=Members2}.
 
 handle_cast(State=#state{random_ring=RRing, others=Others, nstates=NStates}, _,
             Node, shutdown) ->
@@ -921,7 +922,7 @@ handle_cast(State=#state{random_ring=RRing, others=Others, nstates=NStates}, _,
 
 handle_cast(State, _, Node, {rejoin, OtherCS}) ->
     CState = get_cstate(State, Node),
-    SameCluster = (CState#chstate.clustername =:= OtherCS#chstate.clustername),
+    SameCluster = (CState?CHSTATE.clustername =:= OtherCS?CHSTATE.clustername),
     case SameCluster of
         true ->
             PNode = owner_node(OtherCS),
@@ -1059,7 +1060,7 @@ s_finish_handoff(State, AH={Mod, Idx, Prev, New}) ->
 maybe_shutdown(State, Node) ->
     CState = get_cstate(State, Node),
     Ready = ring_ready(CState),
-    Next = CState#chstate.next,
+    Next = CState?CHSTATE.next,
     NoIndices = (indices(CState, Node) =:= []),
     NoPartitions = (count_vnodes(State, Node) =:= 0),
     NoPendingIndices = ([] =:= ([Idx || {Idx, _, NextOwner, _, _} <- Next,
@@ -1080,12 +1081,12 @@ reconcile(State, CS01, CS02) ->
     CS03 = update_seen(VNode, CS01),
     CS04 = update_seen(VNode, CS02),
     Seen = reconcile_seen(CS03, CS04),
-    CS1 = CS03#chstate{seen=Seen},
-    CS2 = CS04#chstate{seen=Seen},
+    CS1 = CS03?CHSTATE{seen=Seen},
+    CS2 = CS04?CHSTATE{seen=Seen},
     SeenChanged = not equal_seen(CS01, CS1),
 
-    VC1 = CS1#chstate.vclock,
-    VC2 = CS2#chstate.vclock,
+    VC1 = CS1?CHSTATE.vclock,
+    VC2 = CS2?CHSTATE.vclock,
     VC3 = vclock:merge([VC1, VC2]),
     %%io:format("V1: ~p~nV2: ~p~n", [VC1, VC2]),
     Newer = vclock:descends(VC1, VC2),
@@ -1094,50 +1095,50 @@ reconcile(State, CS01, CS02) ->
     case {Equal, Newer, Older} of
         {_, true, false} ->
             %%io:format("CS1: ~p~n", [CS1]),
-            {SeenChanged, CS1#chstate{vclock=VC3}};
+            {SeenChanged, CS1?CHSTATE{vclock=VC3}};
         {_, false, true} ->
             %%io:format("CS2: ~p~n", [CS2]),
-            {true, CS2#chstate{nodename=VNode, vclock=VC3}};
+            {true, CS2?CHSTATE{nodename=VNode, vclock=VC3}};
         {true, _, _} ->
-            {SeenChanged, CS1#chstate{vclock=VC3}};
+            {SeenChanged, CS1?CHSTATE{vclock=VC3}};
         {_, true, true} ->
             io:format("C1: ~p~nC2: ~p~n", [CS1, CS2]),
             throw("Equal vclocks, but cstate unequal");
         {_, false, false} ->
             CS3 = reconcile_divergent(State, VNode, CS1, CS2),
-            {true, CS3#chstate{nodename=VNode}}
+            {true, CS3?CHSTATE{nodename=VNode}}
     end.
 
 reconcile_divergent(State, VNode, CS1, CS2) ->
-    VClock = vclock:increment(VNode, vclock:merge([CS1#chstate.vclock,
-                                                   CS2#chstate.vclock])),
+    VClock = vclock:increment(VNode, vclock:merge([CS1?CHSTATE.vclock,
+                                                   CS2?CHSTATE.vclock])),
     Members = reconcile_members(CS1, CS2),
     CS3 = reconcile_ring(State, CS1, CS2, get_members(Members)),
-    CS3#chstate{vclock=VClock, members=Members}.
+    CS3?CHSTATE{vclock=VClock, members=Members}.
 
 reconcile_members(CS1, CS2) ->
-    %%?debugFmt("M1: ~p~nM2: ~p~n", [CS1#chstate.members, CS2#chstate.members]),
+    %%?debugFmt("M1: ~p~nM2: ~p~n", [CS1?CHSTATE.members, CS2?CHSTATE.members]),
     orddict:merge(
-      fun(_K, {Valid1, VC1}, {Valid2, VC2}) ->
+      fun(_K, {Valid1, VC1, _}, {Valid2, VC2, _}) ->
               New1 = vclock:descends(VC1, VC2),
               New2 = vclock:descends(VC2, VC1),
               MergeVC = vclock:merge([VC1, VC2]),
               case {New1, New2} of
                   {true, false} ->
-                      {Valid1, MergeVC};
+                      {Valid1, MergeVC, []};
                   {false, true} ->
-                      {Valid2, MergeVC};
+                      {Valid2, MergeVC, []};
                   {_, _} ->
-                      {merge_status(Valid1, Valid2), MergeVC}
+                      {merge_status(Valid1, Valid2), MergeVC, []}
               end
       end,
-      CS1#chstate.members,
-      CS2#chstate.members).
+      CS1?CHSTATE.members,
+      CS2?CHSTATE.members).
 
 reconcile_seen(CS1, CS2) ->
     orddict:merge(fun(_, VC1, VC2) ->
                           vclock:merge([VC1, VC2])
-                  end, CS1#chstate.seen, CS2#chstate.seen).
+                  end, CS1?CHSTATE.seen, CS2?CHSTATE.seen).
 
 merge_next_status(complete, _) ->
     complete;
@@ -1181,8 +1182,8 @@ substitute(Idx, TL1, TL2) ->
               end, TL1).
 
 reconcile_ring(_State,
-               CS1=#chstate{claimant=Claimant1, rvsn=VC1, next=Next1},
-               CS2=#chstate{claimant=Claimant2, rvsn=VC2, next=Next2},
+               CS1=?CHSTATE{claimant=Claimant1, rvsn=VC1, next=Next1},
+               CS2=?CHSTATE{claimant=Claimant2, rvsn=VC2, next=Next2},
                Members) ->
     V1Newer = vclock:descends(VC1, VC2),
     V2Newer = vclock:descends(VC2, VC1),
@@ -1190,25 +1191,25 @@ reconcile_ring(_State,
     %%io:format("Next1: ~p~nNext2: ~p~n", [Next1, Next2]),
     case {EqualVC, V1Newer, V2Newer} of
         {true, _, _} ->
-            ?assertEqual(CS1#chstate.chring, CS2#chstate.chring),
+            ?assertEqual(CS1?CHSTATE.chring, CS2?CHSTATE.chring),
             Next = reconcile_next(Next1, Next2),
-            CS1#chstate{next=Next};
+            CS1?CHSTATE{next=Next};
         {_, true, false} ->
             Next = reconcile_divergent_next(Next1, Next2),
-            CS1#chstate{next=Next};
+            CS1?CHSTATE{next=Next};
         {_, false, true} ->
             Next = reconcile_divergent_next(Next2, Next1),
-            CS2#chstate{next=Next};
+            CS2?CHSTATE{next=Next};
         {_, _, _} ->
             CValid1 = lists:member(Claimant1, Members),
             CValid2 = lists:member(Claimant2, Members),
             case {CValid1, CValid2} of
                 {true, false} ->
                     Next = reconcile_divergent_next(Next1, Next2),
-                    CS1#chstate{next=Next};
+                    CS1?CHSTATE{next=Next};
                 {false, true} ->
                     Next = reconcile_divergent_next(Next2, Next1),
-                    CS2#chstate{next=Next};
+                    CS2?CHSTATE{next=Next};
                 {false, false} ->
                     %% This can occur when removed/down nodes are still
                     %% up and gossip to each other. We need to pick a
@@ -1218,10 +1219,10 @@ reconcile_ring(_State,
                     case Claimant1 < Claimant2 of
                         true ->
                             Next = reconcile_divergent_next(Next1, Next2),
-                            CS1#chstate{next=Next};
+                            CS1?CHSTATE{next=Next};
                         false ->
                             Next = reconcile_divergent_next(Next2, Next1),
-                            CS2#chstate{next=Next}
+                            CS2?CHSTATE{next=Next}
                     end;
                 {true, true} ->
                     %% This should never happen in normal practice.
@@ -1229,10 +1230,10 @@ reconcile_ring(_State,
                     case Claimant1 < Claimant2 of
                         true ->
                             Next = reconcile_divergent_next(Next1, Next2),
-                            CS1#chstate{next=Next};
+                            CS1?CHSTATE{next=Next};
                         false ->
                             Next = reconcile_divergent_next(Next2, Next1),
-                            CS2#chstate{next=Next}
+                            CS2?CHSTATE{next=Next}
                     end
             end
     end.
@@ -1313,11 +1314,11 @@ update_nstate(State, Node, NState) ->
 get_cstate(State, Node) ->
     (get_nstate(State, Node))#nstate.chstate.
 
-member_status(#chstate{members=Members}, Node) ->
+member_status(?CHSTATE{members=Members}, Node) ->
     member_status(Members, Node);
 member_status(Members, Node) ->
     case orddict:find(Node, Members) of
-        {ok, {Status, _}} ->
+        {ok, {Status, _, _}} ->
             Status;
         _ ->
             invalid
@@ -1327,20 +1328,20 @@ get_members(Members) ->
     get_members(Members, [joining, valid, leaving, exiting, down]).
 
 get_members(Members, Types) ->
-    [Node || {Node, {V, _}} <- Members, lists:member(V, Types)].
+    [Node || {Node, {V, _, _}} <- Members, lists:member(V, Types)].
 
-update_seen(Node, CState=#chstate{vclock=VClock, seen=Seen}) ->
+update_seen(Node, CState=?CHSTATE{vclock=VClock, seen=Seen}) ->
     Seen2 = orddict:update(Node,
                            fun(SeenVC) ->
                                    vclock:merge([SeenVC, VClock])
                            end,
                            VClock, Seen),
-    CState#chstate{seen=Seen2}.
+    CState?CHSTATE{seen=Seen2}.
 
 update_seen(State, Node, CState) ->
     CState2 = update_seen(Node, CState),
     State2 = save_cstate(State, Node, CState2),
-    Changed = (CState2#chstate.seen /= CState#chstate.seen),
+    Changed = (CState2?CHSTATE.seen /= CState?CHSTATE.seen),
     {Changed, State2, CState2}.
 
 update_cstate(NState=#nstate{}, Node, CState) ->
@@ -1369,11 +1370,11 @@ save_cstate(State, Node, CState) ->
 ring_ready(CState0) ->
     Owner = owner_node(CState0),
     CState = update_seen(Owner, CState0),
-    Seen = CState#chstate.seen,
+    Seen = CState?CHSTATE.seen,
     %% TODO: Should we add joining here?
-    %%Members = get_members(CState#chstate.members, [joining, valid, leaving, exiting]),
-    Members = get_members(CState#chstate.members, [valid, leaving]),
-    VClock = CState#chstate.vclock,
+    %%Members = get_members(CState?CHSTATE.members, [joining, valid, leaving, exiting]),
+    Members = get_members(CState?CHSTATE.members, [valid, leaving]),
+    VClock = CState?CHSTATE.vclock,
     R = [begin
              case orddict:find(Node, Seen) of
                  error ->
@@ -1434,9 +1435,9 @@ ring_changed(State, _RRing, {Node, _NState}, CState0) ->
     end.
 
 maybe_update_claimant(State, Node, CState) ->
-    Members = get_members(CState#chstate.members, [valid, leaving]),
-    Claimant = CState#chstate.claimant,
-    RVsn = CState#chstate.rvsn,
+    Members = get_members(CState?CHSTATE.members, [valid, leaving]),
+    Claimant = CState?CHSTATE.claimant,
+    RVsn = CState?CHSTATE.rvsn,
     NextClaimant = hd(Members ++ [undefined]),
     ClaimantMissing = not lists:member(Claimant, Members),
 
@@ -1445,14 +1446,14 @@ maybe_update_claimant(State, Node, CState) ->
             %% Become claimant
             ?assert(Node /= Claimant),
             RVsn2 = vclock:increment(Claimant, RVsn),
-            CState2 = CState#chstate{claimant=Node, rvsn=RVsn2},
+            CState2 = CState?CHSTATE{claimant=Node, rvsn=RVsn2},
             {true, State, CState2};
         _ ->
             {false, State, CState}
     end.
 
 maybe_update_ring(State, Node, CState) ->
-    Claimant = CState#chstate.claimant,
+    Claimant = CState?CHSTATE.claimant,
     case Claimant of
         Node ->
             case claiming_members(CState) of
@@ -1468,10 +1469,10 @@ maybe_update_ring(State, Node, CState) ->
     end.
 
 maybe_remove_exiting(State, Node, CState) ->
-    Claimant = CState#chstate.claimant,
+    Claimant = CState?CHSTATE.claimant,
     case Claimant of
         Node ->
-            Exiting = get_members(CState#chstate.members, [exiting]),
+            Exiting = get_members(CState?CHSTATE.members, [exiting]),
             %%io:format("Claimant ~p removing exiting ~p~n", [Node, Exiting]),
             Changed = (Exiting /= []),
             {State2, CState2} =
@@ -1486,10 +1487,10 @@ maybe_remove_exiting(State, Node, CState) ->
     end.
 
 maybe_handle_joining(State, Node, CState) ->
-    Claimant = CState#chstate.claimant,
+    Claimant = CState?CHSTATE.claimant,
     case Claimant of
         Node ->
-            Joining = get_members(CState#chstate.members, [joining]),
+            Joining = get_members(CState?CHSTATE.members, [joining]),
             %% ?debugFmt("Claimant ~p joining ~p~n", [Node, Joining]),
             Changed = (Joining /= []),
             {State2, CState2} =
@@ -1516,26 +1517,26 @@ get_counts(Nodes, Ring) ->
     dict:to_list(Counts).
 
 update_ring(State, _RRing, CNode, CState) ->
-    Next0 = CState#chstate.next,
+    Next0 = CState?CHSTATE.next,
 
-    ?ROUT("Members: ~p~n", [CState#chstate.members]),
+    ?ROUT("Members: ~p~n", [CState?CHSTATE.members]),
     ?ROUT("Updating ring :: next0 : ~p~n", [Next0]),
 
     %% Remove tuples from next for removed nodes
-    InvalidMembers = get_members(CState#chstate.members, [invalid]),
+    InvalidMembers = get_members(CState?CHSTATE.members, [invalid]),
     Next2 = lists:filter(fun(NInfo) ->
                                  {_, NextOwner, _} = next_owner(State, NInfo),
                                  not lists:member(NextOwner, InvalidMembers)
                          end, Next0),
-    CState2 = CState#chstate{next=Next2},
+    CState2 = CState?CHSTATE{next=Next2},
 
     %% Transfer ownership after completed handoff
     {RingChanged1, CState3} = transfer_ownership(State, CState2),
-    ?ROUT("Updating ring :: next1 : ~p~n", [CState3#chstate.next]),
+    ?ROUT("Updating ring :: next1 : ~p~n", [CState3?CHSTATE.next]),
 
     %% Ressign leaving/inactive indices
     {RingChanged2, State2, CState4} = reassign_indices(State, CState3),
-    ?ROUT("Updating ring :: next2 : ~p~n", [CState4#chstate.next]),
+    ?ROUT("Updating ring :: next2 : ~p~n", [CState4?CHSTATE.next]),
 
     %% Rebalance the ring as necessary
     Next3 = rebalance_ring(CNode, CState4),
@@ -1547,14 +1548,14 @@ update_ring(State, _RRing, CNode, CState) ->
     Changed = (NextChanged or RingChanged1 or RingChanged2),
     case Changed of
         true ->
-            RVsn2 = vclock:increment(CNode, CState4#chstate.rvsn),
+            RVsn2 = vclock:increment(CNode, CState4?CHSTATE.rvsn),
             ?ROUT("Updating ring :: next3 : ~p~n", [Next4]),
-            {true, State2, CState4#chstate{next=Next4, rvsn=RVsn2}};
+            {true, State2, CState4?CHSTATE{next=Next4, rvsn=RVsn2}};
         false ->
             {false, State, CState}
     end.
 
-transfer_ownership(State, CState=#chstate{next=Next}) ->
+transfer_ownership(State, CState=?CHSTATE{next=Next}) ->
     %% Remove already completed and transfered changes
     Next2 = lists:filter(fun(NInfo={Idx, _, _, _, _}) ->
                                  {_, NewOwner, S} = next_owner(State, NInfo),
@@ -1574,10 +1575,10 @@ transfer_ownership(State, CState=#chstate{next=Next}) ->
     NextChanged = (Next2 /= Next),
     RingChanged = (all_owners(CState) /= all_owners(CState2)),
     Changed = (NextChanged or RingChanged),
-    {Changed, CState2#chstate{next=Next2}}.
+    {Changed, CState2?CHSTATE{next=Next2}}.
 
-reassign_indices(State, CState=#chstate{next=Next}) ->
-    Invalid = get_members(CState#chstate.members, [invalid]),
+reassign_indices(State, CState=?CHSTATE{next=Next}) ->
+    Invalid = get_members(CState?CHSTATE.members, [invalid]),
     {State2, CState2} =
         lists:foldl(fun(Node, {State0, Ring0}) ->
                             Allowed2 = State0#state.allowed ++ indices(Ring0, Node),
@@ -1586,7 +1587,7 @@ reassign_indices(State, CState=#chstate{next=Next}) ->
                     end, {State, CState}, Invalid),
     CState3 = case Next of
                   [] ->
-                      Leaving = get_members(CState#chstate.members, [leaving]),
+                      Leaving = get_members(CState?CHSTATE.members, [leaving]),
                       lists:foldl(fun(Node, Ring0) ->
                                           %%remove_from_cluster(Ring0, Node)
                                           remove_node(Ring0, Node, leaving)
@@ -1597,10 +1598,10 @@ reassign_indices(State, CState=#chstate{next=Next}) ->
     Owners1 = all_owners(CState),
     Owners2 = all_owners(CState3),
     RingChanged = (Owners1 /= Owners2),
-    NextChanged = (Next /= CState3#chstate.next),
+    NextChanged = (Next /= CState3?CHSTATE.next),
     {RingChanged or NextChanged, State2, CState3}.
 
-rebalance_ring(_CNode, CState=#chstate{next=[]}) ->
+rebalance_ring(_CNode, CState=?CHSTATE{next=[]}) ->
     Members = claiming_members(CState),
     CState2 = lists:foldl(fun(Node, Ring0) ->
                                   claim_until_balanced(Ring0, Node)
@@ -1613,12 +1614,12 @@ rebalance_ring(_CNode, CState=#chstate{next=[]}) ->
                PrevOwner /= NewOwner],
     %% ?debugFmt("Next: ~p~n", [Next]),
     Next;
-rebalance_ring(_CNode, _CState=#chstate{next=Next}) ->
+rebalance_ring(_CNode, _CState=?CHSTATE{next=Next}) ->
     Next.
 
 handle_down_nodes(CState, Next) ->
-    LeavingMembers = get_members(CState#chstate.members, [leaving, invalid]),
-    DownMembers = get_members(CState#chstate.members, [down]),
+    LeavingMembers = get_members(CState?CHSTATE.members, [leaving, invalid]),
+    DownMembers = get_members(CState?CHSTATE.members, [down]),
     Next2 = [begin
                  OwnerLeaving = lists:member(O, LeavingMembers),
                  NextDown = lists:member(NO, DownMembers),
@@ -1651,7 +1652,7 @@ claim_until_balanced(Ring, Node) ->
             claim_until_balanced(NewRing, Node)
     end.
 
-all_next_owners(#chstate{next=Next}) ->
+all_next_owners(?CHSTATE{next=Next}) ->
     [{Idx, NextOwner} || {Idx, _, NextOwner, _, _} <- Next].
 
 change_owners(CState, Reassign) ->
@@ -1687,9 +1688,9 @@ remove_node(CState, Node, Status, Indices) ->
 
     %% Unlike rebalance_ring, remove_node can be called when Next is non-empty,
     %% therefore we need to merge the values. Original Next has priority.
-    Next2 = lists:ukeysort(1, CState#chstate.next ++ Next),
+    Next2 = lists:ukeysort(1, CState?CHSTATE.next ++ Next),
     CState2 = change_owners(CState, Reassign),
-    CState2#chstate{next=Next2}.
+    CState2?CHSTATE{next=Next2}.
 
 remove_from_cluster(Ring, ExitingNode) ->
     %% % Set the remote node to stop claiming.
@@ -1701,7 +1702,7 @@ remove_from_cluster(Ring, ExitingNode) ->
     %% {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     AllOwners = riak_core_ring:all_owners(Ring),
 
-    %%?debugFmt("Members: ~p~nOwners: ~p~n", [Ring#chstate.members, AllOwners]),
+    %%?debugFmt("Members: ~p~nOwners: ~p~n", [Ring?CHSTATE.members, AllOwners]),
     % Transfer indexes to other nodes...
     ExitRing =
         case attempt_simple_transfer(Ring, AllOwners, ExitingNode) of
@@ -1781,13 +1782,13 @@ attempt_simple_transfer(Ring, [], _, _, _, _) ->
 
 %% Update global members set used for test case generation.
 update_members(State=#state{members=Members}, CS2) ->
-    CS1 = #chstate{members=Members},
+    CS1 = ?CHSTATE{members=Members},
     Members2 = reconcile_members(CS1, CS2),
     State#state{members=Members2}.
 
 increment_cstate_vclock(Node, CState) ->
-    VClock = vclock:increment(Node, CState#chstate.vclock),
-    CState#chstate{vclock=VClock}.
+    VClock = vclock:increment(Node, CState?CHSTATE.vclock),
+    CState?CHSTATE{vclock=VClock}.
 
 %% Returns true if the nodes can communicate (ie. not split)
 can_communicate(_State, N1, N2) when N1 =:= N2 ->
@@ -1799,7 +1800,7 @@ can_communicate(State, N1, N2) ->
     (not dict:is_key({N1, N2}, State#state.split)).
 
 next_owner(State, CState, Idx) ->
-    case lists:keyfind(Idx, 1, CState#chstate.next) of
+    case lists:keyfind(Idx, 1, CState?CHSTATE.next) of
         false ->
             {undefined, undefined, undefined};
         NInfo ->
@@ -1807,7 +1808,7 @@ next_owner(State, CState, Idx) ->
     end.
 
 next_owner(_State, CState, Idx, Mod) ->
-    case lists:keyfind(Idx, 1, CState#chstate.next) of
+    case lists:keyfind(Idx, 1, CState?CHSTATE.next) of
         false ->
             {undefined, undefined, undefined};
         {_, Owner, NextOwner, _Transfers, complete} ->
@@ -1824,7 +1825,7 @@ next_owner(_State, CState, Idx, Mod) ->
 next_owner(_State, {_, Owner, NextOwner, _Transfers, Status}) ->
     {Owner, NextOwner, Status}.
 
-mark_transfer_complete(State, CState=#chstate{next=Next, vclock=VClock}, Idx, Mod) ->
+mark_transfer_complete(State, CState=?CHSTATE{next=Next, vclock=VClock}, Idx, Mod) ->
     {Idx, Owner, NextOwner, Transfers, Status} = lists:keyfind(Idx, 1, Next),
     Transfers2 = ordsets:add_element(Mod, Transfers),
     VNodeMods = vnode_modules(State, Owner),
@@ -1839,23 +1840,23 @@ mark_transfer_complete(State, CState=#chstate{next=Next, vclock=VClock}, Idx, Mo
     Next2 = lists:keyreplace(Idx, 1, Next,
                              {Idx, Owner, NextOwner, Transfers2, Status2}),
     VClock2 = vclock:increment(Owner, VClock),
-    CState#chstate{next=Next2, vclock=VClock2}.
+    CState?CHSTATE{next=Next2, vclock=VClock2}.
    
 %% VClock timestamps may be different for test generation versus
 %% shrinking/checking phases. Normalize to test for equality.
 equal_cstate(CS1, CS2) ->
-    T1 = equal_members(CS1#chstate.members, CS2#chstate.members),
-    T2 = equal_vclock(CS1#chstate.rvsn, CS2#chstate.rvsn),
+    T1 = equal_members(CS1?CHSTATE.members, CS2?CHSTATE.members),
+    T2 = equal_vclock(CS1?CHSTATE.rvsn, CS2?CHSTATE.rvsn),
     T3 = equal_seen(CS1, CS2),
 
     %% Clear fields checked manually and test remaining through equality.
-    CS3=CS1#chstate{nodename=ok, members=ok, vclock=ok, rvsn=ok, seen=ok},
-    CS4=CS2#chstate{nodename=ok, members=ok, vclock=ok, rvsn=ok, seen=ok},
+    CS3=CS1?CHSTATE{nodename=ok, members=ok, vclock=ok, rvsn=ok, seen=ok},
+    CS4=CS2?CHSTATE{nodename=ok, members=ok, vclock=ok, rvsn=ok, seen=ok},
     T4 = (CS3 =:= CS4),
     T1 and T2 and T3 and T4.
 
 equal_members(M1, M2) ->
-    L = orddict:merge(fun(_, {Status1, VC1}, {Status2, VC2}) ->
+    L = orddict:merge(fun(_, {Status1, VC1, _}, {Status2, VC2, _}) ->
                               (Status1 =:= Status2) andalso
                                   equal_vclock(VC1, VC2)
                       end, M1, M2),
@@ -1871,8 +1872,8 @@ equal_seen(CS1, CS2) ->
     {_, R} = lists:unzip(L),
     lists:all(fun(X) -> X =:= true end, R).
 
-filtered_seen(CS=#chstate{seen=Seen}) ->
-    case get_members(CS#chstate.members) of
+filtered_seen(CS=?CHSTATE{seen=Seen}) ->
+    case get_members(CS?CHSTATE.members) of
         [] ->
             Seen;
         Members ->
@@ -1950,7 +1951,7 @@ run_cmds(RingSize, Cmds) ->
     %% Most update to data active member
     {_, Member0} = lists:foldl(fun(Node, {VClock0, Result}) ->
                                        CS = get_cstate(State, Node),
-                                       VClock1 = CS#chstate.vclock,
+                                       VClock1 = CS?CHSTATE.vclock,
                                        case vclock:descends(VClock1, VClock0) of
                                            true ->
                                                {VClock1, Node};
@@ -1968,12 +1969,12 @@ run_cmds(RingSize, Cmds) ->
     Owners2 = all_owners(get_cstate(State4, Member0)),
     CState2 = get_cstate(State4, Member0),
     ?debugFmt("Owners1: ~p~nOwners2: ~p~n", [Owners1, Owners2]),
-    ?debugFmt("Next0: ~p~n", [CState#chstate.next]),
-    ?debugFmt("Next1: ~p~n", [CState2#chstate.next]),
+    ?debugFmt("Next0: ~p~n", [CState?CHSTATE.next]),
+    ?debugFmt("Next1: ~p~n", [CState2?CHSTATE.next]),
     %% ?debugFmt("M: ~p~n", [State4#state.members]),
     %% NS2 = dict:map(fun(_, NState) ->
     %%                        CS = NState#nstate.chstate,
-    %%                        CS2 = CS#chstate{next=[]},
+    %%                        CS2 = CS?CHSTATE{next=[]},
     %%                        NState#nstate{chstate=CS2}
     %%                end, State4#state.nstates),
     %% State5 = State4#state{nstates=NS2},
@@ -1999,7 +2000,7 @@ test_join() ->
                    {call,join_eqc,initial_cluster,[{[1,0,2],[3,4,5]},[0,1,2,3,4,5,6,7]]}},
                   {set,{var,6},{call,join_eqc,join,[4,1]}}]),
     CS4 = get_cstate(S, 4),
-    M = get_members(CS4#chstate.members),
+    M = get_members(CS4?CHSTATE.members),
     ?assertEqual([0,1,2,4], M).
 
 %% Claimant transition due to remove
@@ -2012,7 +2013,7 @@ test_claimant1() ->
                   {set,{var,10},{call,join_eqc,remove,[0,3]}},
                   {set,{var,37},{call,join_eqc,random_gossip,[2,3]}}]),
     CS2 = get_cstate(S, 2),
-    ?assertEqual(2, CS2#chstate.claimant).
+    ?assertEqual(2, CS2?CHSTATE.claimant).
    
 
 %% Claimant transition due to leave
@@ -2029,7 +2030,7 @@ test_claimant2() ->
                   {set,{var,187},{call,join_eqc,random_gossip,[0,5]}},
                   {set,{var,236},{call,join_eqc,random_gossip,[4,0]}}]),
     CS4 = get_cstate(S, 4),
-    ?assertEqual(4, CS4#chstate.claimant).
+    ?assertEqual(4, CS4?CHSTATE.claimant).
 
 %% Test that after handoff, the vnode forwards to the new owner.
 test_read_forward() ->


### PR DESCRIPTION
This PR adds a legacy gossip mode to the new gossip/membership code as well as supports rolling upgrades. In-place upgrades, leave/rejoin, and stable hybrid/mixed-version clusters are all supported. Read the commit message for the first commit for more details.

At a minimum please re-test the following scenarios that I've already tested manually:
1. In-place upgrades. Have 0.14.2 cluster, and in-place upgrade a node at a time. Cluster should stay in legacy mode until all nodes are upgraded, and then move into new gossip/membership protocol.
2. Leave/rejoin upgrades. Similar to above.
3. Try setting the {riak_core, legacy_gossip, true} in the app.config and ensure that the node uses legacy gossip.
4. Test that the cluster automatically changes from new to legacy gossip whenever an old or legacy-mode node joins, and back to new if that node leaves/is removed.

A few things. In a mixed cluster environment, 0.14.2 nodes will fail on ringready/transfers due to the RPC call retrieving the new ring. This PR negotiates formats over gossip, but not over RPC. However, transfers/ringready from a new code node will work fine in a mixed cluster.

Another issue is that in a mixed-mode cluster, transfers is somewhat useless. It will always say there is some outstanding transfers because the new nodes are running riak_pipe but the old nodes are not. This is the same on master. It's an issue with handoff waiting for node_watcher:services to claim the target node is running pipe, which it doesn't because 0.14.2 doesn't run pipe. For similar reasons, old nodes may sometimes not shutdown after handoff in a mixed-version cluster.

Note: The riak_core_gossip_legacy.erl file is copy of gossip from master with some minor changes. It's much clear to review if you look at it with respect to master's gossip rather than as a new file:
git diff master:src/riak_core_gossip.erl src/riak_core_gossip_legacy.erl
