### PR TITLE
Fix BZ1242: Stalled handoff when ring is fixed-up

### DIFF
--- a/src/riak_core_gossip.erl
+++ b/src/riak_core_gossip.erl
@@ -272,6 +272,8 @@ handle_cast({send_ring_to, Node}, State) ->
                         rpc_gossip_version(MyRing, Node)
                 end,
     RingOut = riak_core_ring:downgrade(GossipVsn, MyRing),
+    riak_core_ring:check_tainted(RingOut,
+                                 "Error: Sending tainted ring over gossip"),
     gen_server:cast({?MODULE, Node}, {reconcile_ring, RingOut}),
     {noreply, State};
 
@@ -283,6 +285,8 @@ handle_cast({distribute_ring, Ring}, State) ->
                       Ring
               end,
     Nodes = riak_core_ring:active_members(Ring),
+    riak_core_ring:check_tainted(RingOut,
+                                 "Error: Sending tainted ring over gossip"),
     gen_server:abcast(Nodes, ?MODULE, {reconcile_ring, RingOut}),
     {noreply, State};
 

--- a/src/riak_core_gossip.erl
+++ b/src/riak_core_gossip.erl
@@ -273,7 +273,8 @@ handle_cast({send_ring_to, Node}, State) ->
                 end,
     RingOut = riak_core_ring:downgrade(GossipVsn, MyRing),
     riak_core_ring:check_tainted(RingOut,
-                                 "Error: Sending tainted ring over gossip"),
+                                 "Error: riak_core_gossip/send_ring_to :: "
+                                 "Sending tainted ring over gossip"),
     gen_server:cast({?MODULE, Node}, {reconcile_ring, RingOut}),
     {noreply, State};
 
@@ -286,7 +287,8 @@ handle_cast({distribute_ring, Ring}, State) ->
               end,
     Nodes = riak_core_ring:active_members(Ring),
     riak_core_ring:check_tainted(RingOut,
-                                 "Error: Sending tainted ring over gossip"),
+                                 "Error: riak_core_gossip/distribute_ring :: "
+                                 "Sending tainted ring over gossip"),
     gen_server:abcast(Nodes, ?MODULE, {reconcile_ring, RingOut}),
     {noreply, State};
 

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -397,8 +397,12 @@ random_other_active_node(State) ->
 -spec reconcile(ExternState :: chstate(), MyState :: chstate()) ->
         {no_change, chstate()} | {new_ring, chstate()}.
 reconcile(ExternState, MyState) ->
-    check_tainted(ExternState, "Error: reconciling a tainted ring"),
-    check_tainted(MyState, "Error: reconciling a tainted ring"),
+    check_tainted(ExternState,
+                  "Error: riak_core_ring/reconcile :: "
+                  "reconciling tainted external ring"),
+    check_tainted(MyState, 
+                  "Error: riak_core_ring/reconcile :: "
+                  "reconciling tainted internal ring"),
     case internal_reconcile(MyState, ExternState) of
         {false, State} ->
             {no_change, State};
@@ -629,7 +633,8 @@ next_owner(State, Idx, Mod) ->
 %% @doc Returns true if all cluster members have seen the current ring.
 -spec ring_ready(State :: chstate()) -> boolean().
 ring_ready(State0) ->
-    check_tainted(State0, "Error: ring_ready called on tainted ring"),
+    check_tainted(State0,
+                  "Error: riak_core_ring/ring_ready called on tainted ring"),
     Owner = owner_node(State0),
     State = update_seen(Owner, State0),
     Seen = State?CHSTATE.seen,
@@ -678,7 +683,8 @@ handoff_complete(State, Idx, Mod) ->
     transfer_complete(State, Idx, Mod).
 
 ring_changed(Node, State) ->
-    check_tainted(State, "Error: ring_changed called with tainted ring"),
+    check_tainted(State,
+                  "Error: riak_core_ring/ring_changed called on tainted ring"),
     internal_ring_changed(Node, State).
 
 pretty_print(Ring, Opts) ->

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -60,6 +60,7 @@
          downgrade/2,
          set_tainted/1,
          check_tainted/2,
+         nearly_equal/2,
          claimant/1,
          member_status/2,
          pretty_print/2,
@@ -217,6 +218,17 @@ check_tainted(Ring=?CHSTATE{}, Msg) ->
         _ ->
             ok
     end.
