### PR TITLE
AZ 761: Prevent nodes from prematurely leaving

### DIFF
--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -597,7 +597,7 @@ ring_ready(State0) ->
     Owner = owner_node(State0),
     State = update_seen(Owner, State0),
     Seen = State?CHSTATE.seen,
-    Members = get_members(State?CHSTATE.members, [valid, leaving]),
+    Members = get_members(State?CHSTATE.members, [valid, leaving, exiting]),
     VClock = State?CHSTATE.vclock,
     R = [begin
              case orddict:find(Node, Seen) of
@@ -618,7 +618,7 @@ ring_ready_info(State0) ->
     Owner = owner_node(State0),
     State = update_seen(Owner, State0),
     Seen = State?CHSTATE.seen,
-    Members = get_members(State?CHSTATE.members, [valid, leaving]),
+    Members = get_members(State?CHSTATE.members, [valid, leaving, exiting]),
     RecentVC =
         orddict:fold(fun(_, VC, Recent) ->
                              case vclock:descends(VC, Recent) of
@@ -889,7 +889,8 @@ maybe_remove_exiting(Node, CState) ->
     Claimant = CState?CHSTATE.claimant,
     case Claimant of
         Node ->
-            Exiting = get_members(CState?CHSTATE.members, [exiting]),
+            %% Change exiting nodes to invalid, skipping this node.
+            Exiting = get_members(CState?CHSTATE.members, [exiting]) -- [Node],
             Changed = (Exiting /= []),
             CState2 =
                 lists:foldl(fun(ENode, CState0) ->

--- a/test/new_cluster_membership_model_eqc.erl
+++ b/test/new_cluster_membership_model_eqc.erl
@@ -134,9 +134,9 @@ handoff_all(State) ->
     State3.
 
 do_maybe(State, Cmd, Args) ->
-    case precondition(State, {call,join_eqc,Cmd,Args}) of
+    case precondition(State, {call,?MODULE,Cmd,Args}) of
         true ->
-            run(State, {call,join_eqc,Cmd,Args});
+            run(State, {call,?MODULE,Cmd,Args});
         false ->
             State
     end.
@@ -155,9 +155,9 @@ test_ring_convergence(State) ->
     end.
 
 do_gossip(State, N2, N1) ->
-    case precondition(State, {call,join_eqc,random_gossip,[N2,N1]}) of
+    case precondition(State, {call,?MODULE,random_gossip,[N2,N1]}) of
         true ->
-            {true, run(State, {call,join_eqc,random_gossip,[N2,N1]})};
+            {true, run(State, {call,?MODULE,random_gossip,[N2,N1]})};
         false ->
             {false, State}
     end.
@@ -1355,7 +1355,7 @@ ring_ready(CState0) ->
     Seen = CState?CHSTATE.seen,
     %% TODO: Should we add joining here?
     %%Members = get_members(CState?CHSTATE.members, [joining, valid, leaving, exiting]),
-    Members = get_members(CState?CHSTATE.members, [valid, leaving]),
+    Members = get_members(CState?CHSTATE.members, [valid, leaving, exiting]),
     VClock = CState?CHSTATE.vclock,
     R = [begin
              case orddict:find(Node, Seen) of
@@ -1454,7 +1454,7 @@ maybe_remove_exiting(State, Node, CState) ->
     Claimant = CState?CHSTATE.claimant,
     case Claimant of
         Node ->
-            Exiting = get_members(CState?CHSTATE.members, [exiting]),
+            Exiting = get_members(CState?CHSTATE.members, [exiting]) -- [Node],
             %%io:format("Claimant ~p removing exiting ~p~n", [Node, Exiting]),
             Changed = (Exiting /= []),
             {State2, CState2} =


### PR DESCRIPTION
Change ring_ready to also consider exiting nodes in it's decision, fixing a corner case that led to notfounds. This was the previous behavior during most of the development of the new clustering code (and was heavily tested), but was changed last minute to address a bug where the current claimant would shutdown after leaving but before other nodes saw it transition from exiting to leaving, and therefore the ring would never converge and a new claimant would never be selected.

Since the exiting change was reverted to old behavior, the above claimant issue was addressed by modifying the claimant so that it does not transition itself from exiting to invalid, and therefore does not shutdown. After transitioning to exiting, the ring will converge, a new claimant will be selected (since only valid and leaving nodes can be the claimant), and the new claimant will transition the previous claimant from exiting to invalid and start the shutdown process.

Updated and verified in the membership EQC model as well.
