### PR TITLE
Repair Command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-
+APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \
+	public_key mnesia syntax_tools compiler
+COMBO_PLT = $(HOME)/.riak_core_combo_dialyzer_plt
 
 .PHONY: deps test
 
@@ -13,7 +15,7 @@ deps:
 clean:
 	./rebar clean
 
-distclean: clean 
+distclean: clean
 	./rebar delete-deps
 
 test: all
@@ -22,7 +24,19 @@ test: all
 docs: deps
 	./rebar skip_deps=true doc
 
+build_plt: compile
+	dialyzer --build_plt --output_plt $(COMBO_PLT) --apps $(APPS) \
+		deps/*/ebin apps/*/ebin
+
+check_plt: compile
+	dialyzer --check_plt --plt $(COMBO_PLT) --apps $(APPS) \
+		deps/*/ebin apps/*/ebin
+
 dialyzer: compile
-	@dialyzer -Wno_return -c apps/riak_core/ebin
+	@echo
+	@echo Use "'make check_plt'" to check PLT prior to using this target.
+	@echo Use "'make build_plt'" to build PLT prior to using this target.
+	@echo
+	dialyzer --plt $(COMBO_PLT) ebin
 
 

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ docs: deps
 
 build_plt: compile
 	dialyzer --build_plt --output_plt $(COMBO_PLT) --apps $(APPS) \
-		deps/*/ebin apps/*/ebin
+		deps/*/ebin
 
 check_plt: compile
 	dialyzer --check_plt --plt $(COMBO_PLT) --apps $(APPS) \
-		deps/*/ebin apps/*/ebin
+		deps/*/ebin
 
 dialyzer: compile
 	@echo

--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -47,6 +47,7 @@
              riak_core_node_watcher,
              riak_core_node_watcher_events,
              riak_core_pb,
+             riak_core_repair,
              riak_core_ring,
              riak_core_ring_events,
              riak_core_ring_handler,

--- a/include/riak_core_handoff.hrl
+++ b/include/riak_core_handoff.hrl
@@ -13,3 +13,26 @@
         }).
 
 -type ho_stats() :: #ho_stats{}.
+-type ho_type() :: ownership_handoff | hinted_handoff.
+-type predicate() :: fun((any()) -> boolean()).
+
+-type index() :: integer().
+-type mod_src_tgt() :: {module(), index(), index()}.
+-type mod_partition() :: {module(), index()}.
+
+-record(handoff_status,
+        { mod_src_tgt           :: mod_src_tgt(),
+          src_node              :: node(),
+          target_node           :: node(),
+          direction             :: inbound | outbound,
+          transport_pid         :: pid(),
+          timestamp             :: tuple(),
+          status                :: any(),
+          stats                 :: dict(),
+          vnode_pid             :: pid() | undefined,
+          type                  :: ownership | hinted_handoff | repair,
+          req_origin            :: node(),
+          filter_mod_fun        :: {module(), atom()}
+        }).
+-type handoff() :: #handoff_status{}.
+-type handoffs() :: [handoff()].

--- a/include/riak_core_handoff.hrl
+++ b/include/riak_core_handoff.hrl
@@ -26,10 +26,12 @@
           target_node           :: node(),
           direction             :: inbound | outbound,
           transport_pid         :: pid(),
+          transport_mon         :: reference(),
           timestamp             :: tuple(),
           status                :: any(),
           stats                 :: dict(),
           vnode_pid             :: pid() | undefined,
+          vnode_mon             :: reference(),
           type                  :: ownership | hinted_handoff | repair,
           req_origin            :: node(),
           filter_mod_fun        :: {module(), atom()}

--- a/include/riak_core_handoff.hrl
+++ b/include/riak_core_handoff.hrl
@@ -13,7 +13,7 @@
         }).
 
 -type ho_stats() :: #ho_stats{}.
--type ho_type() :: ownership_handoff | hinted_handoff.
+-type ho_type() :: ownership_handoff | hinted_handoff | repair.
 -type predicate() :: fun((any()) -> boolean()).
 
 -type index() :: integer().
@@ -32,9 +32,8 @@
           stats                 :: dict(),
           vnode_pid             :: pid() | undefined,
           vnode_mon             :: reference(),
