### PR TITLE
Restructure stats to be managed by riak_core

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -67,7 +67,14 @@
              slide,
              spiraltime,
              supervisor_pre_r14b04,
-             vclock
+             vclock,
+             riak_core_metric,
+             riak_core_metric_sup,
+             riak_core_metric_proc,
+             riak_core_metric_counter,
+             riak_core_metric_histogram,
+             riak_core_metric_meter,
+             riak_core_metric_duration
             ]},
   {registered, []},
   {applications, [

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -90,6 +90,8 @@ start(_StartType, _StartArgs) ->
                         [lager:posix_error(Reason)]),
                     throw({error, Reason})
             end,
+            %% register stats mod
+            ok = riak_core:register(riak_core, [{stat_specs, riak_core_stat}]),
             {ok, Pid};
         {error, Reason} ->
             {error, Reason}

--- a/src/riak_core_metric.erl
+++ b/src/riak_core_metric.erl
@@ -33,7 +33,7 @@
                  Args :: [stat_arg()]
                 }.
 
--type stat_arg() :: {Name :: type | desc | display,
+-type stat_arg() :: {Name :: type | group | presentation,
                      Value :: term()
                     }.
 

--- a/src/riak_core_metric.erl
+++ b/src/riak_core_metric.erl
@@ -1,0 +1,66 @@
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc riak_core_metric is a behaviour that metrics conform to.
+%% it is part of the riak_core stats subsystem.
+%% current impls are Meter(spiral), Counter, Histogram(slide)
+
+-module(riak_core_metric).
+
+-export([behaviour_info/1, regname/2, join_as_atom/1]).
+
+-export_type([stat_specs/0]).
+
+-type stat_specs() ::  [stat()].
+
+-type stat() :: {Name :: atom(),
+                 Args :: [stat_arg()]
+                }.
+
+-type stat_arg() :: {Name :: type | desc | display,
+                     Value :: term()
+                    }.
+
+behaviour_info(callbacks) ->
+    [{new, 0},
+     {value, 2},
+     {value, 3},
+     {update, 2}
+    ].
+
+regname(App, Name) when is_atom(App), is_atom(Name) ->
+    join_as_atom(['stats_', App, $_, Name]).
+
+join_as_atom(L) ->
+    join_as_atom(L, <<>>).
+
+join_as_atom([], Acc) ->
+    binary_to_atom(Acc, latin1);
+join_as_atom([Elem|Rest], Acc) ->
+    Bin1 = to_binary(Elem),
+    join_as_atom(Rest, <<Acc/binary, Bin1/binary>>).
+
+to_binary(Atom) when is_atom(Atom) ->
+    atom_to_binary(Atom, latin1);
+to_binary(List) when is_list(List) ->
+    list_to_binary(List);
+to_binary(Bin) when is_binary(Bin) ->
+    Bin;
+to_binary(Int) when is_integer(Int) ->
+    <<Int>>.

--- a/src/riak_core_metric_counter.erl
+++ b/src/riak_core_metric_counter.erl
@@ -17,7 +17,7 @@
 %%
 %% -------------------------------------------------------------------
 
-%% @doc A counter. Wraps, erm, an integer()
+%% @doc A counter. Wraps an integer()
 -module(riak_core_metric_counter).
 
 -behaviour(riak_core_metric).
@@ -26,34 +26,58 @@
 
 -export([increment/2, increment/3, decrement/2, decrement/3, total/2]).
 
+%% @doc increments the counter for App named Stat
+%% by Amount.
+-spec increment(atom(), atom(), integer()) ->
+                       ok.
 increment(App, Stat, Amount) ->
     riak_core_metric_proc:update(App, Stat, Amount).
 
+%% @doc increment the counter for App named Stat
+%% by 1.
+-spec increment(atom(), atom()) ->
+                       ok.
 increment(App, Stat) ->
     increment(App, Stat, 1).
 
+%% @doc decrement the counter for App named Stat
+%% by Amount.
+-spec decrement(atom(), atom(), integer()) ->
+                       ok.
 decrement(App, Stat, Amount) ->
     riak_core_metric_proc:update(App, Stat, {decrement, Amount}).
 
+%% @doc decrement the counter for App named Stat
+%% by 1.
+-spec decrement(atom(), atom()) -> ok.
 decrement(App, Stat) ->
     decrement(App, Stat, 1).
 
+%% @doc return the counter for App named Stat's
+%% current value.
+-spec total(atom(), atom()) -> non_neg_integer().
 total(App, Stat) ->
     riak_core_metric_proc:value(App, Stat).
 
 %% Behaviour
+-spec new() -> 0.
 new() ->
     0.
 
+-spec value(atom(), non_neg_integer()) ->
+                   {atom(), non_neg_integer()}.
 value(Name, Counter) ->
     {Name, Counter}.
 
+-spec value(_, atom(), non_neg_integer()) ->
+                   {atom(), non_neg_integer()}.
 value(_, Name, Counter) ->
     value(Name, Counter).
 
-update({decrement, Amount}, 0) when is_integer(Amount) ->
-    0;
+-spec update({atom(), integer()}, non_neg_integer()) ->
+                    non_neg_integer();
+            (integer(), non_neg_integer()) -> non_neg_integer().
 update({decrement, Amount}, Counter) when is_integer(Amount) ->
-    Counter - Amount;
+    erlang:max(Counter - Amount, 0);
 update(Amount, Counter) when is_integer(Amount) ->
-    Counter + Amount.
+    erlang:max(Counter + Amount, 0).

--- a/src/riak_core_metric_counter.erl
+++ b/src/riak_core_metric_counter.erl
@@ -1,0 +1,59 @@
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc A counter. Wraps, erm, an integer()
+-module(riak_core_metric_counter).
+
+-behaviour(riak_core_metric).
+
+-export([new/0, value/2, value/3,  update/2]).
+
+-export([increment/2, increment/3, decrement/2, decrement/3, total/2]).
+
+increment(App, Stat, Amount) ->
+    riak_core_metric_proc:update(App, Stat, Amount).
+
+increment(App, Stat) ->
+    increment(App, Stat, 1).
+
+decrement(App, Stat, Amount) ->
+    riak_core_metric_proc:update(App, Stat, {decrement, Amount}).
+
+decrement(App, Stat) ->
+    decrement(App, Stat, 1).
+
+total(App, Stat) ->
+    riak_core_metric_proc:value(App, Stat).
+
+%% Behaviour
+new() ->
+    0.
+
+value(Name, Counter) ->
+    {Name, Counter}.
+
+value(_, Name, Counter) ->
+    value(Name, Counter).
+
+update({decrement, Amount}, 0) when is_integer(Amount) ->
+    0;
+update({decrement, Amount}, Counter) when is_integer(Amount) ->
+    Counter - Amount;
+update(Amount, Counter) when is_integer(Amount) ->
+    Counter + Amount.

--- a/src/riak_core_metric_duration.erl
+++ b/src/riak_core_metric_duration.erl
@@ -1,0 +1,74 @@
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc tracks a duration, min, max, last, mean
+-module(riak_core_metric_duration).
+
+-behaviour(riak_core_metric).
+
+%% Behaviour API
+-export([new/0, value/2, value/3,  update/2]).
+
+%% Public API
+-export([start/2, stop/2, cumulative/2]).
+
+-record(cuml, {count =  0 :: integer(),
+               min        :: integer(),
+               max   = -1 :: integer(),
+               mean  =  0 :: integer(),
+               last       :: integer(),
+               start      :: calendar:t_now()}).
+
+start(App, Stat) ->
+    riak_core_metric_proc:update(App, Stat, start).
+
+stop(App, Stat) ->
+    riak_core_metric_proc:update(App, Stat, stop).
+
+cumulative(App, Stat) ->
+    riak_core_metric_proc:value(App, Stat).
+
+new() ->
+    #cuml{}.
+
+value(Name, Dur) ->
+    display(Name, to_proplist(Dur), [count, min, max, mean, last], []).
+
+value(Fields, Name, Dur) ->
+    display(Name, to_proplist(Dur), Fields, []).
+
+update(start, Dur) ->
+    Dur#cuml{start=erlang:now()};
+update(stop, #cuml{count=N, min=Min, max=Max, mean=Mean, start=T0}) ->
+    Duration = timer:now_diff(erlang:now(), T0),
+    Min2 = erlang:min(Min, Duration),
+    Max2 = erlang:max(Max, Duration),
+    Mean2 = ((N * Mean) + Duration) div (N+1),
+    #cuml{count=N+1, min=Min2, max=Max2, mean=Mean2, last=Duration, start=undefined}.
+
+%% internal
+display(_Stat, _Cuml, [], Acc) ->
+    lists:reverse(Acc);
+display(Stat, Cuml, [Field|Rest], Acc) ->
+    Name = riak_core_metric:join_as_atom([Stat, '_', Field]),
+    Value = proplists:get_value(Field, Cuml),
+    display(Stat, Cuml, Rest, [{Name, Value}|Acc]).
+
+to_proplist(Cuml) when is_record(Cuml, cuml) ->
+    lists:zip(record_info(fields, cuml), tl(tuple_to_list(Cuml))).

--- a/src/riak_core_metric_duration.erl
+++ b/src/riak_core_metric_duration.erl
@@ -28,6 +28,8 @@
 %% Public API
 -export([start/2, stop/2, cumulative/2]).
 
+-export_type([display_spec/0]).
+
 -record(cuml, {count =  0 :: integer(),
                min        :: integer(),
                max   = -1 :: integer(),
@@ -35,24 +37,49 @@
                last       :: integer(),
                start      :: calendar:t_now()}).
 
+-type display() :: [{field(), integer()}].
+-type field() :: count | min | max | mean | last | start.
+-type display_spec() :: [field()].
+
+%% @doc start timing the duration
+-spec start(atom(), atom()) -> ok.
 start(App, Stat) ->
     riak_core_metric_proc:update(App, Stat, start).
 
+%% @doc stop timing the duration
+-spec stop(atom(), atom()) -> ok.
 stop(App, Stat) ->
     riak_core_metric_proc:update(App, Stat, stop).
 
+%% @doc get display the current value of
+%% the duration Stat. Value is
+%% returned as a proplist
+-spec cumulative(atom(), atom()) ->
+                        display().
 cumulative(App, Stat) ->
     riak_core_metric_proc:value(App, Stat).
 
+-spec new() -> #cuml{}.
 new() ->
     #cuml{}.
 
+%% @doc format Dur as a proplist with
+%% default fields count, min, max, mean and last
+-spec value(atom(), #cuml{}) ->
+                  display().
 value(Name, Dur) ->
     display(Name, to_proplist(Dur), [count, min, max, mean, last], []).
 
+%% @doc fromat Dur as a proplist
+%% Fields is a list of values to display
+%% picked from count, min, max, mean, last
+-spec value(display_spec(), atom(), #cuml{}) ->
+                   display().
 value(Fields, Name, Dur) ->
     display(Name, to_proplist(Dur), Fields, []).
 
+-spec update(start, #cuml{}) -> #cuml{};
+            (stop, #cuml{}) -> #cuml{}.
 update(start, Dur) ->
     Dur#cuml{start=erlang:now()};
 update(stop, #cuml{count=N, min=Min, max=Max, mean=Mean, start=T0}) ->
@@ -63,6 +90,8 @@ update(stop, #cuml{count=N, min=Min, max=Max, mean=Mean, start=T0}) ->
     #cuml{count=N+1, min=Min2, max=Max2, mean=Mean2, last=Duration, start=undefined}.
 
 %% internal
+-spec display(atom(), display(), [field()], display()) ->
+                     display().
 display(_Stat, _Cuml, [], Acc) ->
     lists:reverse(Acc);
 display(Stat, Cuml, [Field|Rest], Acc) ->
@@ -70,5 +99,6 @@ display(Stat, Cuml, [Field|Rest], Acc) ->
     Value = proplists:get_value(Field, Cuml),
     display(Stat, Cuml, Rest, [{Name, Value}|Acc]).
 
+-spec to_proplist(#cuml{}) -> display().
 to_proplist(Cuml) when is_record(Cuml, cuml) ->
     lists:zip(record_info(fields, cuml), tl(tuple_to_list(Cuml))).

--- a/src/riak_core_metric_histogram.erl
+++ b/src/riak_core_metric_histogram.erl
@@ -1,0 +1,77 @@
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc An histogram . Wraps slide
+-module(riak_core_metric_histogram).
+
+-behaviour(riak_core_metric).
+
+-export([new/0, value/2, value/3,  update/2]).
+
+-export([increment/4, minute/7, sum/2]).
+
+increment(App, Stat, Reading, Moment) ->
+    riak_core_metric_proc:update(App, Stat, {Reading, Moment}).
+
+minute(App, Stat, Moment, Min, Max, Bins, RoundingMode) ->
+    riak_core_metric_proc:value(App, Stat, {Moment, Min, Max, Bins, RoundingMode}).
+
+sum(App, Stat) ->
+    riak_core_metric_proc:value(App, Stat).
+    
+%% Behaviour
+new() ->
+    slide:fresh().
+
+value(Name, Slide) ->
+    {Name, slide:sum(Slide)}.
+
+value(DisplaySpec, Name,  Slide) ->
+    {Min, Max, Bins, RoundingMode} = proplists:get_value(args, DisplaySpec),
+    Fields = proplists:get_value(fields, DisplaySpec),
+    Prefix = proplists:get_value(prefix, DisplaySpec),
+    Res = slide:mean_and_nines(Slide, slide:moment(), Min, Max, Bins, RoundingMode),
+    PL = to_proplist(Res),
+    FieldPrefix = field_prefix(Prefix, Name),
+    display(FieldPrefix, Fields, PL, []).
+
+
+update({Reading, Moment}, Slide) ->
+    slide:update(Slide, Reading, Moment).
+
+%% Internal
+to_proplist({Cnt, Mean, {Median, NineFive, NineNine, Max}}) ->
+    [{count, Cnt},
+     {mean, Mean},
+     {median, Median},
+     {'95', NineFive},
+     {'99', NineNine},
+     {'100', Max}].
+
+field_prefix(undefined, Name) ->
+    Name;
+field_prefix(Prefix, Name) ->
+    riak_core_metric:join_as_atom([Prefix, '_', Name]).
+
+display(_Prefix, [], _Stat, Acc) ->
+    lists:reverse(Acc);
+display(Prefix, [Field|Rest], Stats, Acc) ->
+    Name = riak_core_metric:join_as_atom([Prefix, '_',  Field]),
+    Item = {Name, proplists:get_value(Field, Stats)},
+    display(Prefix, Rest, Stats, [Item|Acc]).

--- a/src/riak_core_metric_meter.erl
+++ b/src/riak_core_metric_meter.erl
@@ -1,0 +1,51 @@
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc A Meter. Wraps spiraltime
+-module(riak_core_metric_meter).
+
+-behaviour(riak_core_metric).
+
+%% Behaviour API
+-export([new/0, value/2, value/3, update/2]).
+
+%% Usage API
+-export([increment/3, increment/4, minute/2]).
+
+increment(App, Stat, Amount, Moment) ->
+    riak_core_metric_proc:update(App, Stat, {Amount, Moment}).
+
+increment(App, Stat, Moment) ->
+    increment(App, Stat, 1, Moment).
+
+minute(App, Stat) ->
+    riak_core_metric_proc:value(App, Stat).
+
+new() ->
+    spiraltime:fresh().
+
+value(Name, Meter) ->
+    {_Moment, Count} = spiraltime:rep_minute(Meter),
+    {Name, Count}.
+
+value(_Spec, Name, Meter) ->
+    value(Name, Meter).
+
+update({Amount, Moment}, Meter) ->
+    spiraltime:incr(Amount, Moment, Meter).

--- a/src/riak_core_metric_meter.erl
+++ b/src/riak_core_metric_meter.erl
@@ -28,24 +28,47 @@
 %% Usage API
 -export([increment/3, increment/4, minute/2]).
 
+%% @doc update the count for the App Stat by Amount for the
+%% given moment.
+-spec increment(atom(), atom(), integer(), integer()) -> ok.
 increment(App, Stat, Amount, Moment) ->
     riak_core_metric_proc:update(App, Stat, {Amount, Moment}).
 
+%% @doc update the count for the App Stat by 1 for the
+%% given moment.
+-spec increment(atom(), atom(), integer()) -> ok.
 increment(App, Stat, Moment) ->
     increment(App, Stat, 1, Moment).
 
+%% @doc display the number of entries in the last minute
+%% for App Stat.
+-spec minute(atom(), atom()) -> {atom(), integer()}.
 minute(App, Stat) ->
     riak_core_metric_proc:value(App, Stat).
 
+%% @doc create a new meter.
+-spec new() -> spiraltime:spiral().
 new() ->
     spiraltime:fresh().
 
+%% @doc format the number of entries in the last minute as
+%% {name, count}.
+-spec value(atom(), spiraltime:spiral()) ->
+                   {atom(), integer()}.
 value(Name, Meter) ->
     {_Moment, Count} = spiraltime:rep_minute(Meter),
     {Name, Count}.
 
+%% @doc format the number of entries in the last minute as
+%% {name, count}.
+-spec value(_, atom(), spiraltime:spiral()) ->
+                   {atom(), integer()}.
 value(_Spec, Name, Meter) ->
     value(Name, Meter).
 
+%% @doc update the entry for the given Momen by Amout,
+%%  in the given Meter
+-spec update({integer(), integer()}, spiraltime:spiral()) ->
+                    spiraltime:spiral().
 update({Amount, Moment}, Meter) ->
     spiraltime:incr(Amount, Moment, Meter).

--- a/src/riak_core_metric_proc.erl
+++ b/src/riak_core_metric_proc.erl
@@ -1,0 +1,96 @@
+%% -------------------------------------------------------------------
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc process/state wrapper around a metric
+
+-module(riak_core_metric_proc).
+
+-behaviour(gen_server).
+
+%% API
+-export([start_link/3, update/3, value/2, value/3]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-record(state, {name, mod, mod_state, presentation, description}).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+start_link(App, Name, Args) ->
+    RegName = riak_core_metric:regname(App, Name),
+    gen_server:start_link({local, RegName}, ?MODULE, [{name, Name}|Args], []).
+
+update(App, Name, Args) ->
+    RegName = riak_core_metric:regname(App, Name),
+    gen_server:cast(RegName, {update, Args}).
+
+value(App, Name) ->
+    value(App, Name, []).
+
+value(App, Name, Presentation) ->
+    RegName = riak_core_metric:regname(App, Name),
+    {ok, Val} = gen_server:call(RegName, {value, Presentation}),
+    Val.
+
+init(Args) ->
+    Name = proplists:get_value(name, Args),
+    {type, ShortName} = proplists:lookup(type, Args), %% Does mod need init args?
+    Mod = mod_from_shortname(ShortName),
+    Description = proplists:get_value(description, Args),
+    DisplaySpec =  proplists:get_value(presentation, Args),
+    ModState = Mod:new(),
+    {ok, #state{name=Name, mod=Mod, mod_state=ModState, description=Description, presentation=DisplaySpec}}.
+
+handle_call({value, _}, _From, #state{mod=Mod, mod_state=ModState, presentation=undefined, name=Name}=State) ->
+    Stat = Mod:value(Name, ModState),
+    {reply, {ok, Stat}, State};
+handle_call({value, undefined}, _From, #state{mod=Mod, mod_state=ModState, name=Name}=State) ->
+    Stat = Mod:value(Name, ModState),
+    {reply, {ok, Stat}, State};
+handle_call({value, Presentation}, _From, #state{mod=Mod, mod_state=ModState, presentation=DisplaySpecs, name=Name}=State) ->
+    Stat = case proplists:get_value(Presentation, DisplaySpecs) of
+               undefined ->
+                   Mod:value(Name, ModState);
+               DisplaySpec ->
+                   Mod:value(DisplaySpec, Name, ModState)
+           end,
+    {reply, {ok, Stat}, State}.
+
+handle_cast({update, Args}, #state{mod=Mod, mod_state=ModState0}=State) ->
+    ModState = Mod:update(Args, ModState0),
+    {noreply, State#state{mod_state=ModState}}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+mod_from_shortname(ShortName) ->
+    list_to_atom("riak_core_metric_" ++ atom_to_list(ShortName)).

--- a/src/riak_core_metric_sup.erl
+++ b/src/riak_core_metric_sup.erl
@@ -1,0 +1,67 @@
+%% -------------------------------------------------------------------
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc starts and supervises a process per stat
+%% register stats through riak_core:register/2
+
+-module(riak_core_metric_sup).
+-behaviour(supervisor).
+-export([start_link/0, init/1]).
+-export([start_stat/3, stop_stat/2, start_stats/2]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    remove_slide_private_dirs(),
+    %% Populate supervisor list with stats for already registered app,stat
+    %% modules. Ensures restart of stat procs after a crash of this supervisor.
+    Refs0 = [mod_refs(App, Mod) || {App, Mod} <- riak_core:stat_specs()],
+    Refs = lists:flatten(Refs0),
+    {ok, {{one_for_one, 5, 10}, Refs}}.
+
+start_stat(App, Stat, Args) ->
+    Ref = stat_ref(App, Stat, Args),
+    Pid = case supervisor:start_child(?MODULE, Ref) of
+              {ok, Child} -> Child;
+              {error, {already_started, Child}} -> Child
+          end,
+    Pid.
+
+stop_stat(App, Stat) ->
+    supervisor:terminate_child(?MODULE, {App, Stat}),
+    supervisor:delete_child(?MODULE, {App, Stat}),
+    ok.
+
+start_stats(App, Mod) ->
+    Stats = Mod:stat_specs(),
+    [start_stat(App, Stat, Args) || {Stat, Args} <- Stats],
+    ok.
+
+%% @private
+mod_refs(App, Mod) ->
+    Stats = Mod:stat_specs(),
+    [stat_ref(App, Stat, Args) || {Stat, Args} <- Stats].
+
+stat_ref(App, Stat, Args) ->
+    {{App, Stat}, {riak_core_metric_proc, start_link, [App, Stat, Args]},
+     permanent, 5000, worker, [riak_core_metric_proc]}.
+
+remove_slide_private_dirs() ->
+    os:cmd("rm -rf " ++ slide:private_dir()).

--- a/src/riak_core_stat.erl
+++ b/src/riak_core_stat.erl
@@ -19,191 +19,85 @@
 %% -------------------------------------------------------------------
 
 -module(riak_core_stat).
--behaviour(gen_server2).
 
 %% API
--export([start_link/0, get_stats/0, get_stats/1, update/1]).
+-export([get_stats/0, get_stats/1, update/1]).
 
-%% gen_server callbacks
--export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
+%% Metrics API
+-export([stat_specs/0]).
+
+-define(APP, riak_core).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--record(cuml, {count =  0 :: integer(),
-               min        :: integer(),
-               max   = -1 :: integer(),
-               mean  =  0 :: integer(),
-               last       :: integer()}).
-
--record(state, {
-          ignored_gossip_total   :: integer(),
-          rings_reconciled_total :: integer(),
-          rejected_handoffs      :: integer(),
-          gossip_received        :: spiraltime:spiral(),
-          rings_reconciled       :: spiraltime:spiral(),
-          converge_epoch         :: calendar:t_now(),
-          converge_delay         :: #cuml{},
-          rebalance_epoch        :: calendar:t_now(),
-          rebalance_delay        :: #cuml{}
-         }).
-
-%% @spec start_link() -> {ok,Pid} | ignore | {error,Error}
-%% @doc Start the server.
-start_link() ->
-    gen_server2:start_link({local, ?MODULE}, ?MODULE, [], []).
+-spec stat_specs() -> riak_core_metric:stat_specs().
+stat_specs() ->
+    [{ignored_gossip_total, [{type, counter}, {group, gossip}]},
+     {rings_reconciled_total, [{type, counter}, {group, gossip}]},
+     {rejected_handoffs, [{type, counter}, {group, gossip}]},
+     {gossip_received, [{type, meter}, {group, gossip}]},
+     {rings_reconciled, [{type, meter}, {group, gossip}]},
+     {converge_delay, [{type, duration}, {group, gossip},
+                       {presentation,
+                        [{legacy, [min, max, mean, last]}]}]},
+     {rebalance_delay, [{type, duration}, {group, gossip},
+                        {presentation,
+                         [{legacy, [min, max, mean, last]}]}]}
+    ].
 
 %% @spec get_stats() -> proplist()
 %% @doc Get the current aggregation of stats.
 get_stats() ->
-    get_stats(slide:moment()).
+    produce_stats(legacy).
 
-get_stats(Moment) ->
-    gen_server2:call(?MODULE, {get_stats, Moment}, infinity).
+get_stats(_Moment) ->
+    produce_stats(legacy).
 
 %% @spec update(term()) -> ok
 %% @doc Update the given stat.
 update(Stat) ->
-    gen_server2:cast(?MODULE, {update, Stat, slide:moment()}).
-
-%% @private
-init([]) ->
-    %% Removing the slide directory here would conflict with riak_kv_stat.
-    %% We will need to resolve if we ever use slide metrics in this module.
-    %%
-    %% process_flag(trap_exit, true),
-    %% remove_slide_private_dirs(),
-
-    {ok, #state{ignored_gossip_total=0,
-                rings_reconciled_total=0,
-                rejected_handoffs=0,
-                gossip_received=spiraltime:fresh(),
-                rings_reconciled=spiraltime:fresh(),
-                converge_delay=#cuml{},
-                rebalance_delay=#cuml{}
-               }}.
-
-%% @private
-handle_call({get_stats, Moment}, _From, State) ->
-    {reply, produce_stats(State, Moment), State};
-handle_call(_Request, _From, State) ->
-    Reply = ok,
-    {reply, Reply, State}.
-
-%% @private
-handle_cast({update, Stat, Moment}, State) ->
-    {noreply, update(Stat, Moment, State)};
-handle_cast(_Msg, State) ->
-    {noreply, State}.
-
-%% @private
-handle_info(_Info, State) ->
-    {noreply, State}.
-
-%% @private
-terminate(_Reason, _State) ->
-    ok.
-
-%% @private
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
+    update(Stat, slide:moment()).
 
 %%--------------------------------------------------------------------
 %%% Internal functions
 %%--------------------------------------------------------------------
 
 %% @doc Update the given stat in State, returning a new State.
--spec update(Stat::term(), integer(), #state{}) -> #state{}.
-update(converge_timer_begin, _Moment, State) ->
-    State#state{converge_epoch=erlang:now()};
-update(converge_timer_end, _Moment, State=#state{converge_epoch=undefined}) ->
-    State;
-update(converge_timer_end, _Moment, State=#state{converge_epoch=T0}) ->
-    Duration = timer:now_diff(erlang:now(), T0),
-    update_cumulative(#state.converge_delay, Duration,
-                      State#state{converge_epoch=undefined});
+-spec update(Stat::term(), integer()) -> ok.
+update(converge_timer_begin, _Moment) ->
+    riak_core_metric_duration:start(?APP, converge_delay);
+update(converge_timer_end, _Moment) ->
+    riak_core_metric_duration:stop(?APP, converge_delay);
+update(rebalance_timer_begin, _Moment) ->
+    riak_core_metric_duration:start(?APP, rebalance_delay);
+update(rebalance_timer_end, _Moment) ->
+    riak_core_metric_duration:stop(?APP, rebalance_delay);
+update(rejected_handoffs, _Moment) ->
+    riak_core_metric_counter:increment(?APP, rejected_handoffs);
+update(ignored_gossip, _Moment) ->
+    riak_core_metric_counter:increment(?APP, ignored_gossip_total);
+update(gossip_received, Moment) ->
+    riak_core_metric_meter:increment(?APP, gossip_received, Moment);
+update(rings_reconciled, Moment) ->
+    riak_core_metric_meter:increment(?APP, rings_reconciled, Moment),
+    riak_core_metric_counter:increment(?APP, rings_reconciled_total);
+update(_, _) ->
+    ok.
 
-update(rebalance_timer_begin, _Moment, State) ->
-    State#state{rebalance_epoch=erlang:now()};
-update(rebalance_timer_end, _Moment, State=#state{rebalance_epoch=undefined}) ->
-    State;
-update(rebalance_timer_end, _Moment, State=#state{rebalance_epoch=T0}) ->
-    Duration = timer:now_diff(erlang:now(), T0),
-    update_cumulative(#state.rebalance_delay, Duration,
-                      State#state{rebalance_epoch=undefined});
-
-update(rejected_handoffs, _Moment, State) ->
-    int_incr(#state.rejected_handoffs, State);
-
-update(ignored_gossip, _Moment, State) ->
-    int_incr(#state.ignored_gossip_total, State);
-
-update(gossip_received, Moment, State) ->
-    spiral_incr(#state.gossip_received, Moment, State);
-
-update(rings_reconciled, Moment, State) ->
-    spiral_incr(#state.rings_reconciled, Moment,
-                int_incr(#state.rings_reconciled_total, State));
-
-update(_, _, State) ->
-    State.
-
-%% @spec spiral_incr(integer(), integer(), state()) -> state()
-%% @doc Increment the value of a spiraltime structure at a given
-%%      position of the State tuple.
-spiral_incr(Elt, Moment, State) ->
-    setelement(Elt, State,
-               spiraltime:incr(1, Moment, element(Elt, State))).
-
-%% @doc Increment the value at the given position of the State tuple.
-int_incr(Elt, State) ->
-    int_incr(Elt, 1, State).
-int_incr(Elt, Amount, State) ->
-    setelement(Elt, State, element(Elt, State) + Amount).
-
-%% @doc Add a value to a set, updating the cumulative min/max/mean
-update_cumulative(Elt, Value, State) ->
-    #cuml{count=N, min=Min, max=Max, mean=Mean} = element(Elt, State),
-    Min2 = erlang:min(Min, Value),
-    Max2 = erlang:max(Max, Value),
-    Mean2 = ((N * Mean) + Value) div (N+1),
-    Stat2 = #cuml{count=N+1, min=Min2, max=Max2, mean=Mean2, last=Value},
-    setelement(Elt, State, Stat2).
-
-%% @spec produce_stats(state(), integer()) -> proplist()
+%% @spec produce_stats(Presentation : atom()) -> proplist()
 %% @doc Produce a proplist-formatted view of the current aggregation
 %%      of stats.
-produce_stats(State, Moment) ->
-    lists:append([gossip_stats(Moment, State),
+produce_stats(Presentation) ->
+    lists:append([gossip_stats(Presentation),
                   vnodeq_stats()]).
 
-%% @spec spiral_minute(integer(), integer(), state()) -> integer()
-%% @doc Get the count of events in the last minute from the spiraltime
-%%      structure at the given element of the state tuple.
-spiral_minute(_Moment, Elt, State) ->
-    {_,Count} = spiraltime:rep_minute(element(Elt, State)),
-    Count.
-
-%% @spec gossip_stats(integer(), state()) -> proplist()
+%% @spec gossip_stats(integer()) -> proplist()
 %% @doc Get the gossip stats proplist.
-gossip_stats(Moment, State=#state{converge_delay=CDelay,
-                                  rebalance_delay=RDelay}) ->
-
-    [{ignored_gossip_total, State#state.ignored_gossip_total},
-     {rings_reconciled_total, State#state.rings_reconciled_total},
-     {rings_reconciled, spiral_minute(Moment, #state.rings_reconciled, State)},
-     {gossip_received, spiral_minute(Moment, #state.gossip_received, State)},
-     {converge_delay_min,  CDelay#cuml.min},
-     {converge_delay_max,  CDelay#cuml.max},
-     {converge_delay_mean, CDelay#cuml.mean},
-     {converge_delay_last, CDelay#cuml.last},
-     {rebalance_delay_min,  RDelay#cuml.min},
-     {rebalance_delay_max,  RDelay#cuml.max},
-     {rebalance_delay_mean, RDelay#cuml.mean},
-     {rebalance_delay_last, RDelay#cuml.last}].
-
+gossip_stats(Presentation) ->
+    GossipStats = [riak_core_metric_proc:value(?APP, Name, Presentation) || {Name, Spec} <- stat_specs(), lists:keyfind(gossip, 2, Spec) /= false],
+    lists:flatten( GossipStats ).
 
 %% Provide aggregate stats for vnode queues.  Compute instantaneously for now,
 %% may need to cache if stats are called heavily (multiple times per seconds)

--- a/src/riak_core_stat.erl
+++ b/src/riak_core_stat.erl
@@ -65,7 +65,7 @@ update(Stat) ->
 %%--------------------------------------------------------------------
 
 %% @doc Update the given stat in State, returning a new State.
--spec update(Stat::term(), integer()) -> ok.
+-spec update(Stat::term(), non_neg_integer()) -> ok.
 update(converge_timer_begin, _Moment) ->
     riak_core_metric_duration:start(?APP, converge_delay);
 update(converge_timer_end, _Moment) ->

--- a/src/riak_core_sup.erl
+++ b/src/riak_core_sup.erl
@@ -59,7 +59,6 @@ init([]) ->
 
     Children = lists:flatten(
                  [?CHILD(riak_core_sysmon_minder, worker),
-                  ?CHILD(riak_core_stat, worker),
                   ?CHILD(riak_core_vnode_sup, supervisor, 305000),
                   ?CHILD(riak_core_eventhandler_sup, supervisor),
                   ?CHILD(riak_core_handoff_sup, supervisor),
@@ -70,6 +69,7 @@ init([]) ->
                   ?CHILD(riak_core_node_watcher, worker),
                   ?CHILD(riak_core_vnode_manager, worker),
                   ?CHILD(riak_core_gossip, worker),
+                  ?CHILD(riak_core_metric_sup, supervisor),
                   RiakWebs
                  ]),
 

--- a/src/slide.erl
+++ b/src/slide.erl
@@ -53,6 +53,8 @@
 -export([mean_and_nines/2, mean_and_nines/6]).
 -export([private_dir/0, sync/1]).
 
+-export_type([slide/0]).
+
 -include_lib("kernel/include/file.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -67,6 +69,8 @@
           readings_fh, %% filehandle for current moment's readings
           readings_m %% moment associated with readings_fh
          }).
+
+-type slide() :: #slide{}.
 
 %% @spec fresh() -> slide()
 %% @equiv fresh(60)


### PR DESCRIPTION
Jon's original requirement email said the following-

```
The current stats implementation has a number of problems
  - structure wise the modules that implement stats calculation are in
    riak_core, and modules that use them are in riak_core_stats, riak_kv_stats and
    riak_repl_stats
  - riak_kv_stat process has been a bottleneck in the past due to the amount of
    garbage it creates and how much data goes through it.
  - SNMP/JMX apps are tied to riak_kv_stat implementation and a pain to extend.

New stats subsystem
  - when apps register with riak_core, provide a list of the stats that
    the app provides (e.g. for RiakKV put FSM time, number of gossip events
    number of handoff events etc)
  - for each registered stat provide a specification (probably good to use a proplist
    so we could add oid's later if we make SNMP generic)
     - how to handle it - e.g. a gauge to count the rate of events, a duration for 
       request times (fsm/vnode etc) (maybe module names for stats mods perhaps
       with a shorthand name)
     - what it means - human readable description
     - what to display (e.g. for get/put FSM times we'd like to display a min/mean/95/99/max
           time over the last minute and total).
  - riak_core will be responsible for maintaining all state for the statistics
     - we'd quite like to move to an erlang process-per-stat, could use the registered
        name mechanism if stats were unique.
```

This PR addresses the base of that. When we're happy with it I'll work on some further features for display/JMX etc. Will raise separate PR for Repl and KV
