### PR TITLE
handoff visibility

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -28,6 +28,7 @@
              riak_core_coverage_plan,
              riak_core_eventhandler_guard,
              riak_core_eventhandler_sup,
+             riak_core_format,
              riak_core_gossip,
              riak_core_handoff_listener,
              riak_core_handoff_listener_sup,

--- a/include/riak_core_handoff.hrl
+++ b/include/riak_core_handoff.hrl
@@ -3,3 +3,13 @@
 -define(PT_MSG_OLDSYNC, 2).
 -define(PT_MSG_SYNC, 3).
 -define(PT_MSG_CONFIGURE, 4).
+
+-record(ho_stats,
+        {
+          interval_end          :: erlang:timestamp(),
+          last_update           :: erlang:timestamp(),
+          objs=0                :: non_neg_integer(),
+          bytes=0               :: non_neg_integer()
+        }).
+
+-type ho_stats() :: #ho_stats{}.

--- a/src/riak_core_format.erl
+++ b/src/riak_core_format.erl
@@ -1,0 +1,79 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Functions for formatting data.
+
+-module(riak_core_format).
+-export([fmt/2,
+         human_size_fmt/2,
+         human_time_fmt/2]).
+
+%% @doc Created a string `Str' based on the format string `FmtStr' and
+%%      list of args `Args'.
+-spec fmt(string(), list()) -> Str::string().
+fmt(FmtStr, Args) ->
+    lists:flatten(io_lib:format(FmtStr, Args)).
+
+%% @doc Create a human friendly string `Str' for number of bytes
+%%      `Bytes' and format based on format string `Fmt'.
+-spec human_size_fmt(string(), non_neg_integer()) -> Str::string().
+human_size_fmt(Fmt, Bytes) ->
+    Fmt2 = Fmt ++ " ~s",
+    {Value, Units} = human_size(Bytes, ["B","KB","MB","GB","TB","PB"]),
+    fmt(Fmt2, [Value, Units]).
+
+%% @doc Create a human friendly string `Str' for the given time in
+%%      microseconds `Micros'.  Format according to format string
+%%      `Fmt'.
+-spec human_time_fmt(string(), non_neg_integer()) -> Str::string().
+human_time_fmt(Fmt, Micros) ->
+    Fmt2 = Fmt ++ " ~s",
+    {Value, Units} = human_time(Micros),
+    fmt(Fmt2, [Value, Units]).
+
+%%%===================================================================
+%%% Private
+%%%===================================================================
+
+%% @private
+%%
+%% @doc Formats a byte size into a human-readable size with units.
+%%      Thanks StackOverflow:
+%%      http://stackoverflow.com/questions/2163691/simpler-way-to-format-bytesize-in-a-human-readable-way
+-spec human_size(non_neg_integer(), list()) -> iolist().
+human_size(S, [_|[_|_] = L]) when S >= 1024 -> human_size(S/1024, L);
+human_size(S, [M|_]) ->
+    {float(S), M}.
+
+%% @private
+%%
+%% @doc Given a number of `Micros' returns a human friendly time
+%%      duration in the form of `{Value, Units}'.
+-spec human_time(non_neg_integer()) -> {Value::number(), Units::string()}.
+human_time(Micros) ->
+    human_time(Micros, {1000, "us"}, [{1000, "ms"}, {1000, "s"}, {60, "min"}, {60, "hr"}, {24, "d"}]).
+
+-spec human_time(non_neg_integer(), {pos_integer(), string()},
+                 [{pos_integer(), string()}]) ->
+                        {number(), string()}.
+human_time(T, {Divisor, Unit}, Units) when T < Divisor orelse Units == [] ->
+    {float(T), Unit};
+human_time(T, {Divisor, _}, [Next|Units]) ->
+    human_time(T / Divisor, Next, Units).

--- a/src/riak_core_handoff_sender_sup.erl
+++ b/src/riak_core_handoff_sender_sup.erl
@@ -43,5 +43,6 @@ init ([]) ->
          ]}}.
 
 %% start a sender process
-start_sender (TargetNode,Module,Idx,VnodePid) ->
-    supervisor:start_child(?MODULE,[TargetNode,Module,Idx,VnodePid]).
+-spec start_sender(node(), module(), any(), pid()) -> {ok, Sender::pid()}.
+start_sender(TargetNode, Module, Idx, Vnode) ->
+    supervisor:start_child(?MODULE, [TargetNode, Module, Idx, Vnode]).

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -91,7 +91,8 @@
          ring_changed/2,
          set_cluster_name/2,
          reconcile_names/2,
-         reconcile_members/2]).
+         reconcile_members/2,
+         is_primary/2]).
 
 -export_type([riak_core_ring/0]).
 
@@ -229,6 +230,13 @@ nearly_equal(RingA, RingB) ->
     RingB2 = RingB?CHSTATE{vclock=[], meta=[]},
     TestRing = (RingA2 =:= RingB2),
     TestVC and TestRing.
+
+%% @doc Determine if a given Index/Node `IdxNode' combination is a
+%%      primary.
+-spec is_primary(chstate(), {integer(), node()}) -> boolean().
+is_primary(Ring, IdxNode) ->
+    Owners = all_owners(Ring),
+    lists:member(IdxNode, Owners).
 
 %% @doc Produce a list of all nodes that are members of the cluster
 -spec all_members(State :: chstate()) -> [Node :: term()].


