### PR TITLE
BZ 1220: Fix ringready in 1.0 to show all nodes in a mixed-version cluster

### DIFF
--- a/src/riak_core_status.erl
+++ b/src/riak_core_status.erl
@@ -120,7 +120,7 @@ ring_status() ->
 %% Retrieve the rings for all other nodes by RPC
 get_rings() ->
     {RawRings, Down} = riak_core_util:rpc_every_member(
-                         riak_core_ring_manager, get_raw_ring, [], 30000),
+                         riak_core_ring_manager, get_my_ring, [], 30000),
     RawRings2 = [riak_core_ring:upgrade(R) || {ok, R} <- RawRings],
     Rings = orddict:from_list([{riak_core_ring:owner_node(R), R} || R <- RawRings2]),
     {lists:sort(Down), Rings}.


### PR DESCRIPTION
In a mixed node cluster, 'riak-admin ringready' will fail on 0.14.2 nodes, and only list 1.0 nodes on a 1.0 cluster. This fix makes it so that ringready from a 1.0 node will list all nodes when part of a mixed cluster.

https://issues.basho.com/show_bug.cgi?id=1220
