### PR TITLE
Have vnode manager periodically start never-been-started vnodes

### DIFF
--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -41,7 +41,9 @@
 -record(idxrec, {key, idx, mod, pid, monref}).
 -record(state, {idxtab, 
                 forwarding :: [pid()],
-                handoff :: [{term(), integer(), pid(), node()}]
+                handoff :: [{term(), integer(), pid(), node()}],
+                known_modules :: [term()],
+                never_started :: [{integer(), term()}]
                }).
 
 -define(DEFAULT_OWNERSHIP_TRIGGER, 8).
@@ -107,7 +109,8 @@ get_tab() ->
 init(_State) ->
     {ok, Ring} = riak_core_ring_manager:get_raw_ring(),
     Mods = [Mod || {_, Mod} <- riak_core:vnode_modules()],
-    State = #state{forwarding=[], handoff=[]},
+    State = #state{forwarding=[], handoff=[],
+                   known_modules=[], never_started=[]},
     State2 = find_vnodes(State),
     AllVNodes = get_all_vnodes(Mods, State2),
     State3 = update_forwarding(AllVNodes, Mods, Ring, State2),
@@ -215,7 +218,9 @@ handle_cast(management_tick, State) ->
     AllVNodes = get_all_vnodes(Mods, State),
     State2 = update_handoff(AllVNodes, Ring, State),
     trigger_ownership_handoff(Mods, Ring, State2),
-    {noreply, State2};
+    State3 = update_never_started(Ring, State2),
+    State4 = maybe_start_vnodes(State3),
+    {noreply, State4};
 
 handle_cast(_, State) ->
     {noreply, State}.
@@ -251,7 +256,10 @@ code_change(_OldVsn, State, _Extra) ->
 %% ===================================================================
 
 schedule_management_timer() ->
-    timer:apply_after(30000, gen_server, cast, [?MODULE, management_tick]).
+    ManagementTick = app_helper:get_env(riak_core,
+                                        vnode_management_timer,
+                                        30000),
+    timer:apply_after(ManagementTick, gen_server, cast, [?MODULE, management_tick]).
 
 trigger_ownership_handoff(Mods, Ring, State) ->
     Transfers = riak_core_ring:pending_changes(Ring),
@@ -474,4 +482,43 @@ get_all_vnodes_status(State=#state{forwarding=Forwarding, handoff=HO}) ->
                          end, Types2, [Pids2, Forwarding2, Handoff2]),
     Status.
 
