### PR TITLE
Raise handoff concurrency to two

### DIFF
--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -65,7 +65,7 @@
         }).
 
 %% this can be overridden with riak_core handoff_concurrency
--define(HANDOFF_CONCURRENCY,1).
+-define(HANDOFF_CONCURRENCY,2).
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).


### PR DESCRIPTION
Now that handoff concurrency limits apply to inbound/outbound, we should set the limit to 2 (conservatively) so that a node can at least handle an inbound and outbound transfer.  1 is too conservative, for a three node cluster only one transfer will ever be active at once.

Users can still set higher using the appenv.
