### PR TITLE
refactored gen_server2 -> riak_core_gen_server

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -9,7 +9,7 @@
              bloom,
              chash,
              gen_nb_server,
-             gen_server2,
+             riak_core_gen_server,
              json_pp,
              merkerl,
              priority_queue,

--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -12,7 +12,7 @@
              riak_core_gen_server,
              json_pp,
              merkerl,
-             priority_queue,
+             riak_core_priority_queue,
              process_proxy,
              riak_core_gossip_legacy,
              riak_core,

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{erl_first_files, ["src/gen_nb_server.erl", "src/gen_server2.erl"]}.
+{erl_first_files, ["src/gen_nb_server.erl", "src/riak_core_gen_server.erl"]}.
 {cover_enabled, true}.
 {erl_opts, [{parse_transform, lager_transform}]}.
 {edoc_opts, [{preprocess, true}]}.

--- a/src/riak_core_gen_server.erl
+++ b/src/riak_core_gen_server.erl
@@ -1,22 +1,22 @@
 %% This file is a copy of gen_server.erl from the R13B-1 Erlang/OTP
 %% distribution, with the following modifications:
 %%
-%% 1) the module name is gen_server2
+%% 1) the module name is riak_core_gen_server
 %%
 %% 2) more efficient handling of selective receives in callbacks
-%% gen_server2 processes drain their message queue into an internal
+%% riak_core_gen_server processes drain their message queue into an internal
 %% buffer before invoking any callback module functions. Messages are
 %% dequeued from the buffer for processing. Thus the effective message
-%% queue of a gen_server2 process is the concatenation of the internal
+%% queue of a riak_core_gen_server process is the concatenation of the internal
 %% buffer and the real message queue.
 %% As a result of the draining, any selective receive invoked inside a
 %% callback is less likely to have to scan a large message queue.
 %%
-%% 3) gen_server2:cast is guaranteed to be order-preserving
+%% 3) riak_core_gen_server:cast is guaranteed to be order-preserving
 %% The original code could reorder messages when communicating with a
 %% process on a remote node that was not currently connected.
 %%
-%% 4) The new functions gen_server2:pcall/3, pcall/4, and pcast/3
+%% 4) The new functions riak_core_gen_server:pcall/3, pcall/4, and pcast/3
 %% allow callers to attach priorities to requests. Requests with
 %% higher priorities are processed before requests with lower
 %% priorities. The default priority is 0.
@@ -57,7 +57,7 @@
 %% 
 %%     $Id$
 %%
--module(gen_server2).
+-module(riak_core_gen_server).
 
 %%% ---------------------------------------------------
 %%%

--- a/src/riak_core_handoff_receiver.erl
+++ b/src/riak_core_handoff_receiver.erl
@@ -22,7 +22,7 @@
 
 -module(riak_core_handoff_receiver).
 -include("riak_core_handoff.hrl").
--behaviour(gen_server2).
+-behaviour(riak_core_gen_server).
 -export([start_link/0,                          % Don't use SSL
          start_link/1,                          % SSL options list, empty=no SSL
          set_socket/2]).
@@ -42,10 +42,10 @@ start_link() ->
     start_link([]).
 
 start_link(SslOpts) ->
-    gen_server2:start_link(?MODULE, [SslOpts], []).
+    riak_core_gen_server:start_link(?MODULE, [SslOpts], []).
 
 set_socket(Pid, Socket) ->