+
+%% @doc Verify that the two rings are identical expect that metadata can
+%%      differ and RingB's vclock is allowed to be equal or a direct
+%%      descendant of RingA's vclock. This matches the changes that the
+%%      fix-up logic may make to a ring.
+nearly_equal(RingA, RingB) ->
+    TestVC = vclock:descends(RingB?CHSTATE.vclock, RingA?CHSTATE.vclock),
+    RingA2 = RingA?CHSTATE{vclock=[], meta=[]},
+    RingB2 = RingB?CHSTATE{vclock=[], meta=[]},
+    TestRing = (RingA2 =:= RingB2),
+    TestVC and TestRing.
 
 %% @doc Produce a list of all nodes that are members of the cluster
 -spec all_members(State :: chstate()) -> [Node :: term()].

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -258,8 +258,7 @@ handle_call({ring_trans, Fun, Args}, _From, State=#state{raw_ring=Ring}) ->
                                    [Other]),
             {reply, not_changed, State}
     end;
-handle_call({set_cluster_name, Name}, _From, State) ->
-    {ok, Ring} = get_my_ring(),
+handle_call({set_cluster_name, Name}, _From, State=#state{raw_ring=Ring}) ->
     NewRing = riak_core_ring:set_cluster_name(Ring, Name),
     prune_write_notify_ring(NewRing),
     {reply, ok, State#state{raw_ring=NewRing}}.
@@ -282,8 +281,7 @@ handle_cast(refresh_my_ring, State) ->
 handle_cast(write_ringfile, test) ->
     {noreply,test};
 
-handle_cast(write_ringfile, State) ->
-    {ok, Ring} = get_my_ring(),
+handle_cast(write_ringfile, State=#state{raw_ring=Ring}) ->
     do_write_ringfile(Ring),
     {noreply,State}.
 

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -411,13 +411,14 @@ set_ring_global_test() ->
     application:set_env(riak_core,ring_creation_size, 4),
     Ring = riak_core_ring:fresh(),
     set_ring_global(Ring),
-    ?assertEqual(Ring, mochiglobal:get(?RING_KEY)).
+    ?assert(riak_core_ring:nearly_equal(Ring, mochiglobal:get(?RING_KEY))).
 
 set_my_ring_test() ->
     application:set_env(riak_core,ring_creation_size, 4),
     Ring = riak_core_ring:fresh(),
     set_ring_global(Ring),
-    ?assertEqual({ok, Ring}, get_my_ring()).
+    {ok, MyRing} = get_my_ring(),
+    ?assert(riak_core_ring:nearly_equal(Ring, MyRing)).
 
 refresh_my_ring_test() ->
     Core_Settings = [{ring_creation_size, 4},

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -129,7 +129,7 @@ init([Mod, Index, InitialInactivityTimeout]) ->
     end,
     riak_core_handoff_manager:remove_exclusion(Mod, Index),
     Timeout = app_helper:get_env(riak_core, vnode_inactivity_timeout, ?DEFAULT_TIMEOUT),
-    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    {ok, Ring} = riak_core_ring_manager:get_raw_ring(),
     State = #state{index=Index, mod=Mod, modstate=ModState,
                    inactivity_timeout=Timeout, pool_pid=PoolPid},
     State2 = update_forwarding_mode(Ring, State),
@@ -476,7 +476,7 @@ should_handoff(#state{handoff_node=HN}) when HN /= none ->
     %% Already handing off
     false;
 should_handoff(#state{index=Idx, mod=Mod}) ->
-    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    {ok, Ring} = riak_core_ring_manager:get_raw_ring(),
     Me = node(),
     {_, NextOwner, _} = riak_core_ring:next_owner(Ring, Idx),
     Owner = riak_core_ring:index_owner(Ring, Idx),


### PR DESCRIPTION
This pull-request fixes BZ1242 by changing riak_core_vnode:should_handoff to use get_raw_ring rather than get_my_ring. This is necessary because get_my_ring returns the fixed-up version of the ring, which has a locally modified vector clock that will never satisfy the ring_ready check used in should_handoff.

In order to prevent other misuses of the fixed-up ring, this pull-request also adds new tainted ring logic that identifies misuses of the fixed-up ring. 

Testing with the tainted logic revealed several additional misuses of the fixed-up ring which are also fixed in this pull-request. 

Manual testing revealed no more tainted error messages after all committed changes.
