### PR TITLE
Fix bug in riak_core_coverage_fsm

### DIFF
--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -230,7 +230,7 @@ waiting_results({{ReqId, VNode}, Results},
             UpdatedVNodes = lists:delete(VNode, CoverageVNodes),
             case UpdatedVNodes of
                 [] ->
-                    Mod:finish(clean, ModState);
+                    Mod:finish(clean, UpdModState);
                 _ ->
                     UpdStateData =
                         StateData#state{coverage_vnodes=UpdatedVNodes,


### PR DESCRIPTION
This change fixes a bug in `riak_core_coverage_fsm` where the updated state is not passed to the module implementing the behavior in the `finish` call. This can lead to incomplete results for operations that accumulate results in the state and do something with them in the `finish` function.
