### PR TITLE
Make vnode forward messages until vnode master removes it

### DIFF
--- a/src/riak_core_gossip.erl
+++ b/src/riak_core_gossip.erl
@@ -77,7 +77,7 @@ stop() ->
     gen_server:cast(?MODULE, stop).
 
 finish_handoff(Idx, Prev, New, Mod) ->
-    gen_server:call(?MODULE, {finish_handoff, Idx, Prev, New, Mod}).
+    gen_server:call(?MODULE, {finish_handoff, Idx, Prev, New, Mod}, infinity).
 
 rejoin(Node, Ring) ->
     gen_server:cast({?MODULE, Node}, {rejoin, Ring}).

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -175,7 +175,7 @@ update_forwarding_mode(_Ring, State=#state{modstate={deleted, _ModState}}) ->
     %% awaiting unregistered message from the vnode master.  The
     %% vnode has been deleted so cannot handle messages even if 
     %% we wanted to.
-    continue(State);
+    State;
 update_forwarding_mode(Ring, State=#state{index=Index, mod=Mod}) ->
     Node = node(),
     case riak_core_ring:next_owner(Ring, Index, Mod) of


### PR DESCRIPTION
With new cluster membership logic the shutdown on handoff completion happens much closer to the node processing live traffic. Ensure that all commands passed into the vnode are forwarded to the new node before shutting down.
