### PR TITLE
Handoffs on a different network

### DIFF
--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -48,6 +48,9 @@ start_fold(TargetNode, Module, Partition, ParentPid, SslOpts) ->
          [_Name,Host] = string:tokens(atom_to_list(TargetNode), "@"),
          {ok, Port} = get_handoff_port(TargetNode),
          {ok, TNHandoffIP} = get_handoff_ip(TargetNode),
+         TNHandoffIP = if TNHandoffIP == "0.0.0.0" -> Host;
+                         true -> TNHandoffIP
+                      end,
          SockOpts = [binary, {packet, 4}, {header,1}, {active, false}],
          {Socket, TcpMod} =
              if SslOpts /= [] ->

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -47,14 +47,15 @@ start_fold(TargetNode, Module, Partition, ParentPid, SslOpts) ->
      try
          [_Name,Host] = string:tokens(atom_to_list(TargetNode), "@"),
          {ok, Port} = get_handoff_port(TargetNode),
+         {ok, TNHandoffIP} = get_handoff_ip(TargetNode),
          SockOpts = [binary, {packet, 4}, {header,1}, {active, false}],
          {Socket, TcpMod} =
              if SslOpts /= [] ->
-                     {ok, Skt} = ssl:connect(Host, Port, SslOpts ++ SockOpts,
+                     {ok, Skt} = ssl:connect(TNHandoffIP, Port, SslOpts ++ SockOpts,
                                              15000),
                      {Skt, ssl};
                 true ->
-                     {ok, Skt} = gen_tcp:connect(Host, Port, SockOpts, 15000),
+                     {ok, Skt} = gen_tcp:connect(TNHandoffIP, Port, SockOpts, 15000),
                      {Skt, gen_tcp}
              end,
 
@@ -234,6 +235,14 @@ visit_item(K, V, {Socket, Parent, Module, TcpMod, Ack, Total, Stats,
         {error, Reason} ->
             {Socket, Parent, Module, TcpMod, Ack, Total, Stats3,
              Partition, {error, Reason}}
+    end.
+
+get_handoff_ip(Node) when is_atom(Node) ->
+    case catch(gen_server2:call({riak_core_handoff_listener, Node}, handoff_ip, infinity)) of
+        {'EXIT', _}  ->
+            %% Check old location from previous release
+            gen_server2:call({riak_kv_handoff_listener, Node}, handoff_ip, infinity);
+        Other -> Other
     end.
 
 get_handoff_port(Node) when is_atom(Node) ->

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -48,9 +48,13 @@ start_fold(TargetNode, Module, Partition, ParentPid, SslOpts) ->
          [_Name,Host] = string:tokens(atom_to_list(TargetNode), "@"),
          {ok, Port} = get_handoff_port(TargetNode),
          {ok, TNHandoffIP} = get_handoff_ip(TargetNode),
-         TNHandoffIP = if TNHandoffIP == "0.0.0.0" -> Host;
-                         true -> TNHandoffIP
-                      end,
+         TNHandoffIP =
+            case get_handoff_ip(TargetNode) of
+                {ok, "0.0.0.0"} ->
+                    Host;
+                {ok, Other} ->
+                    Other
+            end,
          SockOpts = [binary, {packet, 4}, {header,1}, {active, false}],
          {Socket, TcpMod} =
              if SslOpts /= [] ->


### PR DESCRIPTION
This small change is intended to make riak handle the situation when a node's handoff ip is different from the ip associated with its node name. Without this feature, separating handoffs from other cluster communication is complicated and involves advanced routing configuration.
