### PR TITLE
Change log level of worker pool start message.

### DIFF
--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -120,7 +120,7 @@ init([Mod, Index, InitialInactivityTimeout]) ->
     end,
     PoolPid = case lists:keyfind(pool, 1, Props) of
         {pool, WorkerModule, PoolSize, WorkerArgs} ->
-            lager:notice("starting worker pool ~p with size of ~p~n",
+            lager:debug("starting worker pool ~p with size of ~p~n",
                 [WorkerModule, PoolSize]),
             {ok, Pid} = riak_core_vnode_worker_pool:start_link(WorkerModule,
                 PoolSize, Index, WorkerArgs, worker_props),


### PR DESCRIPTION
The message is too verbose to be on for the default configuration. Change it to debug level from notice level.
