### PR TITLE
Possibly a typo in two locations

### DIFF
--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -81,7 +81,7 @@ start_fold(TargetNode, Module, Partition, ParentPid, SslOpts) ->
          ok = TcpMod:send(Socket, M),
          StartFoldTime = now(),
 
-         MRef = monitor(process, ParentPid),
+         MRef = erlang:monitor(process, ParentPid),
          process_flag(trap_exit, true),
          SPid = self(),
          Req = ?FOLD_REQ{foldfun=fun visit_item/3,

--- a/src/riak_core_vnode_proxy.erl
+++ b/src/riak_core_vnode_proxy.erl
@@ -103,7 +103,7 @@ handle_cast({unregister_vnode, Pid}, State) ->
     %% The pid may not match the vnode_pid in the state, but we must send the
     %% unregister event anyway -- the vnode manager requires it.
     gen_fsm:send_event(Pid, unregistered),
-    catch demonitor(State#state.vnode_mref, [flush]),
+    catch erlang:demonitor(State#state.vnode_mref, [flush]),
     NewState = State#state{vnode_pid=undefined, vnode_mref=undefined},
     {noreply, NewState};
 handle_cast(_Msg, State) ->


### PR DESCRIPTION
riak_core doesn't build without specifying full package name (Erlang R14A (erts-5.8))
