### PR TITLE
Refactor riak_core vnode management (part 1)

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -53,6 +53,8 @@
              riak_core_vnode,
              riak_core_vnode_manager,
              riak_core_vnode_master,
+             riak_core_vnode_proxy,
+             riak_core_vnode_proxy_sup,
              riak_core_vnode_sup,
              riak_core_vnode_worker,
              riak_core_vnode_worker_pool,

--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -354,7 +354,7 @@ app_for_module(Mod) ->
     app_for_module(application:which_applications(), Mod).
 
 app_for_module([], _Mod) ->
-    undefined;
+    {ok, undefined};
 app_for_module([{App,_,_}|T], Mod) ->
     {ok, Mods} = application:get_key(App, modules),
     case lists:member(Mod, Mods) of

--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -295,6 +295,12 @@ register_vnode_module(VNodeMod) when is_atom(VNodeMod)  ->
     register_mod(get_app(undefined, VNodeMod), VNodeMod, vnode_modules).
 
 register_mod(App, Module, Type) when is_atom(Module), is_atom(Type) ->
+    case Type of
+        vnode_modules ->
+            riak_core_vnode_proxy_sup:start_proxies(Module);
+        _ ->
+            ok
+    end,
     case application:get_env(riak_core, Type) of
         undefined ->
             application:set_env(riak_core, Type, [{App,Module}]);

--- a/src/riak_core_sup.erl
+++ b/src/riak_core_sup.erl
@@ -65,6 +65,7 @@ init([]) ->
                   ?CHILD(riak_core_handoff_listener, worker),
                   ?CHILD(riak_core_ring_events, worker),
                   ?CHILD(riak_core_ring_manager, worker),
