### PR TITLE
Slf dtrace take1

### DIFF
--- a/src/riak_core_dtrace.erl
+++ b/src/riak_core_dtrace.erl
@@ -58,12 +58,16 @@ dtrace(ArgList) ->
                         {5.8, _} ->
                             %% R14B04
                             put(?MAGIC, dtrace),
-                            dtrace(ArgList);
+                            if ArgList == enabled_check -> ok;
+                               true                     -> dtrace(ArgList)
+                            end;
                         {Num, _} when Num > 5.8 ->
                             %% R15B or higher, though dyntrace option
                             %% was first available in R15B01.
                             put(?MAGIC, dyntrace),
-                            dtrace(ArgList);
+                            if ArgList == enabled_check -> ok;
+                               true                     -> dtrace(ArgList)
+                            end;
                         _ ->
                             put(?MAGIC, unsupported),
                             false
@@ -73,9 +77,13 @@ dtrace(ArgList) ->
                     false
             end;
         dyntrace ->
-            erlang:apply(dyntrace, p, ArgList);
+            if ArgList == enabled_check -> ok;
+               true                     -> erlang:apply(dyntrace, p, ArgList)
+            end;
         dtrace ->
-            erlang:apply(dtrace, p, ArgList);
+            if ArgList == enabled_check -> ok;
+               true                     -> erlang:apply(dtrace, p, ArgList)
+            end;
         _ ->
             false
     end.
@@ -114,35 +122,7 @@ dtrace(Int0, Int1, Ints, String0, String1, Strings)
     end.
 
 enabled() ->
-    case get(?MAGIC) of
-        undefined ->
-            case application:get_env(riak_core, dtrace_support) of
-                {ok, true} ->
-                    case string:to_float(erlang:system_info(version)) of
-                        {5.8, _} ->
-                            %% R14B04
-                            put(?MAGIC, dtrace),
-                            true;
-                        {Num, _} when Num > 5.8 ->
-                            %% R15B or higher, though dyntrace option
-                            %% was first available in R15B01.
-                            put(?MAGIC, dyntrace),
-                            true;
-                        _ ->
-                            put(?MAGIC, unsupported),
-                            false
-                    end;
-                _ ->
-                    put(?MAGIC, unsupported),
-                    false
-            end;
-        dyntrace ->
-            true;
-        dtrace ->
-            true;
-        _ ->
-            false
-    end.
+    dtrace(enabled_check).
 
 put_tag(Tag) ->
     case enabled() of

--- a/src/riak_core_dtrace.erl
+++ b/src/riak_core_dtrace.erl
@@ -58,14 +58,14 @@ dtrace(ArgList) ->
                         {5.8, _} ->
                             %% R14B04
                             put(?MAGIC, dtrace),
-                            if ArgList == enabled_check -> ok;
+                            if ArgList == enabled_check -> true;
                                true                     -> dtrace(ArgList)
                             end;
                         {Num, _} when Num > 5.8 ->
                             %% R15B or higher, though dyntrace option
                             %% was first available in R15B01.
                             put(?MAGIC, dyntrace),
-                            if ArgList == enabled_check -> ok;
+                            if ArgList == enabled_check -> true;
                                true                     -> dtrace(ArgList)
                             end;
                         _ ->
@@ -77,11 +77,11 @@ dtrace(ArgList) ->
                     false
             end;
         dyntrace ->
-            if ArgList == enabled_check -> ok;
+            if ArgList == enabled_check -> true;
                true                     -> erlang:apply(dyntrace, p, ArgList)
             end;
         dtrace ->
-            if ArgList == enabled_check -> ok;
+            if ArgList == enabled_check -> true;
                true                     -> erlang:apply(dtrace, p, ArgList)
             end;
         _ ->


### PR DESCRIPTION
Add basic infrastructure Erlang-triggerable probes to Riak Core apps.

In an ideal world, this module would live in a repo that would be
easily sharable across multiple Basho projects.  The tricky bit for
this would be trying to make generic the
`application:get_env(riak_core, dtrace_support)' call that's
currently in the`riak_kv_dtrace:dtrace/1' function.  But we'll
wait for another day, I think.

The purpose of this module is to reduce the overhead of DTrace (and
SystemTap) probes when those probes are: 1. not supported by the VM,
or 2. disabled by application configuration.  #1 is the bigger
problem: a single call to the code loader can take several
milliseconds.  #2 is useful in the case that we want to try to reduce
the overhead of adding these probes even further by avoiding the NIF
call entirely.

SLF's MacBook Pro tests

without cover, with R14B04 + DTrace:

```
timeit_naive                 average  2236.306 usec/call over     500.0 calls
timeit_mochiglobal           average     0.509 usec/call over  225000.0 calls
timeit_best OFF (fastest)    average     0.051 usec/call over  225000.0 calls
timeit_best ON -init         average     1.027 usec/call over  225000.0 calls
timeit_best ON +init         average     0.202 usec/call over  225000.0 calls
```

with cover, with R14B04 + DTrace:

```
timeit_naive                 average  2286.202 usec/call over     500.0 calls
timeit_mochiglobal           average     1.255 usec/call over  225000.0 calls
timeit_best OFF (fastest)    average     1.162 usec/call over  225000.0 calls
timeit_best ON -init         average     2.207 usec/call over  225000.0 calls
timeit_best ON +init         average     1.303 usec/call over  225000.0 calls
```
