### PR TITLE
Synchronous VNode Startup (AZ1011)

### DIFF
--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -22,7 +22,7 @@
 -module(riak_core).
 -export([stop/0, stop/1, join/1, join/4, remove/1, down/1, leave/0,
          remove_from_cluster/1]).
--export([register_vnode_module/1, vnode_modules/0]).
+-export([vnode_modules/0]).
 -export([register/1, register/2, bucket_fixups/0]).
 -export([add_guarded_event_handler/3, add_guarded_event_handler/4]).
 -export([delete_guarded_event_handler/3]).
@@ -296,9 +296,6 @@ register(App, [{bucket_fixup, FixupMod}|T]) ->
 register(App, [{vnode_module, VNodeMod}|T]) ->
     register_mod(get_app(App, VNodeMod), VNodeMod, vnode_modules),
     register(App, T).
-
-register_vnode_module(VNodeMod) when is_atom(VNodeMod)  ->
-    register_mod(get_app(undefined, VNodeMod), VNodeMod, vnode_modules).
 
 register_mod(App, Module, Type) when is_atom(Module), is_atom(Type) ->
     case application:get_env(riak_core, Type) of

--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -364,7 +364,10 @@ wait_for_application(App) ->
     wait_for_application(App, 0).
 wait_for_application(App, Elapsed) ->
     case lists:keymember(App, 1, application:which_applications()) of
-        true ->
+        true when Elapsed == 0 ->
+            ok;
+        true when Elapsed > 0 ->
+            lager:info("Wait complete for application ~p (~p seconds)", [App, Elapsed div 1000]),
             ok;
         false ->
             %% Possibly print a notice.
@@ -381,7 +384,10 @@ wait_for_service(Service) ->
     wait_for_service(Service, 0).
 wait_for_service(Service, Elapsed) ->
     case lists:member(Service, riak_core_node_watcher:services(node())) of
-        true ->
+        true when Elapsed == 0 ->
+            ok;
+        true when Elapsed > 0 ->
+            lager:info("Wait complete for service ~p (~p seconds)", [Service, Elapsed div 1000]),
             ok;
         false ->
             %% Possibly print a notice.

--- a/src/riak_core_ring_handler.erl
+++ b/src/riak_core_ring_handler.erl
@@ -120,7 +120,7 @@ ensure_vnodes_started({App,Mod}, Ring) ->
                        end,
 
                        %% Let the app finish starting...
-                       case wait_for_app(App, 1000, 100) of
+                       case riak_core:wait_for_application(App) of
                            ok ->
                                %% Start the vnodes.
                                [Mod:start_vnode(I) || I <- Startable],
@@ -157,15 +157,4 @@ startable_vnodes(Mod, Ring) ->
                 RO ->
                     [RO | riak_core_ring:my_indices(Ring)]
             end
-    end.
-
-wait_for_app(App, 0, _) ->
-    {error, {timeout, App}};
-wait_for_app(App, Count, Sleep) ->
-    case lists:keymember(App, 1, application:which_applications()) of
-        true ->
-            ok;
-        false ->
-            timer:sleep(Sleep),
-            wait_for_app(App, Count - 1, Sleep)
     end.

--- a/src/riak_core_ring_handler.erl
+++ b/src/riak_core_ring_handler.erl
@@ -114,15 +114,29 @@ ensure_vnodes_started({App,Mod}, Ring) ->
                        RegName = list_to_atom(
                                    "riak_core_ring_handler_ensure_"
                                    ++ atom_to_list(Mod)),
-                       try register(RegName, self())
+                       try erlang:register(RegName, self())
                        catch error:badarg ->
                                exit(normal)
                        end,
-                       wait_for_app(App, 100, 100),
-                       [Mod:start_vnode(I) || I <- Startable],
-                       exit(normal)
+
+                       %% Let the app finish starting...
+                       case wait_for_app(App, 1000, 100) of
+                           ok ->
+                               %% Start the vnodes.
+                               [Mod:start_vnode(I) || I <- Startable],
+
+                               %% Mark the service as up.
+                               SupName = list_to_atom(atom_to_list(App) ++ "_sup"),
+                               SupPid = erlang:whereis(SupName),
+                               riak_core_node_watcher:service_up(App, SupPid),
+                               exit(normal);
+                           {error, Reason} ->
+                               lager:critical("Failed to start application: ~p", [App]),
+                               throw({error, Reason})
+                       end
                end),
     Startable.
+
 
 startable_vnodes(Mod, Ring) ->
     AllMembers = riak_core_ring:all_members(Ring),
@@ -145,8 +159,8 @@ startable_vnodes(Mod, Ring) ->
             end
     end.
 
-wait_for_app(_, 0, _) ->
-    bummer;
+wait_for_app(App, 0, _) ->
+    {error, {timeout, App}};
 wait_for_app(App, Count, Sleep) ->
     case lists:keymember(App, 1, application:which_applications()) of
         true ->

--- a/src/riak_core_sup.erl
+++ b/src/riak_core_sup.erl
@@ -31,7 +31,7 @@
 -export([init/1]).
 
 %% Helper macro for declaring children of supervisor
--define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 5000, Type, [I]}).
+-define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 305000, Type, [I]}).
 -define (IF (Bool, A, B), if Bool -> A; true -> B end).
 
 %% ===================================================================

--- a/src/riak_core_sup.erl
+++ b/src/riak_core_sup.erl
@@ -31,7 +31,8 @@
 -export([init/1]).
 
 %% Helper macro for declaring children of supervisor
--define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 305000, Type, [I]}).
+-define(CHILD(I, Type, Timeout), {I, {I, start_link, []}, permanent, Timeout, Type, [I]}).
+-define(CHILD(I, Type), ?CHILD(I, Type, 5000)).
 -define (IF (Bool, A, B), if Bool -> A; true -> B end).
 
 %% ===================================================================
@@ -59,7 +60,7 @@ init([]) ->
     Children = lists:flatten(
                  [?CHILD(riak_core_sysmon_minder, worker),
                   ?CHILD(riak_core_stat, worker),
-                  ?CHILD(riak_core_vnode_sup, supervisor),
+                  ?CHILD(riak_core_vnode_sup, supervisor, 305000),
                   ?CHILD(riak_core_eventhandler_sup, supervisor),
                   ?CHILD(riak_core_handoff_manager, worker),
                   ?CHILD(riak_core_handoff_listener, worker),


### PR DESCRIPTION
Fixes regression where a service was declared "up" before all vnodes were started.

This pull request modifies `riak_core_ring_handler:ensure_vnodes_started/N` to add a longer wait for the application to start up, errors if the application fails, starts the vnodes for the application, and then declares the service up.

Depends upon the following pull requests:
- https://github.com/basho/riak_kv/pull/261
- https://github.com/basho/riak_pipe/pull/35
- https://github.com/basho/riak_search/pull/95

p.s. - Yes, this is a dirty, dirty hack. In my opinion, there are issues of complexity and unclear responsibilities in `riak_core_node_watcher`, `riak_core_node_watcher_events`, `riak_core_ring_events`, and `riak_core_ring_handler`. This is due for refactoring.
