### PR TITLE
Az642: Preliminary VNode Manager / Rebalance Under Load

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -49,6 +49,7 @@
              riak_core_test_util,
              riak_core_util,
              riak_core_vnode,
+             riak_core_vnode_manager,
              riak_core_vnode_master,
              riak_core_vnode_sup,
              riak_core_web,

--- a/src/riak_core_ring_handler.erl
+++ b/src/riak_core_ring_handler.erl
@@ -36,6 +36,7 @@ init([]) ->
 handle_event({ring_update, Ring}, State) ->
     %% Make sure all vnodes are started...
     ensure_vnodes_started(Ring),
+    riak_core_vnode_manager:ring_changed(Ring),
     {ok, State}.
 
 handle_call(_Event, State) ->

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -37,6 +37,7 @@
          prune_ringfiles/0,
          read_ringfile/1,
          find_latest_ringfile/0,
+         force_update/0,
          do_write_ringfile/1,
          ring_trans/2,
          set_cluster_name/1,
@@ -91,6 +92,17 @@ ring_trans(Fun, Args) ->
 
 set_cluster_name(Name) ->
     gen_server2:call(?MODULE, {set_cluster_name, Name}, infinity).
+
+%% @doc Exposed for support/debug purposes. Forces the node to change its
+%%      ring in a manner that will trigger reconciliation on gossip.
+force_update() ->
+    ring_trans(
+      fun(Ring, _) ->
+              NewRing = riak_core_ring:update_member_meta(node(), Ring, node(),
+                                                          unused, now()),
+              {new_ring, NewRing}
+      end, []),
+    ok.
 
 do_write_ringfile(Ring) ->
     {{Year, Month, Day},{Hour, Minute, Second}} = calendar:universal_time(),

--- a/src/riak_core_sup.erl
+++ b/src/riak_core_sup.erl
@@ -67,6 +67,7 @@ init([]) ->
                   ?CHILD(riak_core_ring_manager, worker),
                   ?CHILD(riak_core_node_watcher_events, worker),
                   ?CHILD(riak_core_node_watcher, worker),
