### PR TITLE
Change node to use claim_v1 when in legacy mode

### DIFF
--- a/src/riak_core_claim.erl
+++ b/src/riak_core_claim.erl
@@ -81,7 +81,12 @@ default_choose_claim(Ring) ->
     default_choose_claim(Ring, node()).
 
 default_choose_claim(Ring, Node) ->
-    choose_claim_v2(Ring, Node).
+    case riak_core_ring:legacy_ring(Ring) of
+        true ->
+            choose_claim_v1(Ring, Node);
+        false ->
+            choose_claim_v2(Ring, Node)
+    end.
 
 %% @spec default_wants_claim(riak_core_ring()) -> {yes, integer()} | no
 %% @doc Want a partition if we currently have less than floor(ringsize/nodes).
@@ -89,7 +94,12 @@ default_wants_claim(Ring) ->
     default_wants_claim(Ring, node()).
 
 default_wants_claim(Ring, Node) ->
-    wants_claim_v2(Ring, Node).
+    case riak_core_ring:legacy_ring(Ring) of
+        true ->
+            wants_claim_v1(Ring, Node);
+        false ->
+            wants_claim_v2(Ring, Node)
+    end.
 
 %% @deprecated
 wants_claim_v1(Ring) ->
@@ -117,8 +127,7 @@ wants_claim_v1(Ring0, Node) ->
 wants_claim_v2(Ring) ->
     wants_claim_v2(Ring, node()).
 
-wants_claim_v2(RingIn, Node) ->
-    Ring = riak_core_ring:upgrade(RingIn),
+wants_claim_v2(Ring, Node) ->
     Active = riak_core_ring:claiming_members(Ring),
     Owners = riak_core_ring:all_owners(Ring),
     Counts = get_counts(Active, Owners),
@@ -156,8 +165,7 @@ choose_claim_v1(Ring0, Node) ->
 choose_claim_v2(Ring) ->
     choose_claim_v2(Ring, node()).
 
-choose_claim_v2(RingIn, Node) ->
-    Ring = riak_core_ring:upgrade(RingIn),
+choose_claim_v2(Ring, Node) ->
     Active = riak_core_ring:claiming_members(Ring),
     Owners = riak_core_ring:all_owners(Ring),
     Counts = get_counts(Active, Owners),


### PR DESCRIPTION
The new `claim_v2` algorithms introduced as default for 1.0.3 make assumptions about the ring that do not hold for legacy rings. The claim function may therefore crash, preventing a node from joining a cluster. Therefore, change `default_claim` to use `claim_v1` when given a legacy ring.

This ensure that a cluster can properly perform a rolling upgrade from 0.14.2 to 1.0.3. With this change, the old claim algorithm is still used during the upgrade, and then the new algorithm is used after all nodes have been upgraded to 1.0.3. Fixes observed basho_expect rolling upgrade failure.
