### PR TITLE
Add support to vnode master to wait until related service has started

### DIFF
--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -36,6 +36,14 @@ start(_StartType, _StartArgs) ->
     %% riak_core_sysmon_minder start it, because that process can act
     %% on any handler crash notification, whereas we cannot.
 
+    case application:get_env(riak_core, delayed_start) of
+        {ok, Delay} ->
+            lager:info("Delaying riak_core startup as requested"),
+            timer:sleep(Delay);
+        _ ->
+            ok
+    end,
+
     %% Validate that the ring state directory exists
     riak_core_util:start_app_deps(riak_core),
     RingStateDir = app_helper:get_env(riak_core, ring_state_dir),

--- a/src/riak_core_vnode_proxy_sup.erl
+++ b/src/riak_core_vnode_proxy_sup.erl
@@ -47,6 +47,7 @@ stop_proxy(Mod, Index) ->
     ok.
 
 start_proxies(Mod) ->
+    lager:debug("Starting vnode proxies for: ~p", [Mod]),
     Indices = get_indices(),
     [start_proxy(Mod, Index) || Index <- Indices],
     ok.


### PR DESCRIPTION
This patch changes `riak_core_vnode_master` so that the vnode master will wait until the related service has started before handling requests. This is necessary in `legacy_vnode_routing` mode because the routing proxies may not be available until the service has fully started. To actually enable waiting, vnode services must change how they spawn the vnode master, passing in the name of the related service. A separate pull-request makes this change to `riak_kv`.

This change (and the related `riak_kv` change) is designed to address issue #155.
