### PR TITLE
Handoff manager rework part 2

### DIFF
--- a/include/riak_core_handoff.hrl
+++ b/include/riak_core_handoff.hrl
@@ -1,3 +1,14 @@
+
+-record(handoff, { module        :: atom(),
+                   index         :: integer(),
+                   target_node   :: atom(),
+                   vnode_pid     :: pid(),
+                   sender_pid    :: pid(),
+                   restarts      :: integer(),
+                   timestamp     :: tuple(),
+                   status        :: any()
+                 }).
+
 -define(PT_MSG_INIT, 0).
 -define(PT_MSG_OBJ, 1).
 -define(PT_MSG_OLDSYNC, 2).

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -181,8 +181,10 @@ enqueue_handoff(Mod,Idx,Node,VnodePid,Q) ->
 handoff_concurrency_limit_reached() ->
     Receivers=supervisor:count_children(riak_core_handoff_receiver_sup),
     Senders=supervisor:count_children(riak_core_handoff_sender_sup),
+    ActiveReceivers=proplists:get_value(active,Receivers),
+    ActiveSenders=proplists:get_value(active,Senders),
     Limit=app_helper:get_env(riak_core,handoff_concurrency,1),
-    Limit =< (Receivers + Senders).
+    Limit =< (ActiveReceivers + ActiveSenders).
 
 %% pop a handoff off the queue and start it up
 process_handoff_queue(State) ->

--- a/src/riak_core_handoff_receiver_sup.erl
+++ b/src/riak_core_handoff_receiver_sup.erl
@@ -23,7 +23,8 @@
 
 %% beahvior functions
 -export([start_link/0,
-         init/1
+         init/1,
+         active_receivers/0
         ]).
 
 %% public functions
@@ -45,3 +46,7 @@ init ([]) ->
 %% start a sender process
 start_receiver (SSLOpts) ->
     supervisor:start_child(?MODULE,[SSLOpts]).
+
+%% return the number of active receivers
+active_receivers () ->
+    erlang:length(supervisor:which_children(?MODULE)).

--- a/src/riak_core_handoff_receiver_sup.erl
+++ b/src/riak_core_handoff_receiver_sup.erl
@@ -23,8 +23,7 @@
 
 %% beahvior functions
 -export([start_link/0,
-         init/1,
-         active_receivers/0
+         init/1
         ]).
 
 %% public functions
@@ -46,7 +45,3 @@ init ([]) ->
 %% start a sender process
 start_receiver (SSLOpts) ->
     supervisor:start_child(?MODULE,[SSLOpts]).
-
-%% return the number of active receivers
-active_receivers () ->
-    erlang:length(supervisor:which_children(?MODULE)).

--- a/src/riak_core_handoff_sender_sup.erl
+++ b/src/riak_core_handoff_sender_sup.erl
@@ -28,7 +28,7 @@
         ]).
 
 %% public functions
--export([start_sender/3
+-export([start_sender/4
         ]).
 
 -define(CHILD(I,Type), {I,{I,start_link,[]},temporary,brutal_kill,Type,[I]}).
@@ -44,8 +44,8 @@ init ([]) ->
          ]}}.
 
 %% start a sender process
-start_sender (TargetNode,Module,Partition) ->
-    supervisor:start_child(?MODULE,[TargetNode,Module,Partition,self()]).
+start_sender (VnodePid,TargetNode,Module,Partition) ->
+    supervisor:start_child(?MODULE,[TargetNode,Module,Partition,VnodePid]).
 
 %% return the number of active senders
 active_senders () ->

--- a/src/riak_core_handoff_sender_sup.erl
+++ b/src/riak_core_handoff_sender_sup.erl
@@ -23,8 +23,7 @@
 
 %% beahvior functions
 -export([start_link/0,
-         init/1,
-         active_senders/0
+         init/1
         ]).
 
 %% public functions
@@ -46,7 +45,3 @@ init ([]) ->
 %% start a sender process
 start_sender (VnodePid,TargetNode,Module,Partition) ->
     supervisor:start_child(?MODULE,[TargetNode,Module,Partition,VnodePid]).
-
-%% return the number of active senders
-active_senders () ->
-    erlang:length(supervisor:which_children(?MODULE)).

