### PR TITLE
Merge of slf-core-ets-match-replacement + hand-edits onto master.

### DIFF
--- a/src/riak_core_node_watcher.erl
+++ b/src/riak_core_node_watcher.erl
@@ -65,13 +65,13 @@ node_down() ->
     gen_server:call(?MODULE, {node_status, down}, infinity).
 
 services() ->
-    ordsets:from_list([Service || [Service] <- ets:match(?MODULE, {{'_', '$1'}, '_'})]).
+    gen_server:call(?MODULE, services, infinity).
 
 services(Node) ->
-    [Service || [Service] <- ets:match(?MODULE, {{Node, '$1'}, '_'})].
+    pubtab_get_services(Node).
 
 nodes(Service) ->
-    [Node || [Node] <- ets:match(?MODULE, {{'$1', Service}, '_'})].
+    pubtab_get_nodes(Service).
 
 
 %% ===================================================================
@@ -151,7 +151,11 @@ handle_call({node_status, Status}, _From, State) ->
              {Status, Status} -> %% noop
                  State
     end,
-    {reply, ok, update_avsn(S2)}.
+    {reply, ok, update_avsn(S2)};
+handle_call(services, _From, State) ->
+    Res = [Service || {{by_service, Service}, Nds} <- ets:tab2list(?MODULE),
+                      Nds /= []],
+    {reply, lists:sort(Res), State}.
 
 
 handle_cast({ring_update, R}, State) ->
@@ -313,8 +317,8 @@ node_down(Node, State) ->
 
 
 node_delete(Node) ->
-    Services = services(Node),
-    ets:match_delete(?MODULE, {{Node, '_'}, '_'}),
+    Services = pubtab_get_services(Node),
+    [pubtab_delete(Node, Service) || Service <- Services],
     ets:delete(?MODULE, Node),
     Services.
 
@@ -327,12 +331,11 @@ node_update(Node, Services) ->
 
     Added     = ordsets:subtract(NewStatus, OldStatus),
     Deleted   = ordsets:subtract(OldStatus, NewStatus),
-    Unchanged = ordsets:intersection(NewStatus, OldStatus),
 
     %% Update ets table with changes; make sure to touch unchanged
     %% service with latest timestamp
-    [ets:delete(?MODULE, {Node, Ss}) || Ss <- Deleted],
-    ets:insert(?MODULE, [{{Node, Ss}, Now} || Ss <- Added ++ Unchanged]),
+    [pubtab_delete(Node, Ss) || Ss <- Deleted],
+    [pubtab_insert(Node, Ss) || Ss <- Added],
 
     %% Keep track of the last time we recv'd data from a node
     ets:insert(?MODULE, {Node, Now}),
@@ -392,3 +395,31 @@ peers_update(NewPeers, State) ->
     %% Broadcast our current status to new peers
     broadcast(Added, State#state { peers = NewPeers }).
 
+pubtab_delete(Node, Service) ->
+    Svcs = pubtab_get_services(Node),
+    ets:insert(?MODULE, {{by_node, Node}, Svcs -- [Service]}),
+    Nds = pubtab_get_nodes(Service),
+    ets:insert(?MODULE, {{by_service, Service}, Nds -- [Node]}).
+
+pubtab_insert(Node, Service) ->
+    %% Remove Service & node before adding: avoid accidental duplicates
+    Svcs = pubtab_get_services(Node) -- [Service],
+    ets:insert(?MODULE, {{by_node, Node}, [Service|Svcs]}),
+    Nds = pubtab_get_nodes(Service) -- [Node],
+    ets:insert(?MODULE, {{by_service, Service}, [Node|Nds]}).
+
+pubtab_get_services(Node) ->
+    case ets:lookup(?MODULE, {by_node, Node}) of
+        [{{by_node, Node}, Ss}] ->
+            Ss;
+        [] ->
+            []
+    end.
+
+pubtab_get_nodes(Service) ->
+    case ets:lookup(?MODULE, {by_service, Service}) of
+        [{{by_service, Service}, Ns}] ->
+            Ns;
+        [] ->
+            []
+    end.


### PR DESCRIPTION
Avoid use of ets:match() in hot code paths

Profiling with DTrace on Solaris suggests that ets:match() is causing
a much higher than necessary lock contention rate within the Erlang
R14B03 and R14B04 VMs.  Eliminating ets:match() in the riak_core and
riak_kv applications is substantial when using Pthread locking instead
of Ericsson's hand-tuned locking (which is the default).  The results
are more ambiguous when the default locking strategy is used.

Hand-edits were required due to changes in master after the 1.0 branch
was created.