### PR DESCRIPTION
## Purpose

Visibility into handoff is really poor.  The typical method used to
discover handoff information is `riak-admin transfers` but that gives
hardly any useful information, as shown below.

```
'dev3@127.0.0.1' waiting to handoff 7 partitions
'dev2@127.0.0.1' waiting to handoff 4 partitions
'dev1@127.0.0.1' waiting to handoff 5 partitions
```

This PR adds visibility transfers/handoff by tracking various stats on
active transfers and displaying this information in a human friendly
way, as shown below.

```
./dev/dev1/bin/riak-admin transfers
'dev2@127.0.0.1' waiting to handoff 1 partitions
'dev1@127.0.0.1' waiting to handoff 2 partitions

Active Transfers:

transfer type: hinted_handoff
vnode type: riak_kv_vnode
partition: 1096126227998177188652763624537212264741949407232
started: 2012-04-23 03:08:27 [2.02 s ago]
last update: 2012-04-23 03:08:29 [16.97 ms ago]
objects transferred: 5720

                       2857 Objs/s                        
  dev2@127.0.0.1 =======================>   dev3@127.0.0.1
                          23.59 MB/s
```

This PR also gets rid of the annoying side effect of resetting the
inactivity timeout when calling `riak-admin transfers`.  This would
often cause users to wonder why handoffs were never occurring.
## Implementation Details
### vnode folds & status updates

One issue with handoff is that it uses vnode folds to do all it's
work.  This has the one nice benefit that it avoids a local copy of
data (1) but has bad side effect of using uninterruptable fold.  That
is, the vnode fold does the work as fast as it can and doesn't stop
until it's done (2).

In order to get status updates about the handoff the accumulator keeps
some local stats and _approximately_ every 2 seconds sends those stats
to the handoff manager via the `status_update/2` API.  I say the
timing is approximate because expiration of the interval is only
checked during a sender/receiver sync phase (determined by
`ACK_COUNT`).  If the receiver can't keep up or the sender fold is
slow then the status updates could take longer.  Essentially, this
code assumes that `ACK_COUNT` objects can be transferred in less than
2s.  **N.B.** The duration of the status update interval will not
invalidate the stats since they are based on start time and time of
last sync (see `riak_core_handoff_manager:update_stats/2`).

The reason the sender only sends a status update every 2s and only
checks if this interval has expired on sender/receiver sync is because
the vnode fold is a tight loop.  Sending an update for every object
would be too chatty and checking the interval every object could
potentially slow from overhead of getting time and doing math.
### determining transfer type

There are two types of transfer currently, _ownership handoff_ and
_hinted handoff_.  Soon there will be another type, _repair_.  In
order to disambiguate the two types of handoff I have to determine if
the source vnode is primary or not.  In the case of ownership handoff
it is a `primary -> secondary` handoff (where the secondary becomes
primary after handoff completes) and for hinted handoff it's
`secondary -> primary`.
### human friendly formatting

In order to make the stats a little easier to read I added a little
human friendly formatting.  I decided to put the code to support this
in Core rather than KV.  I stole and modified the code from
@seancribbs.
### pull vs. push

One aspect of this PR I'm not wild about is the fact that in order to
get the status a msg must be sent to each handoff manager on each each
node for every time `riak-admin transfers` is called (3).  I'd rather
see a push system where all active status data is collated at a
particular node, like the claimant node in ownership, and the status
call simply reads that.  The pull system is probably fine for now but
could cause trouble on larger clusters, especially if some script
accidentally calls it in a tight loop.
### dict vs. riak_core stats

I'm wondering if I should have make use of the stats API for the
collection of data in the handoff manager rather than a dict?
## Footnotes

1: That is, if the handoff sender process itself was running the
handoff then the vnode data would have to be copied from vnode heap to
sender heap.

2: In the future I think an iterator/cursor based approach to handoff
that is async, interruptable, and rate limited would be good.

3: Which calls `riak_core_status:all_active_transfers` where the RPC
is done.