--- a/src/riak_core_handoff_sender_sup.erl
+++ b/src/riak_core_handoff_sender_sup.erl
@@ -23,7 +23,8 @@
 
 %% beahvior functions
 -export([start_link/0,
-         init/1
+         init/1,
+         active_senders/0
         ]).
 
 %% public functions
@@ -45,3 +46,7 @@ init ([]) ->
 %% start a sender process
 start_sender (TargetNode,Module,Partition) ->
     supervisor:start_child(?MODULE,[TargetNode,Module,Partition,self()]).
+
+%% return the number of active senders
+active_senders () ->
+    erlang:length(supervisor:which_children(?MODULE)).

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -479,6 +479,7 @@ should_handoff(#state{index=Idx, mod=Mod}) ->
                      {_, _, _} ->
                          Me
                  end,
+    lager:info(">>>>> HANDOFF TARGET NODE: ~w (~w)~n", [TargetNode,Me]),
     case TargetNode of
         Me ->
             false;
@@ -488,13 +489,14 @@ should_handoff(#state{index=Idx, mod=Mod}) ->
                 {ok, App} ->
                     case lists:member(TargetNode,
                                       riak_core_node_watcher:nodes(App)) of
-                        false  -> false;
+                        false  -> lager:info(">>>>> FAILED~n"), false;
                         true -> {true, TargetNode}
                     end
             end
     end.
 
 start_handoff(State=#state{index=Idx, mod=Mod, modstate=ModState}, TargetNode) ->
+    lager:info(">>>>> start_handoff~n"),
     case Mod:is_empty(ModState) of
         {true, NewModState} ->
             finish_handoff(State#state{modstate=NewModState,
@@ -502,7 +504,7 @@ start_handoff(State=#state{index=Idx, mod=Mod, modstate=ModState}, TargetNode) -
         {false, NewModState} ->
             NewState = State#state{modstate=NewModState,
                                    handoff_node=TargetNode},
-            ok=riak_core_handoff_manager:add_outbound(Mod, Idx, TargetNode),
+            riak_core_handoff_manager:add_outbound(Mod, Idx, TargetNode),
             continue(NewState)
     end.
 

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -86,9 +86,7 @@ behaviour_info(_Other) ->
           mod :: module(),
           modstate :: term(),
           forward :: node(),
-          handoff_token :: non_neg_integer(),
           handoff_node=none :: none | node(),
-          handoff_pid :: pid(),
           pool_pid :: pid() | undefined,
           inactivity_timeout}).
 
@@ -292,17 +290,11 @@ active(?VNODE_REQ{sender=Sender, request=Request},State) ->
     vnode_handoff_command(Sender, Request, State);
 active(handoff_complete, State=#state{mod=Mod,
                                       modstate=ModState,
-                                      index=Idx,
-                                      handoff_node=HN,
-                                      handoff_token=HT}) ->
-    riak_core_handoff_manager:release_handoff_lock({Mod, Idx}, HT),
+                                      handoff_node=HN}) ->
     Mod:handoff_finished(HN, ModState),
     finish_handoff(State);
 active({handoff_error, _Err, _Reason}, State=#state{mod=Mod,
-                                                    modstate=ModState,
-                                                    index=Idx,
-                                                    handoff_token=HT}) ->
-    riak_core_handoff_manager:release_handoff_lock({Mod, Idx}, HT),
+                                                    modstate=ModState}) ->
     %% it would be nice to pass {Err, Reason} to the vnode but the
     %% API doesn't currently allow for that.
     Mod:handoff_cancelled(ModState),
@@ -319,8 +311,7 @@ active(unregistered, State=#state{mod=Mod, index=Index}) ->
     lager:debug("~p ~p vnode excluded and unregistered.",
                 [Index, Mod]),
     {stop, normal, State#state{handoff_node=none,
-                               pool_pid=undefined,
-                               handoff_pid=undefined}}.
+                               pool_pid=undefined}}.
 
 active(_Event, _From, State) ->
     Reply = ok,
