### PR TITLE
Avoid use of ets:match() in hot code paths

### DIFF
--- a/src/riak_core_node_watcher.erl
+++ b/src/riak_core_node_watcher.erl
@@ -65,13 +65,13 @@ node_down() ->
     gen_server:call(?MODULE, {node_status, down}, infinity).
 
 services() ->
-    ordsets:from_list([Service || [Service] <- ets:match(?MODULE, {{'_', '$1'}, '_'})]).
+    gen_server:call(?MODULE, services, infinity).
 
 services(Node) ->
-    [Service || [Service] <- ets:match(?MODULE, {{Node, '$1'}, '_'})].
+    pubtab_get_services(Node).
 
 nodes(Service) ->
-    [Node || [Node] <- ets:match(?MODULE, {{'$1', Service}, '_'})].
+    pubtab_get_nodes(Service).
 
 
 %% ===================================================================
@@ -151,7 +151,11 @@ handle_call({node_status, Status}, _From, State) ->
              {Status, Status} -> %% noop
                  State
     end,
-    {reply, ok, update_avsn(S2)}.
+    {reply, ok, update_avsn(S2)};
+handle_call(services, _From, State) ->
+    Res = [Service || {{by_service, Service}, Nds} <- ets:tab2list(?MODULE),
+                      Nds /= []],
+    {reply, lists:sort(Res), State}.
 
 
 handle_cast({ring_update, R}, State) ->
@@ -313,8 +317,8 @@ node_down(Node, State) ->
 
 
 node_delete(Node) ->
-    Services = services(Node),
-    ets:match_delete(?MODULE, {{Node, '_'}, '_'}),
+    Services = pubtab_get_services(Node),
+    [pubtab_delete(Node, Service) || Service <- Services],
     ets:delete(?MODULE, Node),
     Services.
 
@@ -327,12 +331,11 @@ node_update(Node, Services) ->
 
     Added     = ordsets:subtract(NewStatus, OldStatus),
     Deleted   = ordsets:subtract(OldStatus, NewStatus),
-    Unchanged = ordsets:intersection(NewStatus, OldStatus),
 
     %% Update ets table with changes; make sure to touch unchanged
     %% service with latest timestamp
-    [ets:delete(?MODULE, {Node, Ss}) || Ss <- Deleted],
-    ets:insert(?MODULE, [{{Node, Ss}, Now} || Ss <- Added ++ Unchanged]),
+    [pubtab_delete(Node, Ss) || Ss <- Deleted],
+    [pubtab_insert(Node, Ss) || Ss <- Added],
 
     %% Keep track of the last time we recv'd data from a node
     ets:insert(?MODULE, {Node, Now}),
@@ -392,3 +395,31 @@ peers_update(NewPeers, State) ->
     %% Broadcast our current status to new peers
     broadcast(Added, State#state { peers = NewPeers }).
 
+pubtab_delete(Node, Service) ->
+    Svcs = pubtab_get_services(Node),
+    ets:insert(?MODULE, {{by_node, Node}, Svcs -- [Service]}),
+    Nds = pubtab_get_nodes(Service),
+    ets:insert(?MODULE, {{by_service, Service}, Nds -- [Node]}).
+
+pubtab_insert(Node, Service) ->
+    %% Remove Service & node before adding: avoid accidental duplicates
+    Svcs = pubtab_get_services(Node) -- [Service],
+    ets:insert(?MODULE, {{by_node, Node}, [Service|Svcs]}),
+    Nds = pubtab_get_nodes(Service) -- [Node],
+    ets:insert(?MODULE, {{by_service, Service}, [Node|Nds]}).
+
+pubtab_get_services(Node) ->
+    case ets:lookup(?MODULE, {by_node, Node}) of
+        [{{by_node, Node}, Ss}] ->
+            Ss;
+        [] ->
+            []
+    end.
+
+pubtab_get_nodes(Service) ->
+    case ets:lookup(?MODULE, {by_service, Service}) of
+        [{{by_service, Service}, Ns}] ->
+            Ns;
+        [] ->
+            []
+    end.

--- a/src/riak_core_vnode_master.erl
+++ b/src/riak_core_vnode_master.erl
@@ -33,7 +33,9 @@
          sync_spawn_command/3, make_request/3,
          make_coverage_request/4,
          unregister_vnode/2, unregister_vnode/3,
-         all_nodes/1, reg_name/1, all_index_pid/1]).
+         all_nodes/1, reg_name/1, all_index_pid/1,
+         %% field debugging
+         get_tab/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
 	 terminate/2, code_change/3]).
 -record(idxrec, {idx, pid, monref}).
@@ -152,6 +154,10 @@ all_index_pid(VNodeMod) ->
     RegName = reg_name(VNodeMod),
     gen_server:call(RegName, all_index_pid, infinity).
 
+get_tab(VNodeMod) ->
+    RegName = reg_name(VNodeMod),
+    gen_server:call(RegName, get_tab, infinity).
+
 %% @private
 init([VNodeMod, LegacyMod, RegName]) ->
     %% Get the current list of vnodes running in the supervisor. We use this
@@ -159,7 +165,7 @@ init([VNodeMod, LegacyMod, RegName]) ->
     %% vnode.
     VnodePids = [Pid || {_, Pid, worker, _}
                             <- supervisor:which_children(riak_core_vnode_sup)],
-    IdxTable = ets:new(RegName, [{keypos, 2}]),
+    IdxTable = ets:new(RegName, [{keypos, 2}, private]),
 
     %% In case this the vnode master is being restarted, scan the existing
     %% vnode children and work out which module and index they are responsible
@@ -229,6 +235,8 @@ handle_call(all_index_pid, _From, State) ->
     Reply = [list_to_tuple(L) 
              || L <- ets:match(State#state.idxtab, {idxrec, '$1', '$2', '_'})],
     {reply, Reply, State};
+handle_call(get_tab, _From, State) ->
+    {reply, ets:tab2list(State#state.idxtab), State};
 handle_call({Partition, get_vnode}, _From, State) ->
     Pid = get_vnode(Partition, State),
     {reply, {ok, Pid}, State};
@@ -253,9 +261,9 @@ code_change(_OldVsn, State, _Extra) ->  {ok, State}.
 
 %% @private
 idx2vnode(Idx, _State=#state{idxtab=T}) ->
-    case ets:match(T, {idxrec, Idx, '$1', '_'}) of
-        [[VNodePid]] -> VNodePid;
-        [] -> no_match
+    case ets:lookup(T, Idx) of
+        [I] -> I#idxrec.pid;
+        []  -> no_match
     end.
 
 %% @private


### PR DESCRIPTION
Profiling with DTrace on Solaris suggests that ets:match() is causing
a much higher than necessary lock contention rate within the Erlang
R14B03 and R14B04 VMs.  Eliminating ets:match() in the riak_core and
riak_kv applications is substantial when using Pthread locking instead
of Ericsson's hand-tuned locking (which is the default).  The results
are more ambiguous when the default locking strategy is used.
