### PR TITLE
Make sure duplicates don't exist in the registered modules

### DIFF
--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -321,7 +321,8 @@ register_mod(App, Module, Type) when is_atom(Module), is_atom(Type) ->
         undefined ->
             application:set_env(riak_core, Type, [{App,Module}]);
         {ok, Mods} ->
-            application:set_env(riak_core, Type, [{App,Module}|Mods])
+            application:set_env(riak_core, Type,
+                lists:usort([{App,Module}|Mods]))
     end.
 
 %% @spec add_guarded_event_handler(HandlerMod, Handler, Args) -> AddResult


### PR DESCRIPTION
Allowing duplicates was breaking the pipe and kv unit tests.
