### PR TITLE
Minor changes before rebase/merge of new cluster membership code

### DIFF
--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -203,6 +203,10 @@ all_members(?CHSTATE{members=Members}) ->
 active_members(?CHSTATE{members=Members}) ->
     get_members(Members, [joining, valid, leaving, exiting]).
 
+%% @doc Returns a list of members guaranteed safe for requests
+ready_members(?CHSTATE{members=Members}) ->
+    get_members(Members, [valid, leaving]).
+
 %% @doc Provide all ownership information in the form of {Index,Node} pairs.
 -spec all_owners(State :: chstate()) -> [{Index :: integer(), Node :: term()}].
 all_owners(State) ->


### PR DESCRIPTION
Changes:
-- Join checks against current ring_size rather than application variable.
-- Join requires joining node to not already be part of a cluster.
-- Down fails if the cluster is in legacy gossip mode.
-- riak_core_ring:ready_members returns nodes guaranteed safe for requests.
