### PR TITLE
Backport handoff_ip bug fix from master to 1.1

### DIFF
--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -45,9 +45,13 @@ start_fold(TargetNode, Module, Partition, ParentPid, SslOpts) ->
          [_Name,Host] = string:tokens(atom_to_list(TargetNode), "@"),
          {ok, Port} = get_handoff_port(TargetNode),
          {ok, TNHandoffIP} = get_handoff_ip(TargetNode),
-         TNHandoffIP = if TNHandoffIP == "0.0.0.0" -> Host;
-                         true -> TNHandoffIP
-                      end,
+         TNHandoffIP =
+            case get_handoff_ip(TargetNode) of
+                {ok, "0.0.0.0"} ->
+                    Host;
+                {ok, Other} ->
+                    Other
+            end,
          SockOpts = [binary, {packet, 4}, {header,1}, {active, false}],
          {Socket, TcpMod} =
              if SslOpts /= [] ->

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -45,6 +45,9 @@ start_fold(TargetNode, Module, Partition, ParentPid, SslOpts) ->
          [_Name,Host] = string:tokens(atom_to_list(TargetNode), "@"),
          {ok, Port} = get_handoff_port(TargetNode),
          {ok, TNHandoffIP} = get_handoff_ip(TargetNode),
+         TNHandoffIP = if TNHandoffIP == "0.0.0.0" -> Host;
+                         true -> TNHandoffIP
+                      end,
          SockOpts = [binary, {packet, 4}, {header,1}, {active, false}],
          {Socket, TcpMod} =
              if SslOpts /= [] ->


### PR DESCRIPTION
Backport handoff_ip bug fix from pull request #176 from master to 1.1.

Master commit: fae63a8d5f441a39914212a0a040311c2b3b1bc0

Change handoff_sender to respect the custom handoff_ip setting configured
on the handoff target node. Prior to this change, the listener would bind
to the configured IP address, but the sender would attempt to connect to
the default IP address associated with the node name.

Thanks go to @micmac for providing the initial version of this patch.
