### PR TITLE
Use platfom_data_dir as root of slide data if not explicitly configured.

### DIFF
--- a/src/slide.erl
+++ b/src/slide.erl
@@ -155,7 +155,7 @@ private_dir() ->
         undefined ->
             Root = case application:get_env(riak_core, platform_data_dir) of
                        undefined -> ?DIR;
-                       X -> filename:join([X, "slide-data"])
+                       {ok, X} -> filename:join([X, "slide-data"])
                    end,
             filename:join([Root, os:getpid()]);
         {ok, Dir} ->

--- a/src/slide.erl
+++ b/src/slide.erl
@@ -153,7 +153,11 @@ sum(#slide{dir=Dir}, Moment, Seconds) ->
 private_dir() ->
     case application:get_env(riak_core, slide_private_dir) of
         undefined ->
-            lists:flatten(io_lib:format("~s/~s", [?DIR, os:getpid()]));
+            Root = case application:get_env(riak_core, platform_data_dir) of
+                       undefined -> ?DIR;
+                       X -> filename:join([X, "slide-data"])
+                   end,
+            filename:join([Root, os:getpid()]);
         {ok, Dir} ->
             Dir
     end.


### PR DESCRIPTION
When not explicitly set via the `slide_private_dir` application env variable, slide.erl uses a location for its data directory (defined in a module macro) that is not safe/cross-platform. This changes the setting to be based on `platform_data_dir`, only falling back to the macro when the `platform_data_dir` is not set.
