### PR TITLE
Refactor riak_core vnode management (part 2)

### DIFF
--- a/src/riak_core_gossip.erl
+++ b/src/riak_core_gossip.erl
@@ -37,7 +37,7 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 -export ([distribute_ring/1, send_ring/1, send_ring/2, remove_from_cluster/2,
-          finish_handoff/4, claim_until_balanced/2, random_gossip/1,
+          claim_until_balanced/2, random_gossip/1,
           recursive_gossip/1, random_recursive_gossip/1, rejoin/2,
           gossip_version/0, legacy_gossip/0, legacy_gossip/1]).
 
@@ -79,9 +79,6 @@ start_link() ->
 
 stop() ->
     gen_server:cast(?MODULE, stop).
-
-finish_handoff(Idx, Prev, New, Mod) ->
-    gen_server:call(?MODULE, {finish_handoff, Idx, Prev, New, Mod}, infinity).
 
 rejoin(Node, Ring) ->
     gen_server:cast({?MODULE, Node}, {rejoin, Ring}).
@@ -137,7 +134,6 @@ random_recursive_gossip(Ring) ->
 
 %% @private
 init(_State) ->
-    schedule_next_gossip(),
     schedule_next_reset(),
     {ok, Ring} = riak_core_ring_manager:get_raw_ring(),
     {Tokens, _} = app_helper:get_env(riak_core, gossip_limit, ?DEFAULT_LIMIT),
@@ -145,35 +141,6 @@ init(_State) ->
                                   #state{gossip_versions=orddict:new(),
                                          gossip_tokens=Tokens}),
     {ok, State}.
-
-
-%% @private
-handle_call({finish_handoff, Idx, Prev, New, Mod}, _From, State) ->
-    {ok, Ring} = riak_core_ring_manager:get_raw_ring(),
-    Owner = riak_core_ring:index_owner(Ring, Idx),
-    {_, NextOwner, Status} = riak_core_ring:next_owner(Ring, Idx, Mod),
-    NewStatus = riak_core_ring:member_status(Ring, New),
-
-    case {Owner, NextOwner, NewStatus, Status} of
-        {_, _, invalid, _} ->
-            %% Handing off to invalid node, don't give-up data.
-            {reply, continue, State};
-        {Prev, New, _, awaiting} ->
-            riak_core_ring_manager:ring_trans(
-              fun(Ring2, _) -> 
-                      Ring3 = riak_core_ring:handoff_complete(Ring2, Idx, Mod),
-                      {new_ring, Ring3}
-              end, []),
-            {reply, forward, State};
-        {Prev, New, _, complete} ->
-            %% Do nothing
-            {reply, continue, State};
-        {Prev, _, _, _} ->
-            %% Handoff wasn't to node that is scheduled in next, so no change.
-            {reply, continue, State};
-        {_, _, _, _} ->
-            {reply, shutdown, State}
-    end;
 
 handle_call(legacy_gossip, _From, State) ->
     {ok, Ring} = riak_core_ring_manager:get_raw_ring(),
@@ -201,7 +168,6 @@ update_gossip_version(Ring) ->
             Ring2
     end.
 
