### PR TITLE
Bz1178 ring fix on register

### DIFF
--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -23,10 +23,10 @@
 -export([stop/0, stop/1, join/1, join/3, remove/1, down/1, leave/0,
          remove_from_cluster/1]).
 -export([register_vnode_module/1, vnode_modules/0]).
--export([register/1, bucket_fixups/0]).
+-export([register/1, register/2, bucket_fixups/0]).
 -export([add_guarded_event_handler/3, add_guarded_event_handler/4]).
 -export([delete_guarded_event_handler/3]).
-
+-compile({no_auto_import,[register/2]}).
 %% @spec stop() -> ok
 %% @doc Stop the riak application and the calling process.
 stop() -> stop("riak stop requested").
@@ -248,24 +248,35 @@ bucket_fixups() ->
         {ok, Mods} -> Mods
     end.
 
+%% Get the application name if not supplied, first by get_application
+%% then by searching by module name
+get_app(undefined, Module) ->
+    {ok, App} = case application:get_application(self()) of
+                    {ok, AppName} -> {ok, AppName};
+                    undefined -> app_for_module(Module)
+                end,
+    App;
+get_app(App, _Module) ->
+    App.
+
 %% @doc Register a riak_core application.
-register([]) ->
+register(Props) ->
+    register(undefined, Props).
+
+%% @doc Register a named riak_core application.
+register(_App, []) ->
     ok;
-register([{bucket_fixup, FixupMod}|T]) ->
-    register_mod(FixupMod, bucket_fixups),
-    register(T);
-register([{vnode_module, VNodeMod}|T]) ->
-    register_mod(VNodeMod, vnode_modules),
-    register(T).
+register(App, [{bucket_fixup, FixupMod}|T]) ->
+    register_mod(get_app(App, FixupMod), FixupMod, bucket_fixups),
+    register(App, T);
+register(App, [{vnode_module, VNodeMod}|T]) ->
+    register_mod(get_app(App, VNodeMod), VNodeMod, vnode_modules),
+    register(App, T).
 
 register_vnode_module(VNodeMod) when is_atom(VNodeMod)  ->
-    register_mod(VNodeMod, vnode_modules).
+    register_mod(get_app(undefined, VNodeMod), VNodeMod, vnode_modules).
 
-register_mod(Module, Type) when is_atom(Module), is_atom(Type) ->
-    {ok, App} = case application:get_application(self()) of
-        {ok, AppName} -> {ok, AppName};
-        undefined -> app_for_module(Module)
-    end,
+register_mod(App, Module, Type) when is_atom(Module), is_atom(Type) ->
     case application:get_env(riak_core, Type) of
         undefined ->
             application:set_env(riak_core, Type, [{App,Module}]);

--- a/test/bucket_fixup_test.erl
+++ b/test/bucket_fixup_test.erl
@@ -64,6 +64,60 @@ fixup_test_() ->
         ]
     }.
 
+load_test_() ->
+    {setup,
+     fun() ->
+             %% catch(riak_core_ring_manager:stop()),
+             %% catch(exit(whereis(riak_core_ring_events), shutdown)),
+             application:load(riak_core),
+             application:set_env(riak_core, bucket_fixups, []),
+             application:set_env(riak_core, default_bucket_props, []),
+
+                 %% dbgh:start(),
+                 %% dbgh:trace(riak_core),
+                 %% dbgh:trace(riak_core_ring_events),
+                 %% dbgh:trace(riak_core_ring_manager),
+                 %% dbgh:trace(riak_core_bucket),
+
+             Me = self(),
+             Pid = proc_lib:spawn(
+                     fun() ->
+                             {ok, _RingEvt} = riak_core_ring_events:start_link(),
+                             {ok, _RingMgr} = riak_core_ring_manager:start_link(),
+                             %% ok = riak_core_ring_manager:set_my_ring(riak_core_ring:fresh()),
+                             %% io:format(user, "=== Set ring\n", []),
+                             Me ! ready,
+                             receive
+                                 done ->
+                                     ok
+                             end
+                     end),
+             receive
+                 ready -> ok
+             end,
+             Pid
+     end,
+     fun(Pid) ->
+             riak_core_ring_manager:stop(),
+             Pid ! done,
+             application:unload(riak_core),
+             exit(Pid, kill)
+     end,
+     [
+      ?_test(begin
+                 {ok, _R} = riak_core_ring_manager:get_my_ring(),
+                 riak_core_bucket:set_bucket(test1, []),
+                 ?assertEqual([{name, test1}],
+                              riak_core_bucket:get_bucket(test1)),
+                 riak_core:register(loadtestapp, [{bucket_fixup, ?MODULE}]),
+                 ?assertEqual([{test, 1}, {name, test1}],
+                              riak_core_bucket:get_bucket(test1)),
+                 ok
+             end)
+     ]
+    }.
+
+
 do_no_harm() ->
     Ring = riak_core_ring:update_meta({bucket,test0},
         [],


### PR DESCRIPTION
Makes the bucket property fixups run on register.

Tested by spinning up riak with riak_search {enabled, false} , setting {search, true} bprops, checking the bucket properties to make sure there are no post-commit hooks.
Then restarting riak with riak_search {enabled, true} and checkign the postcommit hook - it should be set now.
