### PR TITLE
Set default handoff_concurrency to 1

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -100,7 +100,7 @@
          {vnode_inactivity_timeout, 60000},
          
          %% Number of VNodes allowed to do handoff concurrently.
-         {handoff_concurrency, 4},
+         {handoff_concurrency, 1},
 
          %% Disable Nagle on HTTP sockets
          {disable_http_nagle, false},

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -39,7 +39,7 @@ get_exclusions(Module) ->
     gen_server:call(?MODULE, {get_exclusions, Module}, infinity).
 
 get_handoff_lock(LockId) ->
-    TokenCount = app_helper:get_env(riak_core, handoff_concurrency, 4),
+    TokenCount = app_helper:get_env(riak_core, handoff_concurrency, 1),
     get_handoff_lock(LockId, TokenCount).
 
 get_handoff_lock(_LockId, 0) ->


### PR DESCRIPTION
We've found that in extreme load situations our default handoff concurrency,
paired with the fact that, currently, no incoming throttling is done, can cause
the node to become overloaded and the latency to spike.  Rather than have
a potentially harmful default Riak should err on side of safety.
