### PR TITLE
Fix bz1235: vnodes crashing when receiving unexpected handoff

### DIFF
--- a/src/riak_core_handoff_receiver.erl
+++ b/src/riak_core_handoff_receiver.erl
@@ -106,7 +106,7 @@ process_message(?PT_MSG_OBJ, MsgData, State=#state{vnode=VNode, count=Count}) ->
     case gen_fsm:sync_send_all_state_event(VNode, Msg, 60000) of
         ok ->
             State#state{count=Count+1};
-        E={error, Err} ->
+        E={error, _} ->
             exit(E)
     end;
 process_message(?PT_MSG_OLDSYNC, MsgData, State=#state{sock=Socket,

--- a/src/riak_core_handoff_receiver.erl
+++ b/src/riak_core_handoff_receiver.erl
@@ -103,8 +103,12 @@ process_message(?PT_MSG_INIT, MsgData, State=#state{vnode_mod=VNodeMod}) ->
     State#state{partition=Partition, vnode=VNode};
 process_message(?PT_MSG_OBJ, MsgData, State=#state{vnode=VNode, count=Count}) ->
     Msg = {handoff_data, MsgData},
-    gen_fsm:sync_send_all_state_event(VNode, Msg, 60000),
-    State#state{count=Count+1};
+    case gen_fsm:sync_send_all_state_event(VNode, Msg, 60000) of
+        ok ->
+            State#state{count=Count+1};
+        E={error, Err} ->
+            exit(E)
+    end;
 process_message(?PT_MSG_OLDSYNC, MsgData, State=#state{sock=Socket,
                                                        tcp_mod=TcpMod}) ->
     TcpMod:send(Socket, <<?PT_MSG_OLDSYNC:8,"sync">>),

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -369,6 +369,10 @@ handle_event(R=?COVERAGE_REQ{}, _StateName, State) ->
 handle_sync_event(get_mod_index, _From, StateName,
                   State=#state{index=Idx,mod=Mod}) ->
     {reply, {Mod, Idx}, StateName, State, State#state.inactivity_timeout};
+handle_sync_event({handoff_data,_BinObj}, _From, StateName, 
+                  State=#state{modstate={deleted, _ModState}}) ->
+    {reply, {error, vnode_exiting}, StateName, State,
+     State#state.inactivity_timeout};
 handle_sync_event({handoff_data,BinObj}, _From, StateName, 
                   State=#state{mod=Mod, modstate=ModState}) ->
     case Mod:handle_handoff_data(BinObj, ModState) of


### PR DESCRIPTION
Sync messages sent to vnodes when they are exiting cause them to crash:
https://issues.basho.com/show_bug.cgi?id=1235

After talking to Jon, the decision for now is to prevent vnodes from crashing, and pass an error up to the handoff receiver. The handoff receiver will check for the error, and exit. This will cause the handoff sender to crash, but this an acceptable crash (compared to crashing vnodes). The handoff will eventually be restarted in the future against the proper target node, and complete successfully.