+                  ?CHILD(riak_core_vnode_proxy_sup, supervisor),
                   ?CHILD(riak_core_node_watcher_events, worker),
                   ?CHILD(riak_core_node_watcher, worker),
                   ?CHILD(riak_core_vnode_manager, worker),

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -349,7 +349,7 @@ finish_handoff(State=#state{mod=Mod,
             {ok, NewModState} = Mod:delete(ModState),
             lager:debug("~p ~p vnode finished handoff and deleted.",
                         [Idx, Mod]),
-            riak_core_vnode_master:unregister_vnode(Idx, Mod),
+            riak_core_vnode_manager:unregister_vnode(Idx, Mod),
             riak_core_vnode_manager:set_not_forwarding(self(), false),
             continue(State#state{modstate={deleted,NewModState}, % like to fail if used
                                  handoff_node=none,

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -27,14 +27,19 @@
 -export([start_link/0, stop/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
--export([all_vnodes/0, ring_changed/1, set_not_forwarding/2,
+-export([all_vnodes/0, all_vnodes/1, ring_changed/1, set_not_forwarding/2,
          force_handoffs/0]).
+-export([all_nodes/1, all_index_pid/1, get_vnode_pid/2, start_vnode/2,
+         unregister_vnode/2, unregister_vnode/3]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--record(state, {not_forwarding :: [pid()]}).
+-record(idxrec, {key, idx, mod, pid, monref}).
+-record(state, {idxtab, 
+                not_forwarding :: [pid()]
+               }).
 
 -define(DEFAULT_OWNERSHIP_TRIGGER, 8).
 
@@ -49,17 +54,10 @@ stop() ->
     gen_server:cast(?MODULE, stop).
 
 all_vnodes() ->
-    Mods = [Mod || {_App, Mod} <- riak_core:vnode_modules()],
-    lists:flatmap(fun all_vnodes/1, Mods).
+    gen_server:call(?MODULE, all_vnodes).
 
 all_vnodes(Mod) ->
-    try riak_core_vnode_master:all_index_pid(Mod) of
-        IdxPids ->
-            [{Mod, Idx, Pid} || {Idx, Pid} <- IdxPids]
-    catch
-        _:_ ->
-            []
-    end.
+    gen_server:call(?MODULE, {all_vnodes, Mod}).
 
 ring_changed(Ring) ->
     gen_server:cast(?MODULE, {ring_changed, Ring}).
@@ -73,7 +71,26 @@ set_not_forwarding(Pid, Value) ->
 force_handoffs() -> 
     [riak_core_vnode:trigger_handoff(Pid) || {_, _, Pid} <- all_vnodes()],
     ok.
-    
+
+unregister_vnode(Index, VNodeMod) ->
+    unregister_vnode(Index, self(), VNodeMod).
+
+unregister_vnode(Index, Pid, VNodeMod) ->
+    gen_server:cast(?MODULE, {unregister, Index, VNodeMod, Pid}).
+
+%% Request a list of Pids for all vnodes
+all_nodes(VNodeMod) ->
+    gen_server:call(?MODULE, {all_nodes, VNodeMod}, infinity).
+
+all_index_pid(VNodeMod) ->
+    gen_server:call(?MODULE, {all_index_pid, VNodeMod}, infinity).
+
+get_vnode_pid(Index, VNodeMod) ->
+    gen_server:call(?MODULE, {Index, VNodeMod, get_vnode}, infinity).
+
+start_vnode(Index, VNodeMod) ->
+    gen_server:cast(?MODULE, {Index, VNodeMod, start_vnode}).
+
 %% ===================================================================
 %% gen_server behaviour
 %% ===================================================================
@@ -81,17 +98,72 @@ force_handoffs() ->
 %% @private
 init(_State) ->
     State = #state{not_forwarding=[]},
-    {ok, State}.
+    State2 = find_vnodes(State),
+    {ok, State2}.
 
 %% @private
+find_vnodes(State) ->
+    %% Get the current list of vnodes running in the supervisor. We use this
+    %% to rebuild our ETS table for routing messages to the appropriate
+    %% vnode.
+    VnodePids = [Pid || {_, Pid, worker, _}
+                            <- supervisor:which_children(riak_core_vnode_sup)],
+    IdxTable = ets:new(ets_vnodes, [{keypos, 2}]),
+
+    %% In case this the vnode master is being restarted, scan the existing
+    %% vnode children and work out which module and index they are responsible
+    %% for.  During startup it is possible that these vnodes may be shutting
+    %% down as we check them if there are several types of vnodes active.
+    PidIdxs = lists:flatten(
+                [try
+                     [{Pid, riak_core_vnode:get_mod_index(Pid)}]
+                 catch
+                     _:_Err ->
+                         []
+                 end || Pid <- VnodePids]),
+
+    %% Populate the ETS table with processes running this VNodeMod (filtered
+    %% in the list comprehension)
+    F = fun(Pid, Idx, Mod) ->
+                Mref = erlang:monitor(process, Pid),
+                #idxrec { key = {Idx,Mod}, idx = Idx, mod = Mod, pid = Pid,
+                          monref = Mref }
+        end,
+    IdxRecs = [F(Pid, Idx, Mod) || {Pid, {Mod, Idx}} <- PidIdxs],
+    true = ets:insert_new(IdxTable, IdxRecs),
+    State#state{idxtab=IdxTable}.
+
+%% @private
+handle_call({all_nodes, Mod}, _From, State) ->
+    {reply, lists:flatten(ets:match(State#state.idxtab, {idxrec, '_', '_', Mod, '$1', '_'})), State};
+handle_call(all_vnodes, _From, State) ->
+    Reply = get_all_vnodes(State),
+    {reply, Reply, State};
+handle_call({all_vnodes, Mod}, _From, State) ->
+    Reply = get_all_vnodes(Mod, State),
+    {reply, Reply, State};
+handle_call({all_index_pid, Mod}, _From, State) ->
+    Reply = get_all_index_pid(Mod, State),
+    {reply, Reply, State};
+handle_call({Partition, Mod, get_vnode}, _From, State) ->
+    Pid = get_vnode(Partition, Mod, State),
+    {reply, {ok, Pid}, State};
 handle_call(_, _From, State) ->
     {reply, ok, State}.
 
 %% @private
+handle_cast({Partition, Mod, start_vnode}, State) ->
+    get_vnode(Partition, Mod, State),
+    {noreply, State};
+handle_cast({unregister, Index, Mod, Pid}, #state{idxtab=T} = State) ->
+    ets:match_delete(T, {idxrec, {Index, Mod}, Index, Mod, Pid, '_'}),
+    riak_core_vnode_proxy:unregister_vnode(Mod, Index),
+    gen_fsm:send_event(Pid, unregistered),
+    {noreply, State};
 handle_cast({ring_changed, Ring}, State=#state{not_forwarding=NF}) ->
     %% Inform vnodes that the ring has changed so they can update their
     %% forwarding state.
-    AllVNodes = all_vnodes(),
+    AllVNodes = get_all_vnodes(State),
     AllPids = [Pid || {_Mod, _Idx, Pid} <- AllVNodes],
     Notify = AllPids -- NF,
     [riak_core_vnode:update_forwarding(Pid, Ring) || Pid <- Notify],
@@ -133,8 +205,9 @@ handle_cast({set_not_forwarding, Pid, Value},
 handle_cast(_, State) ->
     {noreply, State}.
 
-%% @private
-handle_info(_Info, State) -> {noreply, State}.
+handle_info({'DOWN', MonRef, process, _P, _I}, State) ->
+    delmon(MonRef, State),
+    {noreply, State}.
 
 %% @private
 terminate(_Reason, _State) ->
@@ -149,3 +222,45 @@ code_change(_OldVsn, State, _Extra) ->
 %% Internal functions
 %% ===================================================================
 
+get_all_index_pid(Mod, State) ->
+    [list_to_tuple(L) 
+     || L <- ets:match(State#state.idxtab, {idxrec, '_', '$1', Mod, '$2', '_'})].
+
+get_all_vnodes(State) ->
+    Mods = [Mod || {_App, Mod} <- riak_core:vnode_modules()],
+    lists:flatmap(fun(Mod) -> get_all_vnodes(Mod, State) end, Mods).
+
+get_all_vnodes(Mod, State) ->
+    try get_all_index_pid(Mod, State) of
+        IdxPids ->
+            [{Mod, Idx, Pid} || {Idx, Pid} <- IdxPids]
+    catch
+        _:_ ->
+            []
+    end.
+
+%% @private
+idx2vnode(Idx, Mod, _State=#state{idxtab=T}) ->
+    case ets:match(T, {idxrec, {Idx,Mod}, Idx, Mod, '$1', '_'}) of
+        [[VNodePid]] -> VNodePid;
+        [] -> no_match
+    end.
+
+%% @private
+delmon(MonRef, _State=#state{idxtab=T}) ->
+    ets:match_delete(T, {idxrec, '_', '_', '_', '_', MonRef}).
+
+%% @private
+add_vnode_rec(I,  _State=#state{idxtab=T}) -> ets:insert(T,I).
+
+%% @private
+get_vnode(Idx, Mod, State) ->
+    case idx2vnode(Idx, Mod, State) of
+        no_match ->
+            {ok, Pid} = riak_core_vnode_sup:start_vnode(Mod, Idx),
+            MonRef = erlang:monitor(process, Pid),
+            add_vnode_rec(#idxrec{key={Idx,Mod},idx=Idx,mod=Mod,pid=Pid,
+                                  monref=MonRef}, State),
+            Pid;
+        X -> X
+    end.

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -110,10 +110,11 @@ find_vnodes(State) ->
                             <- supervisor:which_children(riak_core_vnode_sup)],
     IdxTable = ets:new(ets_vnodes, [{keypos, 2}]),
 
-    %% In case this the vnode master is being restarted, scan the existing
-    %% vnode children and work out which module and index they are responsible
-    %% for.  During startup it is possible that these vnodes may be shutting
-    %% down as we check them if there are several types of vnodes active.
+    %% If the vnode manager is being restarted, scan the existing
+    %% vnode children and work out which module and index they are
+    %% responsible for.  During startup it is possible that these
+    %% vnodes may be shutting down as we check them if there are
+    %% several types of vnodes active.
     PidIdxs = lists:flatten(
                 [try
                      [{Pid, riak_core_vnode:get_mod_index(Pid)}]

--- a/src/riak_core_vnode_proxy.erl
+++ b/src/riak_core_vnode_proxy.erl
@@ -1,0 +1,115 @@
+%% -------------------------------------------------------------------
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_vnode_proxy).
+-export([start_link/2, init/1, reg_name/2, reg_name/3, call/2, cast/2,
+         unregister_vnode/2, command_return_vnode/2]).
+-export([system_continue/3, system_terminate/4, system_code_change/4]).
+
+-record(state, {mod, index, vnode_pid, vnode_mref}).
+
+reg_name(Mod, Index) ->
+    list_to_atom(lists:flatten(io_lib:format("proxy_~s_~b", [Mod, Index]))).
+
+reg_name(Mod, Index, Node) ->
+    {reg_name(Mod, Index), Node}.
+
+start_link(Mod, Index) ->
+    RegName = reg_name(Mod, Index),
+    proc_lib:start_link(?MODULE, init, [[self(), RegName, Mod, Index]]).
+
+init([Parent, RegName, Mod, Index]) ->
+    erlang:register(RegName, self()),
+    proc_lib:init_ack(Parent, {ok, self()}),
+    State = #state{mod=Mod, index=Index},
+    loop(Parent, State).
+
+unregister_vnode(Mod, Index) ->
+    call(reg_name(Mod, Index), unregister_vnode).
+
+command_return_vnode({Mod,Index,Node}, Req) ->
+    call(reg_name(Mod, Index, Node), {return_vnode, Req}).
+
+call(Name, Msg) ->
+    {ok,Res} = (catch gen:call(Name, '$vnode_proxy_call', Msg)),
+    Res.
+
+cast(Name, Msg) ->
+    catch erlang:send(Name, {'$vnode_proxy_cast', Msg}),
+    ok.
+
+system_continue(Parent, _, State) ->
+    loop(Parent, State).
+
+system_terminate(Reason, _Parent, _, _State) ->
+    exit(Reason).
+
+system_code_change(State, _, _, _) ->
+    {ok, State}.
+
+%% @private
+loop(Parent, State) ->
+    receive
+        {'$vnode_proxy_call', From, Msg} ->
+            {reply, Reply, NewState} = handle_call(Msg, From, State),
+            gen:reply(From, Reply),
+            loop(Parent, NewState);
+        {'$vnode_proxy_cast', Msg} ->
+            {noreply, NewState} = handle_cast(Msg, State),
+            loop(Parent, NewState);
+        {'DOWN', _Mref, process, _Pid, _} ->
+            NewState = State#state{vnode_pid=undefined, vnode_mref=undefined},
+            loop(Parent, NewState);
+        {system, From, Msg} ->
+            sys:handle_system_msg(Msg, From, Parent, ?MODULE, [], State);
+        Msg ->
+            {noreply, NewState} = handle_proxy(Msg, State),
+            loop(Parent, NewState)
+    end.
+
+%% @private
+handle_call(unregister_vnode, _From, State) ->
+    catch demonitor(State#state.vnode_mref, [flush]),
+    NewState = State#state{vnode_pid=undefined, vnode_mref=undefined},
+    {reply, ok, NewState};
+handle_call({return_vnode, Req}, _From, State) ->
+    {Pid, NewState} = get_vnode_pid(State),
+    gen_fsm:send_event(Pid, Req),
+    {reply, {ok, Pid}, NewState};
+
+handle_call(_Msg, _From, State) ->
+    {reply, ok, State}.
+
+%% @private
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%% @private
+handle_proxy(Msg, State) ->
+    {Pid, NewState} = get_vnode_pid(State),
+    Pid ! Msg,
+    {noreply, NewState}.
+
+%% @private
+get_vnode_pid(State=#state{mod=Mod, index=Index, vnode_pid=undefined}) ->
+    {ok, Pid} = riak_core_vnode_manager:get_vnode_pid(Index, Mod),
+    Mref = erlang:monitor(process, Pid),
+    NewState = State#state{vnode_pid=Pid, vnode_mref=Mref},
+    {Pid, NewState};
+get_vnode_pid(State=#state{vnode_pid=Pid}) ->
+    {Pid, State}.

--- a/src/riak_core_vnode_proxy.erl
+++ b/src/riak_core_vnode_proxy.erl
@@ -24,7 +24,10 @@
 -record(state, {mod, index, vnode_pid, vnode_mref}).
 
 reg_name(Mod, Index) ->
-    list_to_atom(lists:flatten(io_lib:format("proxy_~s_~b", [Mod, Index]))).
+    ModBin = atom_to_binary(Mod, latin1),
+    IdxBin = list_to_binary(integer_to_list(Index)),
+    AllBin = <<$p,$r,$o,$x,$y,$_, ModBin/binary, $_, IdxBin/binary>>,
+    binary_to_atom(AllBin, latin1).
 
 reg_name(Mod, Index, Node) ->
     {reg_name(Mod, Index), Node}.

--- a/src/riak_core_vnode_proxy_sup.erl
+++ b/src/riak_core_vnode_proxy_sup.erl
@@ -1,0 +1,63 @@
+%% -------------------------------------------------------------------
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_vnode_proxy_sup).
+-behaviour(supervisor).
+-export([start_link/0, init/1]).
+-export([start_proxy/2, stop_proxy/2, start_proxies/1]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    %% Populate supervisor list with proxies for already registered vnode
+    %% modules. Ensures restart of proxies after a crash of this supervisor.
+    Indices = get_indices(),
+    VMods = riak_core:vnode_modules(),
+    Proxies = [proxy_ref(Mod, Index) || {_, Mod} <- VMods,
+                                        Index <- Indices],
+    {ok, {{one_for_one, 5, 10}, Proxies}}.
+
+start_proxy(Mod, Index) ->
+    Ref = proxy_ref(Mod, Index),
+    Pid = case supervisor:start_child(?MODULE, Ref) of
+              {ok, Child} -> Child;
+              {error, {already_started, Child}} -> Child
+          end,
+    Pid.
+
+stop_proxy(Mod, Index) ->
+    supervisor:terminate_child(?MODULE, {Mod, Index}),
+    supervisor:delete_child(?MODULE, {Mod, Index}),
+    ok.
+
+start_proxies(Mod) ->
+    Indices = get_indices(),
+    [start_proxy(Mod, Index) || Index <- Indices],
+    ok.
+
+%% @private
+proxy_ref(Mod, Index) ->
+    {{Mod, Index}, {riak_core_vnode_proxy, start_link, [Mod, Index]},
+     permanent, 5000, worker, [riak_core_vnode_proxy]}.
+
+%% @private
+get_indices() ->
+    {ok, Ring} = riak_core_ring_manager:get_raw_ring(),
+    AllOwners = riak_core_ring:all_owners(Ring),
+    [Idx || {Idx, _} <- AllOwners].

--- a/test/mock_vnode.erl
+++ b/test/mock_vnode.erl
@@ -52,7 +52,6 @@
 
 %% API
 start_vnode(I) ->
-%    io:format("Starting vnode ~p\n", [I]),
     riak_core_vnode_master:start_vnode(I, ?MODULE).
 
 get_index(Preflist) ->


### PR DESCRIPTION
Move vnode spawning and pid tracking logic from riak_core_master to
riak_core_manager. This change sets the stage for future work that will
make the vnodes more pure, with state transitions coordinated by the
vnode manager. A side-effect is that there is now a central process
managing pids for all registered vnode modules, rather than one master
per vnode module.

Add registered and supervised vnode proxy processes. Requests can be
sent directly to a vnode proxy process for a desired node/index/module
and the request will be forwarded to the proper vnode. The proxy process
coordinates with the vnode manager to know the proper pid for routing,
and monitors the vnode pid in order to clean-up on shutdown/crashes. While
vnodes may be spun up and down on demand by the vnode manager, the relevant
proxy processes are always alive and can be counted on for direct routing.

Change riak_core_vnode_master to use the new vnode proxy support in most
cases. All requests that are routed through a vnode master process will
now use the proxy logic to dispatch requests. Likewise, the non-sync API
exposed by the vnode master module no longer routes through the master
itself, but directly dispatches requests to the proxy processes. Sync
commands still route through the master, which then routes through the
proxy in handle_call. A side-effect is that sync commands now require
three local hops (master, proxy, vnode-pid) rather than two (master,
vnode-pid).

A few notes. You need to add {legacy_vnode_routing, false} to the riak_core portion of app.config if you want the direct routing (ie. bypassing vnode_master) behavior. This is necessary for rolling upgrade support. With or with the setting, vnode master will always route through the proxies, but the setting determines if non-sync requests are sent directly to a proxy or first through vnode master (the second case being safe for old nodes that have a vnode master but no proxies). 

The changes effect the underlying vnode behavior of riak_core, so for testing I just went with basho_expect using this branch for stage injection. basho_expect individual node tests seem to pass the same as they do on master (ie. the same tests fail that fail on master for me). The cluster tests are hit or miss. A few failed, but I think it may have been an issue with the stage beam clobbering approach. Re-running with a package containing my changes to test things out.

I'll likely add an automated integration test that monitors trace messages to determine that requests are proxied as desired. For now, I've manually done similar with redbug (monitoring master, manager, and proxy process handle_calls/casts) and everything looks good.
