### PR TITLE
AZ1057: Fix claim algorithm v2 to work when in legacy cluster mode

### DIFF
--- a/src/riak_core_claim.erl
+++ b/src/riak_core_claim.erl
@@ -117,7 +117,8 @@ wants_claim_v1(Ring0, Node) ->
 wants_claim_v2(Ring) ->
     wants_claim_v2(Ring, node()).
 
-wants_claim_v2(Ring, Node) ->
+wants_claim_v2(RingIn, Node) ->
+    Ring = riak_core_ring:upgrade(RingIn),
     Active = riak_core_ring:claiming_members(Ring),
     Owners = riak_core_ring:all_owners(Ring),
     Counts = get_counts(Active, Owners),
@@ -155,7 +156,8 @@ choose_claim_v1(Ring0, Node) ->
 choose_claim_v2(Ring) ->
     choose_claim_v2(Ring, node()).
 
-choose_claim_v2(Ring, Node) ->
+choose_claim_v2(RingIn, Node) ->
+    Ring = riak_core_ring:upgrade(RingIn),
     Active = riak_core_ring:claiming_members(Ring),
     Owners = riak_core_ring:all_owners(Ring),
     Counts = get_counts(Active, Owners),


### PR DESCRIPTION
Change wants_claim_v2 and choose_claim_v2 to upgrade the input ring. This allows the algorithms to work properly when in legacy mode, where the old ring format may be passed in rather than the new ring format. This allows for mixed 0.14.2 and 1.1 clusters, such as during a rolling upgrade.