-    gen_server2:call(Pid, {set_socket, Socket}).
+    riak_core_gen_server:call(Pid, {set_socket, Socket}).
 
 init([SslOpts]) ->
     {ok, #state{ssl_opts = SslOpts,

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -288,10 +288,10 @@ get_handoff_ip(Node) when is_atom(Node) ->
     end.
 
 get_handoff_port(Node) when is_atom(Node) ->
-    case catch(gen_server2:call({riak_core_handoff_listener, Node}, handoff_port, infinity)) of
+    case catch(riak_core_gen_server:call({riak_core_handoff_listener, Node}, handoff_port, infinity)) of
         {'EXIT', _}  ->
             %% Check old location from previous release
-            gen_server2:call({riak_kv_handoff_listener, Node}, handoff_port, infinity);
+            riak_core_gen_server:call({riak_kv_handoff_listener, Node}, handoff_port, infinity);
         Other -> Other
     end.
 

--- a/src/riak_core_priority_queue.erl
+++ b/src/riak_core_priority_queue.erl
@@ -53,7 +53,7 @@
 %% a base case.
 
 
--module(priority_queue).
+-module(riak_core_priority_queue).
 
 -export([new/0, is_queue/1, is_empty/1, len/1, to_list/1, in/2, in/3,
          out/1, out/2, pout/1, join/2]).

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -24,7 +24,7 @@
 
 -module(riak_core_ring_manager).
 -define(RING_KEY, riak_ring).
--behaviour(gen_server2).
+-behaviour(riak_core_gen_server).
 
 -export([start_link/0,
          start_link/1,
@@ -62,12 +62,12 @@
 %% ===================================================================
 
 start_link() ->
-    gen_server2:start_link({local, ?MODULE}, ?MODULE, [live], []).
+    riak_core_gen_server:start_link({local, ?MODULE}, ?MODULE, [live], []).
 
 
 %% Testing entry point
 start_link(test) ->
-    gen_server2:start_link({local, ?MODULE}, ?MODULE, [test], []).
+    riak_core_gen_server:start_link({local, ?MODULE}, ?MODULE, [test], []).
 
 
 %% @spec get_my_ring() -> {ok, riak_core_ring:riak_core_ring()} | {error, Reason}
@@ -78,29 +78,29 @@ get_my_ring() ->
     end.
 
 get_raw_ring() ->
-    gen_server2:call(?MODULE, get_raw_ring, infinity).
+    riak_core_gen_server:call(?MODULE, get_raw_ring, infinity).
 
 %% @spec refresh_my_ring() -> ok
 refresh_my_ring() ->
-    gen_server2:call(?MODULE, refresh_my_ring, infinity).
+    riak_core_gen_server:call(?MODULE, refresh_my_ring, infinity).
 
 refresh_ring(Node, ClusterName) ->
-    gen_server2:cast({?MODULE, Node}, {refresh_my_ring, ClusterName}).
+    riak_core_gen_server:cast({?MODULE, Node}, {refresh_my_ring, ClusterName}).
 
 %% @spec set_my_ring(riak_core_ring:riak_core_ring()) -> ok
 set_my_ring(Ring) ->
-    gen_server2:call(?MODULE, {set_my_ring, Ring}, infinity).
+    riak_core_gen_server:call(?MODULE, {set_my_ring, Ring}, infinity).
 
 
 %% @spec write_ringfile() -> ok
 write_ringfile() ->
-    gen_server2:cast(?MODULE, write_ringfile).
+    riak_core_gen_server:cast(?MODULE, write_ringfile).
 
 ring_trans(Fun, Args) ->
-    gen_server2:call(?MODULE, {ring_trans, Fun, Args}, infinity).
+    riak_core_gen_server:call(?MODULE, {ring_trans, Fun, Args}, infinity).
 
 set_cluster_name(Name) ->
-    gen_server2:call(?MODULE, {set_cluster_name, Name}, infinity).
+    riak_core_gen_server:call(?MODULE, {set_cluster_name, Name}, infinity).
 
 %% @doc Exposed for support/debug purposes. Forces the node to change its
 %%      ring in a manner that will trigger reconciliation on gossip.
@@ -197,7 +197,7 @@ prune_ringfiles() ->
 
 %% @private (only used for test instances)
 stop() ->
-    gen_server2:cast(?MODULE, stop).
+    riak_core_gen_server:cast(?MODULE, stop).
 
 
 %% ===================================================================


### PR DESCRIPTION
I am developing an application using riak_core and rabbitmq messaging.  When I generated a release with rebar it produced this message:

```
init terminating in do_boot (Module gen_server2 potentially included by two different applications: rabbit_common and riak_core.)
```

This issue was discussed awhile back [here](http://comments.gmane.org/gmane.comp.db.riak.user/4100).

I changed the name to riak_core_gen_server and ran all tests (all 79 tests passed.)

This issue also came up with the priority_queue (originally from rabbitmq) which I also renamed to riak_core_priority_queue.

IMO this will make it easier to build applications using both of these technologies.  Let me know what you think.

Thanks for your time