@@ -385,15 +376,6 @@ handle_sync_event({handoff_data,BinObj}, _From, StateName,
              State#state.inactivity_timeout}
     end.
 
-handle_info({'EXIT', Pid, Reason}, _StateName,
-            State=#state{mod=Mod, index=Index, handoff_pid=Pid}) ->
-    case Reason of
-        normal ->
-            ok;
-        _ ->
-            lager:error("~p ~p handoff crashed ~p\n", [Index, Mod, Reason])
-    end,
-    continue(State#state{handoff_pid=undefined});
 handle_info({'EXIT', Pid, Reason}, _StateName,
             State=#state{mod=Mod, index=Index, pool_pid=Pid}) ->
     case Reason of
@@ -518,18 +500,10 @@ start_handoff(State=#state{index=Idx, mod=Mod, modstate=ModState}, TargetNode) -
             finish_handoff(State#state{modstate=NewModState,
                                        handoff_node=TargetNode});
         {false, NewModState} ->
-            case riak_core_handoff_manager:get_handoff_lock({Mod, Idx}) of
-                {error, max_concurrency} ->
-                    {ok, NewModState1} = Mod:handoff_cancelled(NewModState),
-                    NewState = State#state{modstate=NewModState1},
-                    {next_state, active, NewState, ?LOCK_RETRY_TIMEOUT};
-                {ok, {handoff_token, HandoffToken}} ->
-                    NewState = State#state{modstate=NewModState,
-                                           handoff_token=HandoffToken,
-                                           handoff_node=TargetNode},
-                    ok=riak_core_handoff_manager:add_outbound(Mod, Idx, TargetNode),
-                    continue(NewState)
-            end
+            NewState = State#state{modstate=NewModState,
+                                   handoff_node=TargetNode},
+            ok=riak_core_handoff_manager:add_outbound(Mod, Idx, TargetNode),
+            continue(NewState)
     end.
 
 

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -479,7 +479,6 @@ should_handoff(#state{index=Idx, mod=Mod}) ->
                      {_, _, _} ->
                          Me
                  end,
-    lager:info(">>>>> HANDOFF TARGET NODE: ~w (~w)~n", [TargetNode,Me]),
     case TargetNode of
         Me ->
             false;
@@ -489,14 +488,13 @@ should_handoff(#state{index=Idx, mod=Mod}) ->
                 {ok, App} ->
                     case lists:member(TargetNode,
                                       riak_core_node_watcher:nodes(App)) of
-                        false  -> lager:info(">>>>> FAILED~n"), false;
+                        false  -> false;
                         true -> {true, TargetNode}
                     end
             end
     end.
 
 start_handoff(State=#state{index=Idx, mod=Mod, modstate=ModState}, TargetNode) ->
-    lager:info(">>>>> start_handoff~n"),
     case Mod:is_empty(ModState) of
         {true, NewModState} ->
             finish_handoff(State#state{modstate=NewModState,
@@ -504,7 +502,7 @@ start_handoff(State=#state{index=Idx, mod=Mod, modstate=ModState}, TargetNode) -
         {false, NewModState} ->
             NewState = State#state{modstate=NewModState,
                                    handoff_node=TargetNode},
-            riak_core_handoff_manager:add_outbound(Mod, Idx, TargetNode),
+            riak_core_handoff_manager:add_outbound(self(), Mod, Idx, TargetNode),
             continue(NewState)
     end.
 

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -349,7 +349,6 @@ finish_handoff(State=#state{mod=Mod,
             {ok, NewModState} = Mod:delete(ModState),
             lager:debug("~p ~p vnode finished handoff and deleted.",
                         [Idx, Mod]),
-            riak_core_handoff_manager:remove_handoff(Mod, Idx),
             riak_core_vnode_manager:unregister_vnode(Idx, Mod),
             riak_core_vnode_manager:set_not_forwarding(self(), false),
             continue(State#state{modstate={deleted,NewModState}, % like to fail if used
@@ -528,9 +527,8 @@ start_handoff(State=#state{index=Idx, mod=Mod, modstate=ModState}, TargetNode) -
                     NewState = State#state{modstate=NewModState,
                                            handoff_token=HandoffToken,
                                            handoff_node=TargetNode},
-                    {ok, HandoffPid} = riak_core_handoff_sender_sup:start_sender(TargetNode, Mod, Idx),
-                    riak_core_handoff_manager:add_handoff(Mod, Idx, TargetNode),
-                    continue(NewState#state{handoff_pid=HandoffPid})
+                    ok=riak_core_handoff_manager:add_outbound(Mod, Idx, TargetNode),
+                    continue(NewState)
             end
     end.
 


### PR DESCRIPTION
Make the handoff manager responsible for starting handoffs via a queue, limiting the number of active handoffs poassible at one time.
