### PR TITLE
Eunit ring fixes

### DIFF
--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -129,7 +129,7 @@ init([Mod, Index, InitialInactivityTimeout]) ->
     end,
     riak_core_handoff_manager:remove_exclusion(Mod, Index),
     Timeout = app_helper:get_env(riak_core, vnode_inactivity_timeout, ?DEFAULT_TIMEOUT),
-    {ok, Ring} = riak_core_ring_manager:get_raw_ring(),
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     State = #state{index=Index, mod=Mod, modstate=ModState,
                    inactivity_timeout=Timeout, pool_pid=PoolPid},
     State2 = update_forwarding_mode(Ring, State),

--- a/test/node_watcher_qc.erl
+++ b/test/node_watcher_qc.erl
@@ -455,7 +455,8 @@ build_ring([Node | Rest]) ->
 build_ring([], _Id, _Inc, R) ->
     R;
 build_ring([Node | Rest], Id, Inc, R) ->
-    R2 = riak_core_ring:transfer_node(Id+Inc, Node, R),
+    R1 = riak_core_ring:add_member(node(), R, Node),
+    R2 = riak_core_ring:transfer_node(Id+Inc, Node, R1),
     build_ring(Rest, Id+Inc, Inc, R2).
 
 -endif.


### PR DESCRIPTION
Fixes to a make a couple of EQC tests pass.

Changed riak_core_vnode to consistently use get_my_ring() rather than get_raw_ring() so the ring manager doesn't need to start.

Changed node_watcher_qc to add nodes to the test ring as well as set ownership (actually, probably doesn't need to set ownership any more, but left as it was).