-   
 known_legacy_gossip(Node, State) ->
     case orddict:find(Node, State#state.gossip_versions) of
         error ->
@@ -272,9 +238,7 @@ rpc_gossip_version(Ring, Node) ->
 handle_cast({send_ring_to, _Node}, State=#state{gossip_tokens=0}) ->
     %% Out of gossip tokens, ignore the send request
     {noreply, State};
-
 handle_cast({send_ring_to, Node}, State) ->
-    lager:debug("Sending ring to ~p~n", [Node]),
     {ok, MyRing0} = riak_core_ring_manager:get_raw_ring(),
     MyRing = update_gossip_version(MyRing0),
     GossipVsn = case gossip_version() of
@@ -324,23 +288,13 @@ handle_cast({reconcile_ring, RingIn}, State) ->
 
 handle_cast(reset_tokens, State) ->
     schedule_next_reset(),
+    gen_server:cast(?MODULE, gossip_ring),
     {Tokens, _} = app_helper:get_env(riak_core, gossip_limit, ?DEFAULT_LIMIT),
     {noreply, State#state{gossip_tokens=Tokens}};
 
 handle_cast(gossip_ring, State) ->
-    % First, schedule the next round of gossip...
-    schedule_next_gossip(),
-
     % Gossip the ring to some random other node...
     {ok, MyRing} = riak_core_ring_manager:get_raw_ring(),
-
-    %% Ensure vnodes necessary for ownership change are running
-    case riak_core_ring:disowning_indices(MyRing, node()) of
-        [] ->
-            ok;
-        _ ->
-            riak_core_ring_events:force_update()
-    end,
 
     random_gossip(MyRing),
     {noreply, State};
@@ -378,11 +332,6 @@ code_change(_OldVsn, State, _Extra) ->
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
-
-schedule_next_gossip() ->
-    MaxInterval = app_helper:get_env(riak_core, gossip_interval),
-    Interval = random:uniform(MaxInterval),
-    timer:apply_after(Interval, gen_server, cast, [?MODULE, gossip_ring]).
 
 schedule_next_reset() ->
     {_, Reset} = app_helper:get_env(riak_core, gossip_limit, ?DEFAULT_LIMIT),

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -88,8 +88,6 @@ handle_cast({remove_handoff,Hoff={_Mod,_Idx}}, State=#state{handoffs=Hoffs}) ->
 handle_cast({del_exclusion, {Mod, Idx}}, State=#state{excl=Excl}) ->
     {noreply, State#state{excl=ordsets:del_element({Mod, Idx}, Excl)}};
 handle_cast({add_exclusion, {Mod, Idx}}, State=#state{excl=Excl}) ->
-    {ok, Ring} = riak_core_ring_manager:get_raw_ring(),
-    riak_core_ring_events:ring_update(Ring),
     {noreply, State#state{excl=ordsets:add_element({Mod, Idx}, Excl)}}.
 
 handle_info(_Info, State) ->

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -247,6 +247,9 @@ handle_call({ring_trans, Fun, Args}, _From, State=#state{raw_ring=Ring}) ->
             prune_write_notify_ring(NewRing),
             riak_core_gossip:random_recursive_gossip(NewRing),
             {reply, {ok, NewRing}, State#state{raw_ring=NewRing}};
+        {set_only, NewRing} ->
+            prune_write_ring(NewRing),
+            {reply, {ok, NewRing}, State#state{raw_ring=NewRing}};
         {reconciled_ring, NewRing} ->
             prune_write_notify_ring(NewRing),
             riak_core_gossip:recursive_gossip(NewRing),
@@ -382,6 +385,12 @@ prune_write_notify_ring(Ring) ->
     do_write_ringfile(Ring),
     set_ring_global(Ring),
     riak_core_ring_events:ring_update(Ring).
+
+prune_write_ring(Ring) ->
+    riak_core_ring:check_tainted(Ring, "Error: Persisting tainted ring"),
+    riak_core_ring_manager:prune_ringfiles(),
+    do_write_ringfile(Ring),
+    set_ring_global(Ring).
 
 %% ===================================================================
 %% Unit tests

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -380,10 +380,7 @@ set_ring_global(Ring) ->
 
 %% Persist a new ring file, set the global value and notify any listeners
 prune_write_notify_ring(Ring) ->
-    riak_core_ring:check_tainted(Ring, "Error: Persisting tainted ring"),
-    riak_core_ring_manager:prune_ringfiles(),
-    do_write_ringfile(Ring),
-    set_ring_global(Ring),
+    prune_write_ring(Ring),
     riak_core_ring_events:ring_update(Ring).
 
 prune_write_ring(Ring) ->

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -385,6 +385,11 @@ finish_handoff(State=#state{mod=Mod,
                                  forward=HN})
     end.
 
+handle_event({set_forwarding, undefined}, _StateName,
+             State=#state{modstate={deleted, _ModState}}) ->
+    %% The vnode must forward requests when in the deleted state, therefore
+    %% ignore requests to stop forwarding.
+    continue(State);
 handle_event({set_forwarding, ForwardTo}, _StateName, State) ->
     lager:debug("vnode fwd :: ~p/~p :: ~p -> ~p~n",
                 [State#state.mod, State#state.index, State#state.forward, ForwardTo]),

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -20,8 +20,8 @@
 -behaviour(gen_fsm).
 -include_lib("riak_core_vnode.hrl").
 -export([behaviour_info/1]).
--export([start_link/2,
-         start_link/3,
+-export([start_link/3,
+         start_link/4,
          send_command/2,
          send_command_after/2]).
 -export([init/1,
@@ -34,8 +34,8 @@
          code_change/4]).
 -export([reply/2]).
 -export([get_mod_index/1,
-         update_forwarding/2,
-         trigger_handoff/1]).
+         set_forwarding/2,
+         trigger_handoff/2]).
 
 -spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
 behaviour_info(callbacks) ->
@@ -90,13 +90,15 @@ behaviour_info(_Other) ->
           handoff_node=none :: none | node(),
           handoff_pid :: pid(),
           pool_pid :: pid() | undefined,
+          event_timer :: reference(),
           inactivity_timeout}).
 
-start_link(Mod, Index) ->
-    start_link(Mod, Index, 0).
+start_link(Mod, Index, Forward) ->
+    start_link(Mod, Index, 0, Forward).
 
-start_link(Mod, Index, InitialInactivityTimeout) ->
-    gen_fsm:start_link(?MODULE, [Mod, Index, InitialInactivityTimeout], []).
+start_link(Mod, Index, InitialInactivityTimeout, Forward) ->
+    gen_fsm:start_link(?MODULE,
+                       [Mod, Index, InitialInactivityTimeout, Forward], []).
 
 %% Send a command message for the vnode module by Pid -
 %% typically to do some deferred processing after returning yourself
@@ -111,7 +113,7 @@ send_command_after(Time, Request) ->
     gen_fsm:send_event_after(Time, ?VNODE_REQ{request=Request}).
 
 
-init([Mod, Index, InitialInactivityTimeout]) ->
+init([Mod, Index, InitialInactivityTimeout, Forward]) ->
     %%TODO: Should init args really be an array if it just gets Init?
     process_flag(trap_exit, true),
     {ModState, Props} = case Mod:init([Index]) of
@@ -129,20 +131,19 @@ init([Mod, Index, InitialInactivityTimeout]) ->
     end,
     riak_core_handoff_manager:remove_exclusion(Mod, Index),
     Timeout = app_helper:get_env(riak_core, vnode_inactivity_timeout, ?DEFAULT_TIMEOUT),
-    {ok, Ring} = riak_core_ring_manager:get_raw_ring(),
-    State = #state{index=Index, mod=Mod, modstate=ModState,
+    State = #state{index=Index, mod=Mod, modstate=ModState, forward=Forward,
                    inactivity_timeout=Timeout, pool_pid=PoolPid},
-    State2 = update_forwarding_mode(Ring, State),
-    {ok, active, State2, InitialInactivityTimeout}.
+    lager:debug("vnode :: ~p/~p :: ~p~n", [Mod, Index, Forward]),
+    {ok, active, State, InitialInactivityTimeout}.
 
 get_mod_index(VNode) ->
     gen_fsm:sync_send_all_state_event(VNode, get_mod_index).
 
-update_forwarding(VNode, Ring) ->
-    gen_fsm:send_all_state_event(VNode, {update_forwarding, Ring}).
+set_forwarding(VNode, ForwardTo) ->
+    gen_fsm:send_all_state_event(VNode, {set_forwarding, ForwardTo}).
 
-trigger_handoff(VNode) ->
-    gen_fsm:send_all_state_event(VNode, trigger_handoff).
+trigger_handoff(VNode, TargetNode) ->
+    gen_fsm:send_all_state_event(VNode, {trigger_handoff, TargetNode}).
 
 continue(State) ->
     {next_state, active, State, State#state.inactivity_timeout}.
@@ -170,22 +171,6 @@ continue(State, NewModState) ->
 %% new owner, or simply because the ring has yet to converge on the new owner.
 %% In the forwarding state, all vnode commands and coverage commands are
 %% forwarded to the new owner for processing.
-
-update_forwarding_mode(_Ring, State=#state{modstate={deleted, _ModState}}) ->
-    %% awaiting unregistered message from the vnode master.  The
-    %% vnode has been deleted so cannot handle messages even if
-    %% we wanted to.
-    State;
-update_forwarding_mode(Ring, State=#state{index=Index, mod=Mod}) ->
-    Node = node(),
-    case riak_core_ring:next_owner(Ring, Index, Mod) of
-        {Node, NextOwner, complete} ->
-            riak_core_vnode_manager:set_not_forwarding(self(), false),
-            State#state{forward=NextOwner};
-        _ ->
-            riak_core_vnode_manager:set_not_forwarding(self(), true),
-            State#state{forward=undefined}
-    end.
 
 vnode_command(Sender, Request, State=#state{index=Index,
                                             mod=Mod,
@@ -278,8 +263,9 @@ vnode_handoff_command(Sender, Request, State=#state{index=Index,
             {stop, Reason, State#state{modstate=NewModState}}
     end.
 
-active(timeout, State) ->
-    maybe_handoff(State);
+active(timeout, State=#state{mod=Mod, index=Idx}) ->
+    riak_core_vnode_manager:vnode_event(Mod, Idx, self(), inactive),
+    continue(State);
 active(?COVERAGE_REQ{keyspaces=KeySpaces,
                      request=Request,
                      sender=Sender}, State) ->
@@ -290,28 +276,23 @@ active(?VNODE_REQ{sender=Sender, request=Request},
     vnode_command(Sender, Request, State);
 active(?VNODE_REQ{sender=Sender, request=Request},State) ->
     vnode_handoff_command(Sender, Request, State);
-active(handoff_complete, State=#state{mod=Mod,
-                                      modstate=ModState,
-                                      index=Idx,
-                                      handoff_node=HN,
+active(handoff_complete, State=#state{mod=Mod, 
+                                      index=Idx, 
                                       handoff_token=HT}) ->
     riak_core_handoff_manager:release_handoff_lock({Mod, Idx}, HT),
-    Mod:handoff_finished(HN, ModState),
-    finish_handoff(State);
-active({handoff_error, _Err, _Reason}, State=#state{mod=Mod,
-                                                    modstate=ModState,
-                                                    index=Idx,
+    State2 = start_event_timer(handoff_complete, State),
+    continue(State2);
+active({handoff_error, _Err, _Reason}, State=#state{mod=Mod, 
+                                                    index=Idx, 
                                                     handoff_token=HT}) ->
     riak_core_handoff_manager:release_handoff_lock({Mod, Idx}, HT),
-    %% it would be nice to pass {Err, Reason} to the vnode but the
-    %% API doesn't currently allow for that.
-    Mod:handoff_cancelled(ModState),
-    continue(State#state{handoff_node=none});
-active({update_forwarding, Ring}, State) ->
-    NewState = update_forwarding_mode(Ring, State),
-    continue(NewState);
-active(trigger_handoff, State) ->
-     maybe_handoff(State);
+    State2 = start_event_timer(handoff_error, State),
+    continue(State2);
+active({send_event, Event}, State) ->
+    State2 = start_event_timer(Event, State),
+    continue(State2);
+active({trigger_handoff, TargetNode}, State) ->
+     maybe_handoff(State, TargetNode);
 active(unregistered, State=#state{mod=Mod, index=Index}) ->
     %% Add exclusion so the ring handler will not try to spin this vnode
     %% up until it receives traffic.
@@ -326,12 +307,58 @@ active(_Event, _From, State) ->
     Reply = ok,
     {reply, Reply, active, State, State#state.inactivity_timeout}.
 
+mark_handoff_complete(Idx, Prev, New, Mod) ->
+    Result = riak_core_ring_manager:ring_trans(
+      fun(Ring, _) ->
+              Owner = riak_core_ring:index_owner(Ring, Idx),
+              {_, NextOwner, Status} = riak_core_ring:next_owner(Ring, Idx, Mod),
+              NewStatus = riak_core_ring:member_status(Ring, New),
+
+              case {Owner, NextOwner, NewStatus, Status} of
+                  {Prev, New, _, awaiting} ->
+                      Ring2 = riak_core_ring:handoff_complete(Ring, Idx, Mod),
+                      %% Optimization. Only alter the local ring without
+                      %% triggering a gossip, thus implicitly coalescing
+                      %% multiple vnode handoff completion events. In the
+                      %% future we should decouple vnode handoff state from
+                      %% the ring structure in order to make gossip independent
+                      %% of ring size.
+                      {set_only, Ring2};
+                  _ ->
+                      ignore
+              end
+      end, []),
+
+    case Result of
+        {ok, NewRing} ->
+            NewRing = NewRing;
+        _ ->
+            {ok, NewRing} = riak_core_ring_manager:get_my_ring()
+    end,
+
+    Owner = riak_core_ring:index_owner(NewRing, Idx),
+    {_, NextOwner, Status} = riak_core_ring:next_owner(NewRing, Idx, Mod),
+    NewStatus = riak_core_ring:member_status(NewRing, New),
+
+    case {Owner, NextOwner, NewStatus, Status} of
+        {_, _, invalid, _} ->
+            %% Handing off to invalid node, don't give-up data.
+            continue;
+        {Prev, New, _, _} ->
+            forward;
+        {Prev, _, _, _} ->
+            %% Handoff wasn't to node that is scheduled in next, so no change.
+            continue;
+        {_, _, _, _} ->
+            shutdown
+    end.
+
 finish_handoff(State=#state{mod=Mod,
                             modstate=ModState,
                             index=Idx,
                             handoff_node=HN,
                             pool_pid=Pool}) ->
-    case riak_core_gossip:finish_handoff(Idx, node(), HN, Mod) of
+    case mark_handoff_complete(Idx, node(), HN, Mod) of
         continue ->
             continue(State#state{handoff_node=none});
         Res when Res == forward; Res == shutdown ->
@@ -350,16 +377,42 @@ finish_handoff(State=#state{mod=Mod,
             lager:debug("~p ~p vnode finished handoff and deleted.",
                         [Idx, Mod]),
             riak_core_handoff_manager:remove_handoff(Mod, Idx),
-            riak_core_vnode_master:unregister_vnode(Idx, Mod),
-            riak_core_vnode_manager:set_not_forwarding(self(), false),
+            riak_core_vnode_manager:unregister_vnode(Idx, Mod),
+            lager:debug("vnode hn/fwd :: ~p/~p :: ~p -> ~p~n",
+                        [State#state.mod, State#state.index, State#state.forward, HN]),
             continue(State#state{modstate={deleted,NewModState}, % like to fail if used
                                  handoff_node=none,
                                  forward=HN})
     end.
 
-handle_event(R={update_forwarding, _Ring}, _StateName, State) ->
-    active(R, State);
-handle_event(R=trigger_handoff, _StateName, State) ->
+handle_event({set_forwarding, ForwardTo}, _StateName, State) ->
+    lager:debug("vnode fwd :: ~p/~p :: ~p -> ~p~n",
+                [State#state.mod, State#state.index, State#state.forward, ForwardTo]),
+    continue(State#state{forward=ForwardTo});
+handle_event(finish_handoff, _StateName, State=#state{mod=Mod,
+                                                      modstate=ModState,
+                                                      handoff_node=HN}) ->
+    stop_event_timer(State),
+    case HN of
+        none ->
+            continue(State);
+        _ ->
+            Mod:handoff_finished(HN, ModState),
+            finish_handoff(State)
+    end;
+handle_event(cancel_handoff, _StateName, State=#state{mod=Mod,
+                                                      modstate=ModState}) ->
+    %% it would be nice to pass {Err, Reason} to the vnode but the 
+    %% API doesn't currently allow for that.
+    stop_event_timer(State),
+    case State#state.handoff_node of
+        none ->
+            continue(State);
+        _ ->
+            Mod:handoff_cancelled(ModState),
+            continue(State#state{handoff_node=none})
+    end;
+handle_event(R={trigger_handoff, _TargetNode}, _StateName, State) ->
     active(R, State);
 handle_event(R=?VNODE_REQ{}, _StateName, State) ->
     active(R, State);
@@ -461,56 +514,18 @@ terminate(Reason, _StateName, #state{mod=Mod, modstate=ModState,
 code_change(_OldVsn, StateName, State, _Extra) ->
     {ok, StateName, State}.
 
-maybe_handoff(State=#state{modstate={deleted, _}}) ->
+maybe_handoff(State=#state{modstate={deleted, _}}, _TargetNode) ->
     %% Modstate has been deleted, waiting for unregistered.  No handoff.
     continue(State);
-maybe_handoff(State=#state{mod=Mod, modstate=ModState}) ->
-    case should_handoff(State) of
-        {true, TargetNode} ->
-            case Mod:handoff_starting(TargetNode, ModState) of
-                {true, NewModState} ->
-                    start_handoff(State#state{modstate=NewModState}, TargetNode);
-                {false, NewModState} ->
-                    continue(State, NewModState)
-            end;
-        false ->
-            continue(State)
-    end.
-
-should_handoff(#state{handoff_node=HN}) when HN /= none ->
+maybe_handoff(State=#state{handoff_node=HN}, _TargetNode) when HN /= none ->
     %% Already handing off
-    false;
-should_handoff(#state{index=Idx, mod=Mod}) ->
-    {ok, Ring} = riak_core_ring_manager:get_raw_ring(),
-    Me = node(),
-    {_, NextOwner, _} = riak_core_ring:next_owner(Ring, Idx),
-    Owner = riak_core_ring:index_owner(Ring, Idx),
-    Ready = riak_core_ring:ring_ready(Ring),
-    TargetNode = case {Ready, Owner, NextOwner} of
-                     {_, _, Me} ->
-                         Me;
-                     {_, Me, undefined} ->
-                         Me;
-                     {true, Me, _} ->
-                         NextOwner;
-                     {_, _, undefined} ->
-                         Owner;
-                     {_, _, _} ->
-                         Me
-                 end,
-    case TargetNode of
-        Me ->
-            false;
-        _ ->
-            case app_for_vnode_module(Mod) of
-                undefined -> false;
-                {ok, App} ->
-                    case lists:member(TargetNode,
-                                      riak_core_node_watcher:nodes(App)) of
-                        false  -> false;
-                        true -> {true, TargetNode}
-                    end
-            end
+    continue(State);
+maybe_handoff(State=#state{mod=Mod, modstate=ModState}, TargetNode) ->
+    case Mod:handoff_starting(TargetNode, ModState) of
+        {true, NewModState} ->
+            start_handoff(State#state{modstate=NewModState}, TargetNode);
+        {false, NewModState} ->
+            continue(State, NewModState)
     end.
 
 start_handoff(State=#state{index=Idx, mod=Mod, modstate=ModState}, TargetNode) ->
@@ -555,14 +570,21 @@ reply({raw, Ref, From}, Reply) ->
 reply(ignore, _Reply) ->
     ok.
 
-app_for_vnode_module(Mod) when is_atom(Mod) ->
-    case application:get_env(riak_core, vnode_modules) of
-        {ok, Mods} ->
-            case lists:keysearch(Mod, 2, Mods) of
-                {value, {App, Mod}} ->
-                    {ok, App};
-                false ->
-                    undefined
-            end;
-        undefined -> undefined
-    end.
+%% Individual vnode processes and the vnode manager are tightly coupled. When
+%% vnode events occur, the vnode must ensure that the events are forwarded to
+%% the vnode manager, which will make a state change decision and send an
+%% appropriate message back to the vnode. To minimize blocking, asynchronous
+%% messaging is used. It is possible for the vnode manager to crash and miss
+%% messages sent by the vnode. Therefore, the vnode periodically resends event
+%% messages until an appropriate message is received back from the vnode
+%% manager. The event timer functions below implement this logic.
+start_event_timer(Event, State=#state{mod=Mod, index=Idx}) ->
+    riak_core_vnode_manager:vnode_event(Mod, Idx, self(), Event),
+    stop_event_timer(State),
+    T2 = gen_fsm:send_event_after(30000, {send_event, Event}),
+    State#state{event_timer=T2}.
+
+stop_event_timer(#state{event_timer=undefined}) ->
+    ok;
+stop_event_timer(#state{event_timer=T}) ->
+    gen_fsm:cancel_timer(T).

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -162,8 +162,7 @@ handle_cast({Partition, Mod, start_vnode}, State) ->
     {noreply, State};
 handle_cast({unregister, Index, Mod, Pid}, #state{idxtab=T} = State) ->
     ets:match_delete(T, {idxrec, {Index, Mod}, Index, Mod, Pid, '_'}),
-    riak_core_vnode_proxy:unregister_vnode(Mod, Index),
-    gen_fsm:send_event(Pid, unregistered),
+    riak_core_vnode_proxy:unregister_vnode(Mod, Index, Pid),
     {noreply, State};
 handle_cast({vnode_event, Mod, Idx, Pid, Event}, State) ->
     handle_vnode_event(Event, Mod, Idx, Pid, State);

--- a/src/riak_core_vnode_master.erl
+++ b/src/riak_core_vnode_master.erl
@@ -31,7 +31,7 @@
          command_return_vnode/4,
          sync_command/4,
          sync_spawn_command/3, make_request/3,
-         make_coverage_request/4, reg_name/1]).
+         make_coverage_request/4, all_nodes/1, reg_name/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
 	 terminate/2, code_change/3]).
 -record(state, {idxtab, sup_name, vnode_mod, legacy}).
@@ -136,6 +136,15 @@ make_coverage_request(Request, KeySpaces, Sender, Index) ->
                           keyspaces=KeySpaces,
                           sender=Sender,
                           request=Request}.
+
+%% Request a list of Pids for all vnodes
+%% @deprecated
+%% Provided for compatibility with older vnode master API. New code should
+%% use riak_core_vnode_manager:all_vnode/1 which returns a mod/index/pid
+%% list rather than just a pid list.
+all_nodes(VNodeMod) ->
+    VNodes = riak_core_vnode_manager:all_vnodes(VNodeMod),
+    [Pid || {_Mod, _Idx, Pid} <- VNodes].
 
 %% @private
 init([VNodeMod, LegacyMod, _RegName]) ->

--- a/src/riak_core_vnode_proxy.erl
+++ b/src/riak_core_vnode_proxy.erl
@@ -17,7 +17,7 @@
 %%
 %% -------------------------------------------------------------------
 -module(riak_core_vnode_proxy).
--export([start_link/2, init/1, reg_name/2, reg_name/3, call/2, cast/2,
+-export([start_link/2, init/1, reg_name/2, reg_name/3, call/2, call/3, cast/2,
          unregister_vnode/2, command_return_vnode/2]).
 -export([system_continue/3, system_terminate/4, system_code_change/4]).
 
@@ -43,13 +43,17 @@ init([Parent, RegName, Mod, Index]) ->
     loop(Parent, State).
 
 unregister_vnode(Mod, Index) ->
-    call(reg_name(Mod, Index), unregister_vnode).
+    call(reg_name(Mod, Index), unregister_vnode, infinity).
 
 command_return_vnode({Mod,Index,Node}, Req) ->
     call(reg_name(Mod, Index, Node), {return_vnode, Req}).
 
 call(Name, Msg) ->
     {ok,Res} = (catch gen:call(Name, '$vnode_proxy_call', Msg)),
+    Res.
+
+call(Name, Msg, Timeout) ->
+    {ok,Res} = (catch gen:call(Name, '$vnode_proxy_call', Msg, Timeout)),
     Res.
 
 cast(Name, Msg) ->

--- a/src/riak_core_vnode_sup.erl
+++ b/src/riak_core_vnode_sup.erl
@@ -25,10 +25,10 @@
 -module(riak_core_vnode_sup).
 -behaviour(supervisor).
 -export([start_link/0, init/1]).
--export([start_vnode/2]).
+-export([start_vnode/3]).
 
-start_vnode(Mod, Index) when is_integer(Index) -> 
-    supervisor_pre_r14b04:start_child(?MODULE, [Mod, Index]).
+start_vnode(Mod, Index, ForwardTo) when is_integer(Index) -> 
+    supervisor_pre_r14b04:start_child(?MODULE, [Mod, Index, ForwardTo]).
 
 start_link() ->
     %% We use a custom copy of the supervisor module that is expected to be


### PR DESCRIPTION
Move forwarding and handoff decisions from individual vnode processes
and into the vnode manager. The vnode manager makes handoff and
forwarding decisions whenever the ring changes, and triggers vnode
state changes as appropriate.

Rewrite the logic by which per vnode handoff is marked as complete in
the ring. In particular, move the logic from riak_core_gossip and into
riak_core_vnode. The underlying ring changes are still serialized by
riak_core_ring_manager through the ring_trans function.

Change gossip throttling logic to trigger gossip whenever gossip tokens
reset, replacing the gossip interval approach.

Perform various tuning and additional minor changes that improve cluster
operation during a heavy gossip spike.

The app.config settings and notes from part 1 of the vnode manager rewrite still apply here:
https://github.com/basho/riak_core/pull/106

Changes tested manually along with basho_bench and basho_expect. Need to work on comprehensive integration tests for both part 1 and part 2 of this work. Will work on that alongside code review.