+update_never_started(Ring, State) ->
+    {Indices, _} = lists:unzip(riak_core_ring:all_owners(Ring)),
+    lists:foldl(fun({_App, Mod}, StateAcc) ->
+                        case lists:member(Mod, StateAcc#state.known_modules) of
+                            false ->
+                                update_never_started(Mod, Indices, StateAcc);
+                            true ->
+                                StateAcc
+                        end
+                end, State, riak_core:vnode_modules()).
+
+update_never_started(Mod, Indices, State) ->
+    IdxPids =
+        try
+            get_all_index_pid(Mod, State)
+        catch
+            _:_ -> []
+        end,
+    AlreadyStarted = [Idx || {Idx, _Pid} <- IdxPids],
+    NeverStarted = ordsets:subtract(ordsets:from_list(Indices),
+                                    ordsets:from_list(AlreadyStarted)),
+    NeverStarted2 = [{Idx, Mod} || Idx <- NeverStarted],
+    NeverStarted3 = NeverStarted2 ++ State#state.never_started,
+    KnownModules = [Mod | State#state.known_modules],
+    State#state{known_modules=KnownModules, never_started=NeverStarted3}.
+
+maybe_start_vnodes(State=#state{never_started=NeverStarted}) ->
+    MaxStart = app_helper:get_env(riak_core, vnode_rolling_start, 16),
+    Length = length(NeverStarted),
+    Split =
+        case Length < MaxStart of
+            true ->
+                Length;
+            false ->
+                MaxStart
+        end,
+    {Start, NeverStarted2} = lists:split(Split, NeverStarted),
+    [get_vnode(Idx, Mod, State) || {Idx, Mod} <- Start],
+    State#state{never_started=NeverStarted2}.
 

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -266,7 +266,7 @@ code_change(_OldVsn, State, _Extra) ->
 schedule_management_timer() ->
     ManagementTick = app_helper:get_env(riak_core,
                                         vnode_management_timer,
-                                        30000),
+                                        10000),
     timer:apply_after(ManagementTick, gen_server, cast, [?MODULE, management_tick]).
 
 trigger_ownership_handoff(Mods, Ring, State) ->


### PR DESCRIPTION
Change the vnode manager to keep track of which vnodes have been started at least once, and periodically  start nodes that have never been started. This ensures that vnodes responsible for fallback data are eventually started, and therefore perform hinted handoff.

Resolves issue #154

A riak_test for issue #154 has also been pushed into the riak_test repo. Against master, the test should fail. Against this branch, it should pass.

The passing test should look as follows:

```
$ ./riak_test rtdev.config gh_riak_core_154
01:50:50.398 [info] Application lager started on node 'riak_test@127.0.0.1'
01:50:50.401 [info] Riak path: "/tmp/rt"
01:50:50.401 [info] Running: /tmp/rt/dev/dev1/bin/riak stop
01:50:50.401 [info] Running: /tmp/rt/dev/dev2/bin/riak stop
01:50:52.676 [info] Resetting nodes to fresh state
01:50:52.676 [debug] Running: git --git-dir="/tmp/rt/dev/.git" --work-tree="/tmp/rt/dev" reset HEAD --hard
01:50:52.725 [debug] Running: git --git-dir="/tmp/rt/dev/.git" --work-tree="/tmp/rt/dev" clean -fd
01:50:52.766 [info] Running: /tmp/rt/dev/dev1/bin/riak start
01:50:52.766 [info] Running: /tmp/rt/dev/dev2/bin/riak start
01:50:54.741 [debug] Supervisor inet_gethost_native_sup started undefined at pid <0.64.0>
01:50:54.743 [debug] Supervisor kernel_safe_sup started inet_gethost_native:start_link() at pid <0.63.0>
01:50:54.764 [info] Deployed nodes: ['dev1@127.0.0.1','dev2@127.0.0.1']
01:50:54.783 [debug] [join] 'dev2@127.0.0.1' to ('dev1@127.0.0.1'): ok
01:50:55.802 [info] Cluster built: ['dev1@127.0.0.1','dev2@127.0.0.1']
01:50:55.802 [info] Increase handoff concurrency on nodes
01:50:55.802 [info] Running: /tmp/rt/dev/dev1/bin/riak stop
01:50:58.072 [info] Running: /tmp/rt/dev/dev1/bin/riak start
01:51:00.090 [info] Running: /tmp/rt/dev/dev2/bin/riak stop
01:51:02.395 [info] Running: /tmp/rt/dev/dev2/bin/riak start
01:51:04.182 [info] Write data while 'dev2@127.0.0.1' is offline
01:51:04.182 [info] Running: /tmp/rt/dev/dev2/bin/riak stop
01:51:07.080 [info] Verify that 'dev2@127.0.0.1' is missing data
01:51:07.080 [info] Running: /tmp/rt/dev/dev2/bin/riak start
01:51:08.867 [info] Running: /tmp/rt/dev/dev1/bin/riak stop
01:51:11.614 [info] Restart 'dev1@127.0.0.1' and sleep for 5 min, allowing handoff to occur
01:51:11.614 [info] Running: /tmp/rt/dev/dev1/bin/riak start
01:56:13.404 [info] Verify that 'dev2@127.0.0.1' has all data
01:56:13.404 [info] Running: /tmp/rt/dev/dev1/bin/riak stop
01:56:16.497 [info] gh_riak_core_154: passed
```
