### PR TITLE
Intermittent hang with handoff sender

### DIFF
--- a/src/riak_core_stat.erl
+++ b/src/riak_core_stat.erl
@@ -42,6 +42,7 @@
           ignored_gossip_total   :: integer(),
           rings_reconciled_total :: integer(),
           rejected_handoffs      :: integer(),
+          handoff_timeouts       :: integer(),
           gossip_received        :: spiraltime:spiral(),
           rings_reconciled       :: spiraltime:spiral(),
           converge_epoch         :: calendar:t_now(),
@@ -79,6 +80,7 @@ init([]) ->
     {ok, #state{ignored_gossip_total=0,
                 rings_reconciled_total=0,
                 rejected_handoffs=0,
+                handoff_timeouts=0,
                 gossip_received=spiraltime:fresh(),
                 rings_reconciled=spiraltime:fresh(),
                 converge_delay=#cuml{},
@@ -136,6 +138,9 @@ update(rebalance_timer_end, _Moment, State=#state{rebalance_epoch=T0}) ->
 
 update(rejected_handoffs, _Moment, State) ->
     int_incr(#state.rejected_handoffs, State);
+
+update(handoff_timeouts, _Moment, State) ->
+    int_incr(#state.handoff_timeouts, State);
 
 update(ignored_gossip, _Moment, State) ->
     int_incr(#state.ignored_gossip_total, State);
@@ -195,6 +200,7 @@ gossip_stats(Moment, State=#state{converge_delay=CDelay,
      {rings_reconciled_total, State#state.rings_reconciled_total},
      {rings_reconciled, spiral_minute(Moment, #state.rings_reconciled, State)},
      {gossip_received, spiral_minute(Moment, #state.gossip_received, State)},
+     {handoff_timeouts, State#state.handoff_timeouts},
      {converge_delay_min,  CDelay#cuml.min},
      {converge_delay_max,  CDelay#cuml.max},
      {converge_delay_mean, CDelay#cuml.mean},


### PR DESCRIPTION
On a 1.1.1 cluster we've seen multiple cases of handoff sender processes hanging when the TCP socket has gone away.

Polling riak_core_handoff_manager:status() on all the nodes in a cluster we saw this - with no TCP connections alive

```
[{'riak@1.2.3.195',[]},
 {'riak@1.2.3.197',[]},
 {'riak@1.2.3.199',[{{riak_kv_vnode,713623846352979940529142984724747568191373312000},
                               'riak@1.2.3.197',outbound,active,[]}]},
 {'riak@1.2.3.201',[{{riak_kv_vnode,359666418561901890026688064301272774368452149248},
                               'riak@1.2.3.197',outbound,active,[]}]},
 {'riak@1.2.3.203',[{{riak_kv_vnode,536645132457440915277915524513010171279912730624},
                               'riak@1.2.3.197',outbound,active,[]}]},
 {'riak@1.2.3.205',[]},
 {'riak@1.2.3.207',[]},
 {'riak@1.2.3.209',[]},
 {'riak@1.2.3.211',[{{riak_kv_vnode,108470824645652950960429733678161630365088743424},
                               'riak@1.2.4.214',outbound,active,[]}]},
 {'riak@1.2.3.213',[]},
 {'riak@1.2.3.215',[]},
 {'riak@1.2.3.217',[{{riak_kv_vnode,171269723124715185726994316333939416365929594880},
                               'riak@1.2.4.254',outbound,active,[]}]},
 {'riak@1.2.3.219',[]},
 {'riak@1.2.4.208',[{{riak_kv_vnode,804967698686161372916873286769515256919869095936},
                              'riak@1.2.4.214',outbound,active,[]}]},
 {'riak@1.2.4.210',[{{riak_kv_vnode,753586781748746817198774991869333432010090217472},
                              'riak@1.2.4.208',outbound,active,[]}]},
 {'riak@1.2.4.212',[{{riak_kv_vnode,576608067853207791947547531657596035098629636096},
                              'riak@1.2.4.208',outbound,active,[]}]},
 {'riak@1.2.4.214',[]},
 {'riak@1.2.4.216',[]},
 {'riak@1.2.4.218',[]},
 {'riak@1.2.4.220',[]},
 {'riak@1.2.4.222',[]},
 {'riak@1.2.4.224',[]},
 {'riak@1.2.4.226',[]},
 {'riak@1.2.4.228',[]},
 {'riak@1.2.4.230',[]},
 {'riak@1.2.4.232',[]},
 {'riak@1.2.4.234',[{{riak_kv_vnode,639406966332270026714112114313373821099470487552},
                              'riak@1.2.3.199',outbound,active,[]}]},
 {'riak@1.2.4.236',[]},
 {'riak@1.2.4.238',[]},
 {'riak@1.2.4.240',[]},
 {'riak@1.2.4.242',[]},
 {'riak@1.2.4.244',[]},
 {'riak@1.2.4.246',[]},
 {'riak@1.2.4.248',[]},
 {'riak@1.2.4.250',[]},
 {'riak@1.2.4.252',[]},
 {'riak@1.2.4.254',[]}]
```

```
(riaksearch@10.28.60.208)2> io:format("~s\n", [element(2, erlang:process_info(pid(0,15806,280), backtrace))]).  
Program counter: 0x00007f96f70c2bf8 (prim_inet:recv0/3 + 224)
CP: 0x0000000000000000 (invalid)
arity = 0

0x00007f912bd180a0 Return addr 0x00007f96e933cdb0 (riak_core_handoff_sender:start_fold/5 + 1936)
y(0)     4394
y(1)     #Port<0.142646101>

0x00007f912bd180b8 Return addr 0x0000000000870018 (<terminate process normally>)
y(0)     []
y(1)     []
y(2)     []
y(3)     riak_kv_vnode_master
y(4)     #Port<0.142646101>
y(5)     gen_tcp
y(6)     <0.31027.245>
y(7)     804967698686161372916873286769515256919869095936
y(8)     riak_kv_vnode
y(9)     'riaksearch@10.28.60.214'
y(10)    Catch 0x00007f96e933e2e0 (riak_core_handoff_sender:start_fold/5 + 7360)
```

Digging the TCP port information

```
(riaksearch@10.28.60.208)10> erlang:port_info(Port).
[{name,"tcp_inet"},
 {links,[<0.15806.280>]},
 {id,142646101},
 {connected,<0.15806.280>},
 {input,0},
 {output,14}]
```

Looks like it only output 14 bytes which would match with being stuck at the gen_tcp:recv here https://github.com/basho/riak_core/blob/1.1/src/riak_core_handoff_sender.erl#L75

```
11> size(<<1:8,(atom_to_binary(riak_kv_vnode, utf8))/binary>>).
14
```
