### PR TITLE
AZ1047: Increase default gossip limit for 1.0.3

### DIFF
--- a/src/riak_core_gossip.erl
+++ b/src/riak_core_gossip.erl
@@ -47,8 +47,8 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
-%% Default gossip rate: allow at most 45 gossip messages every 10 seconds
--define(DEFAULT_LIMIT, {45, 10000}).
+%% Set a high default limit to emulate having no limit at all.
+-define(DEFAULT_LIMIT, {1000000, 60000}).
 
 -record(state, {gossip_versions,
                 gossip_tokens}).


### PR DESCRIPTION
Increase the default gossip limit for Riak 1.0.3 to emulate having no limit at all (as was the case in 1.0.2 and earlier). This keeps behavior the same, but gives users the possibility to establish a lower limit if they run into gossip overload conditions. New default allows 1 million gossip messages per minute.