-          type                  :: ownership | hinted_handoff | repair,
+          type                  :: ho_type(),
           req_origin            :: node(),
           filter_mod_fun        :: {module(), atom()}
         }).
--type handoff() :: #handoff_status{}.
--type handoffs() :: [handoff()].
+-type handoff_status() :: #handoff_status{}.

--- a/src/riak_core_bucket.erl
+++ b/src/riak_core_bucket.erl
@@ -29,7 +29,10 @@
          set_bucket/2,
          get_bucket/1,
          get_bucket/2,
-         merge_props/2]).
+         get_buckets/1,
+         merge_props/2,
+         name/1,
+         n_val/1]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -107,6 +110,14 @@ get_bucket(Name, Ring) ->
         {ok, Bucket} -> Bucket
     end.
 
+%% @doc Get bucket properties `Props' for all the buckets in the given
+%%      `Ring'
+-spec get_buckets(riak_core_ring:riak_core_ring()) ->
+                         Props::list().
+get_buckets(Ring) ->
+    Names = riak_core_ring:get_buckets(Ring),
+    [get_bucket(Name, Ring) || Name <- Names].
+
 %% @private
 -spec validate_props(BucketProps::list({PropName::atom(), Value::any()}),
                      Validators::list(module()),
@@ -120,6 +131,12 @@ validate_props(_, [], Errors) ->
 validate_props(BucketProps0, [{_App, Validator}|T], Errors0) ->
     {BucketProps, Errors} = Validator:validate(BucketProps0),
     validate_props(BucketProps, T, lists:flatten([Errors|Errors0])).
+
+name(BProps) ->
+    proplists:get_value(name, BProps).
+
+n_val(BProps) ->
+    proplists:get_value(n_val, BProps).
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -98,7 +98,7 @@ status(Filter) ->
 
 %% @doc Send status updates `Stats' to the handoff manager for a
 %%      particular handoff identified by `ModIdx'.
--spec status_update(modindex(), proplists:proplist()) -> ok.
+-spec status_update(modindex(), ho_stats()) -> ok.
 status_update(ModIdx, Stats) ->
     gen_server:cast(?MODULE, {status_update, ModIdx, Stats}).
 

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -117,10 +117,10 @@ status(Filter) ->
     gen_server:call(?MODULE, {status, Filter}).
 
 %% @doc Send status updates `Stats' to the handoff manager for a
-%%      particular handoff identified by `ModIdx'.
+%%      particular handoff identified by `ModSrcTgt'.
 -spec status_update(mod_src_tgt(), ho_stats()) -> ok.
-status_update(ModIdx, Stats) ->
-    gen_server:cast(?MODULE, {status_update, ModIdx, Stats}).
+status_update(ModSrcTgt, Stats) ->
+    gen_server:cast(?MODULE, {status_update, ModSrcTgt, Stats}).
 
 set_concurrency(Limit) ->
     gen_server:call(?MODULE,{set_concurrency,Limit}).

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -264,10 +264,6 @@ handle_cast({status_update, ModSrcTgt, StatsUpdate}, State=#state{handoffs=HS}) 
             {noreply, State#state{handoffs=HS2}}
     end.
 
-handle_info({handoff_finished, {_Mod, _Target}, Handoff, _Reason}, State) ->
-    %% NOTE: this msg will only come in for repair handoff
-    riak_core_vnode_manager:xfer_complete(Handoff),
-    {noreply, State};
 
 handle_info({'DOWN',_Ref,process,Pid,Reason},State=#state{handoffs=HS}) ->
     case lists:keytake(Pid,#handoff_status.transport_pid,HS) of

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -530,8 +530,13 @@ kill_xfer_i(ModSrcTarget, Reason, HS) ->
                             transport_pid=TP
                            } = Xfer,
             Msg = "~p transfer of ~p from ~p ~p to ~p ~p killed for reason ~p",
-            lager:info(Msg, [Type, Mod, SrcNode, SrcPartition,
-                             TargetNode, TargetPartition, Reason]),
+            case Type of
+                undefined ->
+                    ok;
+                _ ->
+                    lager:info(Msg, [Type, Mod, SrcNode, SrcPartition,
+                                     TargetNode, TargetPartition, Reason])
+            end,
             exit(TP, {kill_xfer, Reason}),
             kill_xfer_i(ModSrcTarget, Reason, HS2)
     end.

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -265,7 +265,7 @@ handle_info({'DOWN', Ref, process, _Pid, Reason}, State=#state{handoffs=HS}) ->
                     %% than 'normal' we should log the reason why as an error
                     normal ->
                         false;
-                    max_concurrency ->
+                    {shutdown, max_concurrency} ->
                         lager:info("An ~w handoff of partition ~w ~w was terminated for reason: ~w~n", [Dir,M,I,Reason]),
                         true;
                     _ ->

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -265,7 +265,9 @@ handle_info({'DOWN', Ref, process, _Pid, Reason}, State=#state{handoffs=HS}) ->
                     %% than 'normal' we should log the reason why as an error
                     normal ->
                         false;
-                    {shutdown, max_concurrency} ->
+                    X when X == max_concurrency orelse
+                           (element(1, X) == shutdown andalso
+                            element(2, X) == max_concurrency) ->
                         lager:info("An ~w handoff of partition ~w ~w was terminated for reason: ~w~n", [Dir,M,I,Reason]),
                         true;
                     _ ->

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -374,7 +374,7 @@ incr_objs(Stats=#ho_stats{objs=Objs}) ->
 %% @private
 %%
 %% @doc Check if the interval has elapsed and if so send handoff stats
-%%      for `ModIdx' to the manager and return a new stats record
+%%      for `ModSrcTgt' to the manager and return a new stats record
 %%      `NetStats'.
 -spec maybe_send_status({module(), non_neg_integer(), non_neg_integer()},
                         ho_stats()) ->

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -34,7 +34,7 @@
 -define(log_fail(Str, Args),
         lager:error("~p transfer of ~p from ~p ~p to ~p ~p failed " ++ Str,
                     [Type, Module, SrcNode, SrcPartition, TargetNode,
-                     TargetPartition, Args])).
+                     TargetPartition] ++ Args)).
 
 %% Accumulator for the visit item HOF
 -record(ho_acc,
@@ -206,9 +206,9 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
          exit:{shutdown, timeout} ->
              %% A receive timeout during handoff
              riak_core_stat:update(handoff_timeouts),
-             ?log_fail(" because of TCP recv timeout", []);
+             ?log_fail("because of TCP recv timeout", []);
          Err:Reason ->
-             ?log_fail(" because of ~p:~p ~p",
+             ?log_fail("because of ~p:~p ~p",
                        [Err, Reason, erlang:get_stacktrace()]),
              gen_fsm:send_event(ParentPid, {handoff_error, Err, Reason})
      end.

--- a/src/riak_core_handoff_sender_sup.erl
+++ b/src/riak_core_handoff_sender_sup.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2011 Basho Technologies, Inc.
+%% Copyright (c) 2011-2012 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -21,28 +21,56 @@
 -module(riak_core_handoff_sender_sup).
 -behaviour(supervisor).
 
-%% beahvior functions
+%% callbacks
 -export([start_link/0,
          init/1
         ]).
 
-%% public functions
--export([start_sender/4
+%% API
+-export([start_handoff/5,
+         start_repair/6
         ]).
 
+-include("riak_core_handoff.hrl").
 -define(CHILD(I,Type), {I,{I,start_link,[]},temporary,brutal_kill,Type,[I]}).
 
-%% begins the supervisor, init/1 will be called
+%%%===================================================================
+%%% API
+%%%===================================================================
+
 start_link () ->
     supervisor:start_link({local,?MODULE},?MODULE,[]).
+
+%% @doc Start the handoff process for the module (`Module'), partition
+%%      (`Partition'), and vnode (`VNode') from the local node to the
+%%      target node (`TargetNode').
+-spec start_handoff(ho_type(), module(), any(), pid(), node()) -> {ok, pid()}.
+start_handoff(Type, Module, Partition, VNode, TargetNode) ->
+    Opts = [{src_partition, Partition},
+            {target_partition, Partition},
+            {filter, none}],
+    supervisor:start_child(?MODULE, [TargetNode, Module, {Type, Opts}, VNode]).
+
+%% @doc Start the repair process for the given module (`Module') from
+%%      the local partition (`SrcPartition') to the remote partition
+%%      (`TargetNode' and `TargetPartition') using the filter
+%%      (`Filter').
+-spec start_repair(module(), any(), any(), pid(), node(), predicate() | none) ->
+                          {ok, pid()}.
+start_repair(Module, SrcPartition, TargetPartition, VNode, TargetNode, Filter) ->
+    Type = repair,
+    Opts = [{src_partition, SrcPartition},
+            {target_partition, TargetPartition},
+            {filter, Filter}],
+    supervisor:start_child(?MODULE, [TargetNode, Module, {Type, Opts}, VNode]).
+
+
+%%%===================================================================
+%%% Callbacks
+%%%===================================================================
 
 %% @private
 init ([]) ->
     {ok,{{simple_one_for_one,10,10},
          [?CHILD(riak_core_handoff_sender,worker)
          ]}}.
-
-%% start a sender process
--spec start_sender(node(), module(), any(), pid()) -> {ok, Sender::pid()}.
-start_sender(TargetNode, Module, Idx, Vnode) ->
-    supervisor:start_child(?MODULE, [TargetNode, Module, Idx, Vnode]).

--- a/src/riak_core_repair.erl
+++ b/src/riak_core_repair.erl
@@ -1,0 +1,121 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_core_repair).
+-export([gen_range/3,
+         gen_range_fun/2,
+         gen_range_map/3]).
+
+-include("riak_core_vnode.hrl").
+
+%% GTE = Greater Than or Equal
+%% LTE = Less Than or Equal
+-type range_wrap() :: {wrap, GTE::binary(), LTE::binary()}.
+-type range_nowrap() :: {nowrap, GTE::binary(), LTE::binary()}.
+-type hash_range() :: range_wrap() | range_nowrap().
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+%% @doc Generate the hash `Range' for a given `Target' partition and
+%%      `NVal'.
+%%
+%% Note: The type of NVal should be pos_integer() but dialyzer says
+%%       success typing is integer() and I don't have time for games.
+-spec gen_range(partition(), riak_core_ring:riak_core_ring(), integer()) ->
+                       hash_range().
+gen_range(Target, Ring, NVal) ->
+    Predecessors = chash:predecessors(<<Target:160/integer>>, Ring, NVal+1),
+    [{FirstIdx, Node}|Rest] = Predecessors,
+    Predecessors2 = [{FirstIdx-1, Node}|Rest],
+    Predecessors3 = [<<I:160/integer>> || {I,_} <- Predecessors2],
+    {A,B} = lists:splitwith(fun(E) -> E > <<0:160/integer>> end, Predecessors3),
+    case B of
+        [] ->
+            %% In this case there is no "wrap" around the end of the
+            %% ring so the range check it simply an inclusive
+            %% inbetween.
+            make_nowrap(A);
+
+        [<<0:160/integer>>] ->
+            %% In this case the 0th partition is first so no wrap
+            %% actually occurred.
+            make_nowrap(A ++ B);
+
+        _ ->
+            %% In this case there is a "wrap" around the end of the
+            %% ring.  Either the key is greater than or equal the
+            %% largest or smaller than or equal to the smallest.
+            make_wrap(A, B)
+    end.
+
+
+%% @doc Generate the function that will return the hash range for a
+%%      given `Bucket'.
+-spec gen_range_fun(list(), hash_range()) -> function().
+gen_range_fun(RangeMap, Default) ->
+    fun(Bucket) ->
+            case lists:keyfind(Bucket, 1, RangeMap) of
+                false -> Default;
+                {_, Val} -> Val
+            end
+    end.
+
+%% @doc Generate the map from bucket `B' to hash `Range' that a key
+%%      must fall into to be included for repair on the `Target'
+%%      partition.
+-spec gen_range_map(partition(), chash:chash(), list()) ->
+                           [{B::riak_object:bucket(), Range::hash_range()}].
+gen_range_map(Target, Ring, NValMap) ->
+    [{I, gen_range(Target, Ring, N)} || {I, N} <- NValMap, N > 1].
+
+
+%% ===================================================================
+%% Internal
+%% ===================================================================
+
+%% @private
+%%
+%% @doc Make the `nowrap' tuple representing the range a key hash must
+%% fall into.
+-spec make_nowrap(list()) -> range_nowrap().
+make_nowrap(RingSlice) ->
+    Slice2 = lists:sort(RingSlice),
+    GTE = hd(Slice2),
+    LTE = lists:last(Slice2),
+    {nowrap, GTE, LTE}.
+
+%% @private
+%%
+%% @doc Make `wrap' tuple representing the two ranges, relative to 0,
+%% that a key hash must fall into.
+%%
+%% `RingSliceAfter' contains entries after the wrap around the 0th
+%% partition.  `RingSliceBefore' are entries before wrap and the
+%% including the wrap at partition 0.
+-spec make_wrap(list(), list()) -> range_wrap().
+make_wrap(RingSliceAfter, RingSliceBefore) ->
+            LTE = hd(RingSliceAfter),
+            %% know first element of RingSliceBefore is 0
+            Before2 = tl(RingSliceBefore),
+            GTE = lists:last(Before2),
+            {wrap, GTE, LTE}.
+

--- a/src/riak_core_repair.erl
+++ b/src/riak_core_repair.erl
@@ -43,7 +43,8 @@
 -spec gen_range(partition(), riak_core_ring:riak_core_ring(), integer()) ->
                        hash_range().
 gen_range(Target, Ring, NVal) ->
-    Predecessors = chash:predecessors(<<Target:160/integer>>, Ring, NVal+1),
+    CH = riak_core_ring:chash(Ring),
+    Predecessors = chash:predecessors(<<Target:160/integer>>, CH, NVal+1),
     [{FirstIdx, Node}|Rest] = Predecessors,
     Predecessors2 = [{FirstIdx-1, Node}|Rest],
     Predecessors3 = [<<I:160/integer>> || {I,_} <- Predecessors2],
@@ -82,7 +83,7 @@ gen_range_fun(RangeMap, Default) ->
 %% @doc Generate the map from bucket `B' to hash `Range' that a key
 %%      must fall into to be included for repair on the `Target'
 %%      partition.
--spec gen_range_map(partition(), chash:chash(), list()) ->
+-spec gen_range_map(partition(), riak_core_ring:riak_core_ring(), list()) ->
                            [{B::riak_object:bucket(), Range::hash_range()}].
 gen_range_map(Target, Ring, NValMap) ->
     [{I, gen_range(Target, Ring, N)} || {I, N} <- NValMap, N > 1].

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -106,7 +106,8 @@
          set_cluster_name/2,
          reconcile_names/2,
          reconcile_members/2,
-         is_primary/2]).
+         is_primary/2,
+         chash/1]).
 
 -export_type([riak_core_ring/0]).
 
@@ -247,6 +248,11 @@ nearly_equal(RingA, RingB) ->
 is_primary(Ring, IdxNode) ->
     Owners = all_owners(Ring),
     lists:member(IdxNode, Owners).
+
+%% @doc Return the `CHash' of the ring.
+-spec chash(chstate()) -> CHash::chash:chash().
+chash(?CHSTATE{chring=CHash}) ->
+    CHash.
 
 %% @doc Produce a list of all nodes that are members of the cluster
 -spec all_members(State :: chstate()) -> [Node :: term()].

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -61,6 +61,7 @@
                }).
 
 -include("riak_core_handoff.hrl").
+-include("riak_core_vnode.hrl").
 -define(XFER_EQ(A, B),
         A#handoff_status.mod_src_tgt == B#handoff_status.mod_src_tgt
         andalso A#handoff_status.timestamp == B#handoff_status.timestamp).
@@ -89,9 +90,9 @@ all_vnodes_status() ->
 
 %% @doc Repair the given `ModPartition' pair for `Service' using the
 %%      given `FilterModFun' to filter keys.
--spec repair(atom(), {module(), non_neg_integer()}, {module(), atom()}) ->
-                    {ok, Pairs::[{non_neg_integer(), node()}]} |
-                    {down, Down::[{non_neg_integer(), node()}]} |
+-spec repair(atom(), {module(), partition()}, {module(), atom()}) ->
+                    {ok, Pairs::[{partition(), node()}]} |
+                    {down, Down::[{partition(), node()}]} |
                     ownership_change_in_progress.
 repair(Service, {_Module, Partition}=ModPartition, FilterModFun) ->
     %% Fwd the request to the partition owner to guarentee that there

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -95,7 +95,7 @@ all_vnodes_status() ->
                     {down, Down::[{partition(), node()}]} |
                     ownership_change_in_progress.
 repair(Service, {_Module, Partition}=ModPartition, FilterModFun) ->
-    %% Fwd the request to the partition owner to guarentee that there
+    %% Fwd the request to the partition owner to guarantee that there
     %% is only one request per partition.
     %%
     %% TODO: Pass Ring (or piece of info) to verify receiving nodes

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -45,8 +45,8 @@
         {
           mod_partition         :: mod_partition(),
           filter_mod_fun        :: {module(), atom()},
-          minus_one_xfer        :: handoff(),
-          plus_one_xfer         :: handoff()
+          minus_one_xfer        :: handoff_status(),
+          plus_one_xfer         :: handoff_status()
         }).
 -type repair() :: #repair{}.
 -type repairs() :: [repair()].
@@ -123,7 +123,7 @@ repair_status({_Module, Partition}=ModPartition) ->
     Owner = riak_core_ring:index_owner(Ring, Partition),
     gen_server:call({?MODULE, Owner}, {repair_status, ModPartition}).
 
--spec xfer_complete(node(), handoff()) -> ok.
+-spec xfer_complete(node(), handoff_status()) -> ok.
 xfer_complete(Origin, Xfer) ->
     gen_server:call({?MODULE, Origin}, {xfer_complete, Xfer}).
 
@@ -712,7 +712,7 @@ check_repairs(Repairs) ->
         end,
     lists:reverse(lists:foldl(Check, [], Repairs)).
 
--spec maybe_retry(handoff()) -> Xfer2::handoff().
+-spec maybe_retry(handoff_status()) -> Xfer2::handoff_status().
 maybe_retry(Xfer) ->
     case riak_core_handoff_manager:xfer_status(Xfer) of
         complete -> Xfer;

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -281,6 +281,12 @@ handle_call({repair_status, ModPartition}, _From, State) ->
         #repair{} -> {reply, in_progress, State}
     end;
 
+%% NOTE: The `xfer_complete' logic assumes two things:
+%%
+%%       1. The `xfer_complete' msg will always be sent to the owner
+%%       of the partition under repair (also called the "target").
+%%
+%%       2. The target partition is always a local, primary partition.
 handle_call({xfer_complete, ModSrcTgt}, _From, State) ->
     Repairs = State#state.repairs,
     {Mod, _, Partition} = ModSrcTgt,

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -65,8 +65,7 @@
 -define(XFER_EQ(A, B),
         A#handoff_status.mod_src_tgt == B#handoff_status.mod_src_tgt
         andalso A#handoff_status.timestamp == B#handoff_status.timestamp).
--define(XFER_COMPLETE(X),
-        X#handoff_status.status == complete).
+-define(XFER_COMPLETE(X), X#handoff_status.status == complete).
 -define(DEFAULT_OWNERSHIP_TRIGGER, 8).
 
 %% ===================================================================
@@ -718,6 +717,7 @@ maybe_retry(Xfer) ->
     case riak_core_handoff_manager:xfer_status(Xfer) of
         complete -> Xfer;
         in_progress -> Xfer;
+        max_concurrency -> riak_core_handoff_manager:retry_xfer(Xfer);
         not_found -> riak_core_handoff_manager:retry_xfer(Xfer)
     end.
 

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -727,15 +727,11 @@ maybe_retry(R, {SrcPartition, _}=Src, Xfer) ->
 -spec check_up([{non_neg_integer(), node()}], [node()]) ->
                       true | {false, Down::[{non_neg_integer(), node()}]}.
 check_up(Pairs, UpNodes) ->
-    F = fun({_Partition, Owner}=P, Down) ->
-                case lists:member(Owner, UpNodes) of
-                    true -> Down;
-                    false -> [P|Down]
-                end
-        end,
-    case lists:foldl(F, [], Pairs) of
+    Down = [Pair || {_Partition, Owner}=Pair <- Pairs,
+                    not lists:member(Owner, UpNodes)],
+    case Down of
         [] -> true;
-        Down -> {false, Down}
+        _ -> {false, Down}
     end.
 
 %% @private

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -229,8 +229,7 @@ handle_call(get_tab, _From, State) ->
     {reply, ets:tab2list(State#state.idxtab), State};
 
 handle_call({repair, Service, {Mod,Partition}=ModPartition, FilterModFun},
-            _From, State) ->
-    #state{repairs=Repairs} = State,
+            _From, #state{repairs=Repairs}=State) ->
 
     case get_repair(ModPartition, Repairs) of
         none ->

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -304,7 +304,8 @@ handle_call({xfer_complete, ModSrcTgt}, _From, State) ->
                          POX2 = POX#xfer_status{status=complete},
                          R#repair{plus_one_xfer=POX2};
                     true ->
-                         throw({xfer_complete_matches_none, R, ModSrcTgt})
+                         lager:error("Received xfer_complete for "
+                                     "non-existing xfer: ~p", [ModSrcTgt])
                  end,
 
             case {?XFER_COMPLETE(R2#repair.minus_one_xfer),

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -346,7 +346,8 @@ handle_cast({ring_changed, Ring}, State) ->
     State3 = update_handoff(AllVNodes, Ring, State2),
 
     %% Trigger ownership transfers.
-    trigger_ownership_handoff(Mods, Ring, State3),
+    Transfers = riak_core_ring:pending_changes(Ring),
+    trigger_ownership_handoff(Transfers, Mods, State3),
 
     {noreply, State3};
 

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -755,7 +755,7 @@ check_up(Pairs, UpNodes) ->
                           [{Partition::non_neg_integer(), Owner::node()}].
 repair_pairs(Ring, Partition) ->
     Owner = riak_core_ring:index_owner(Ring, Partition),
-    CH = element(4, Ring),
+    CH = riak_core_ring:chash(Ring),
     [_, Before] = chash:predecessors(<<Partition:160/integer>>, CH, 2),
     [After] = chash:successors(<<Partition:160/integer>>, CH, 1),
     [Before, {Partition, Owner}, After].


### PR DESCRIPTION
Add repair ability

Add the framework needed for services on top of core to provide a
"repair" mechanism.  At this point repair was built with the sole
purpose of repairing data for KV and Search.

The key insight behind repair is that since Riak is a replicated data
store one partition can be rebuilt from the replicas on other
partitions.  Specifically, the adjacent (i.e. before and after)
partitions on the ring, together, contain all the replicas that are
stored on the partition to be repaired.  The rub is that adjacent
partitions also contain replicas that are _not_ meant to be on the
partition under repair.  This means a filter function must be used
while folding over the source partitions to transfer only the data
that belongs.  This is done as efficiently as possible by generating a
hash range for all the buckets and thus avoiding a preflist
calculation for each key.  Only a hash of each key is done, it's range
determined from a bucket->range map, and then the hash is checked
against the range.  The services under repair (i.e. Search or KV) must
provide callback functions to generate these ranges since it is
specific to the service.

In order to not repeat code and capitalize on concurrency control the
repair mechanism is currently an extension of handoff.  This creates
some awkwardness as repair is _not_ handoff.  Some of the differences
include:
1. It needs to filter data during the fold
2. All vnodes involved are primary and thus repair _cannot_ block
3. Repair involves 3 distinct partitions and 3 distinct vnodes
4. Repair does not imply a change of responsibility from one vnode to
   another, but is more a sharing of data

In the future the handoff subsystem should be rewritten around the
notion of "transfers" in which repair, handoff, and ownership are all
different logical operations but use the transfer mechanism
underneath.  Especially now that repair is in it should be more clear
what that system should look like to meet the goals of all 3.

The idea of repair lives in the vnode manager as it is very much a
vnode semantic.  This is important because other things like handoff
and ownership also affect vnodes and thus affect repair.  The vnode
manager controls the logical repair, but the handoff/transfer
mechanism controls the physical movement of replicas from source to
target.

For now, it seemed easiest and smartest to _not_ allow ownership
change and repair to run concurrently.  In the event that an ownership
change is detected all repairs will be hard killed, regardless of
status.

In the case were the low-level repair transfer is killed because of
`handoff_concurrency` a msg is _not_ sent back to the vnode mgr to
indicate a failure for that transfer.  Instead, the vnode mgr has a
period tick.  During each tick the vnode mgr checks the status of all
it's repairs and retries any transfers that have since died for a
reason other than completion.