+                  ?CHILD(riak_core_vnode_manager, worker),
                   ?CHILD(riak_core_gossip, worker),
                   RiakWebs
                  ]),

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -27,13 +27,16 @@
 -export([start_link/0, stop/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
--export([all_vnodes/0, ring_changed/1, set_not_forwarding/2]).
+-export([all_vnodes/0, ring_changed/1, set_not_forwarding/2,
+         force_handoffs/0]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
 -record(state, {not_forwarding :: [pid()]}).
+
+-define(DEFAULT_OWNERSHIP_TRIGGER, 8).
 
 %% ===================================================================
 %% Public API
@@ -64,6 +67,13 @@ ring_changed(Ring) ->
 set_not_forwarding(Pid, Value) ->
     gen_server:cast(?MODULE, {set_not_forwarding, Pid, Value}).
 
+%% @doc Provided for support/debug purposes. Forces all running vnodes to start
+%%      handoff. Limited by handoff_concurrency setting and therefore may need
+%%      to be called multiple times to force all handoffs to complete.
+force_handoffs() -> 
+    [riak_core_vnode:trigger_handoff(Pid) || {_, _, Pid} <- all_vnodes()],
+    ok.
+    
 %% ===================================================================
 %% gen_server behaviour
 %% ===================================================================
@@ -81,10 +91,29 @@ handle_call(_, _From, State) ->
 handle_cast({ring_changed, Ring}, State=#state{not_forwarding=NF}) ->
     %% Inform vnodes that the ring has changed so they can update their
     %% forwarding state.
-    AllPids = [Pid || {_Mod, _Idx, Pid} <- all_vnodes()],
+    AllVNodes = all_vnodes(),
+    AllPids = [Pid || {_Mod, _Idx, Pid} <- AllVNodes],
     Notify = AllPids -- NF,
     [riak_core_vnode:update_forwarding(Pid, Ring) || Pid <- Notify],
 
+    %% Trigger ownership transfers.
+    Transfers = riak_core_ring:pending_changes(Ring),
+    Limit = app_helper:get_env(riak_core,
+                               forced_ownership_handoff,
+                               ?DEFAULT_OWNERSHIP_TRIGGER),
+    Throttle = lists:sublist(Transfers, Limit),
+    Mods = [Mod || {_, Mod} <- riak_core:vnode_modules()],
+    Awaiting = [{Mod, Idx} || {Idx, Node, _, CMods, S} <- Throttle,
+                              Mod <- Mods,
+                              S =:= awaiting,
+                              Node =:= node(),
+                              not lists:member(Mod, CMods)],
+
+    [riak_core_vnode:trigger_handoff(Pid) || {ModA, IdxA, Pid} <- AllVNodes,
+                                             {ModB, IdxB} <- Awaiting,
+                                             ModA =:= ModB,
+                                             IdxA =:= IdxB],
+    
     %% Filter out dead pids from the not_forwarding list.
     NF2 = lists:filter(fun(Pid) ->
                                is_pid(Pid) andalso is_process_alive(Pid)

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -1,0 +1,122 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_core: Core Riak Application
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_core_vnode_manager).
+
+-behaviour(gen_server).
+
+-export([start_link/0, stop/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+-export([all_vnodes/0, ring_changed/1, set_not_forwarding/2]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-record(state, {not_forwarding :: [pid()]}).
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+stop() ->
+    gen_server:cast(?MODULE, stop).
+
+all_vnodes() ->
+    Mods = [Mod || {_App, Mod} <- riak_core:vnode_modules()],
+    lists:flatmap(fun all_vnodes/1, Mods).
+
+all_vnodes(Mod) ->
+    try riak_core_vnode_master:all_index_pid(Mod) of
+        IdxPids ->
+            [{Mod, Idx, Pid} || {Idx, Pid} <- IdxPids]
+    catch
+        _:_ ->
+            []
+    end.
+
+ring_changed(Ring) ->
+    gen_server:cast(?MODULE, {ring_changed, Ring}).
+
+set_not_forwarding(Pid, Value) ->
+    gen_server:cast(?MODULE, {set_not_forwarding, Pid, Value}).
+
+%% ===================================================================
+%% gen_server behaviour
+%% ===================================================================
+
+%% @private
+init(_State) ->
+    State = #state{not_forwarding=[]},
+    {ok, State}.
+
+%% @private
+handle_call(_, _From, State) ->
+    {reply, ok, State}.
+
+%% @private
+handle_cast({ring_changed, Ring}, State=#state{not_forwarding=NF}) ->
+    %% Inform vnodes that the ring has changed so they can update their
+    %% forwarding state.
+    AllPids = [Pid || {_Mod, _Idx, Pid} <- all_vnodes()],
+    Notify = AllPids -- NF,
+    [riak_core_vnode:update_forwarding(Pid, Ring) || Pid <- Notify],
+
+    %% Filter out dead pids from the not_forwarding list.
+    NF2 = lists:filter(fun(Pid) ->
+                               is_pid(Pid) andalso is_process_alive(Pid)
+                       end, NF),
+    {noreply, State#state{not_forwarding=NF2}};
+
+handle_cast({set_not_forwarding, Pid, Value},
+            State=#state{not_forwarding=NF}) ->
+    NF2 = case Value of
+              true ->
+                  lists:usort([Pid | NF]);
+              false ->
+                  NF -- [Pid]
+          end,
+    {noreply, State#state{not_forwarding=NF2}};
+
+handle_cast(_, State) ->
+    {noreply, State}.
+
+%% @private
+handle_info(_Info, State) -> {noreply, State}.
+
+%% @private
+terminate(_Reason, _State) ->
+    ok.
+
+%% @private
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+

--- a/src/riak_core_vnode_master.erl
+++ b/src/riak_core_vnode_master.erl
@@ -32,7 +32,7 @@
          sync_command/4,
          sync_spawn_command/3, make_request/3,
          make_coverage_request/4,
-         all_nodes/1, reg_name/1]).
+         all_nodes/1, reg_name/1, all_index_pid/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
 	 terminate/2, code_change/3]).
 -record(idxrec, {idx, pid, monref}).
@@ -134,6 +134,10 @@ all_nodes(VNodeMod) ->
     RegName = reg_name(VNodeMod),
     gen_server:call(RegName, all_nodes, infinity).
 
+all_index_pid(VNodeMod) ->
+    RegName = reg_name(VNodeMod),
+    gen_server:call(RegName, all_index_pid, infinity).
+
 %% @private
 init([VNodeMod, LegacyMod, RegName]) ->
     %% Get the current list of vnodes running in the supervisor. We use this
@@ -203,6 +207,10 @@ handle_call({spawn,
     {noreply, State};
 handle_call(all_nodes, _From, State) ->
     {reply, lists:flatten(ets:match(State#state.idxtab, {idxrec, '_', '$1', '_'})), State};
+handle_call(all_index_pid, _From, State) ->
+    Reply = [list_to_tuple(L) 
+             || L <- ets:match(State#state.idxtab, {idxrec, '$1', '$2', '_'})],
+    {reply, Reply, State};
 handle_call({Partition, get_vnode}, _From, State) ->
     Pid = get_vnode(Partition, State),
     {reply, {ok, Pid}, State};

--- a/src/riak_core_vnode_master.erl
+++ b/src/riak_core_vnode_master.erl
@@ -77,14 +77,18 @@ command({Index,Node}, Msg, Sender, VMaster) ->
     gen_server:cast({VMaster, Node}, make_request(Msg, Sender, Index)).
 
 %% Send a command to a covering set of vnodes
-coverage(Msg, CoverageVNodes, Keyspaces, {Type, Ref, From}, VMaster) ->
+coverage(Msg, CoverageVNodes, Keyspaces, {Type, Ref, From}, VMaster)
+  when is_list(CoverageVNodes) ->
     [gen_server:cast({VMaster, Node}, 
                      make_coverage_request(Msg,
                                            Keyspaces, 
                                            {Type, {Ref, {Index, Node}}, From},
                                            Index)) ||
-        {Index, Node} <- CoverageVNodes].
-
+        {Index, Node} <- CoverageVNodes];
+coverage(Msg, {Index, Node}, Keyspaces, Sender, VMaster) ->
+    gen_server:cast({VMaster, Node}, 
+                    make_coverage_request(Msg, Keyspaces, Sender, Index)).
+    
 %% Send the command to an individual Index/Node combination, but also
 %% return the pid for the vnode handling the request, as `{ok,
 %% VnodePid}'.


### PR DESCRIPTION
This PR adds a preliminary vnode manager that is currently used to 1) trigger ownership handoffs independently from vnode inactivity and 2) help vnodes maintain their forwarding status. The vnode manager will eventually take over most of the vnode pid tracking/spawning logic currently included in vnode_master.

For further information, read the full commit messages.
