### PR TITLE
Setting Monitors on Vnode "Sender" Arguments (AZ996)

### DIFF
--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -32,7 +32,8 @@
          handle_info/3,
          terminate/3,
          code_change/4]).
--export([reply/2]).
+-export([reply/2,
+         monitor/1]).
 -export([get_mod_index/1,
          update_forwarding/2,
          trigger_handoff/1]).
@@ -554,6 +555,20 @@ reply({raw, Ref, From}, Reply) ->
     From ! {Ref, Reply};
 reply(ignore, _Reply) ->
     ok.
+
+%% @doc Set up a monitor for the pid named by a {@type sender()} vnode
+%% argument.  If `Sender' was the atom `ignore', this function sets up
+%% a monitor on `self()' in order to return a valid (if useless)
+%% monitor reference.
+-spec monitor(Sender::sender()) -> Monitor::reference().
+monitor({fsm, _, From}) ->
+    erlang:monitor(process, From);
+monitor({server, _, {Pid, _Ref}}) ->
+    erlang:monitor(process, Pid);
+monitor({raw, _, From}) ->
+    erlang:monitor(process, From);
+monitor(ignore) ->
+    erlang:monitor(process, self()).
 
 app_for_vnode_module(Mod) when is_atom(Mod) ->
     case application:get_env(riak_core, vnode_modules) of


### PR DESCRIPTION
Vnodes are passed a `Sender` argument that is of the form `{fsm|server|raw,
X, Y}`. This `monitor/1` function unwraps that structure appropriately and
sets up a monitor on the pid that it names.

This is used by code in the `az996-listkeys-backpressure` branch of riak_kv.
