### PR TITLE
ClaimV3

### DIFF
--- a/src/riak_core_claim.erl
+++ b/src/riak_core_claim.erl
@@ -763,8 +763,8 @@ build_nis(Wants, Owners) ->
                                  end, {0, Initial}, Owners),
     [{Node, Want, Owned} || {Node, Want} <- Wants, {Node1, Owned} <- Ownership, Node == Node1].
 
-%% For each node in wants, work out how many more partition it wants (positive) or is
-%% overlaoded by (negative)
+%% For each node in wants, work out how many more partition each node wants (positive) or is
+%% overloaded by (negative) compared to what it owns.
 wants_owns_diff(Wants, Owns) ->
     [ case lists:keyfind(N, 1, Owns) of
           {N, O} ->

--- a/src/riak_core_claim.erl
+++ b/src/riak_core_claim.erl
@@ -49,7 +49,7 @@
 
 %% A good way to decide on the setting of target_n_val for your application is
 %% to set it to the largest value you expect to use for any bucket's n_val.  The
-%% default is 3.
+%% default is 4.
 
 -module(riak_core_claim).
 -export([claim/1, claim/3, claim_until_balanced/2, claim_until_balanced/4]).
@@ -218,7 +218,7 @@ wants_claim_v3(Ring, _Node) ->
                     %% Otherwise, base wants decision on whether the current 
                     %% wants versus current ownership if the claim does not
                     %% manage to claim all requested nodes then the temporary
-                    %% 'claim_v3' metadatawill stop the loop
+                    %% 'claim_v3' metadata will stop the loop
                     Owns = get_counts(riak_core_ring:claiming_members(Ring),
                                       riak_core_ring:all_owners(Ring)),
                     Deltas = wants_owns_diff(Wants, Owns),
@@ -387,7 +387,7 @@ choose_claim_v3(Ring) ->
     choose_claim_v3(Ring, node()).
 
 choose_claim_v3(Ring, ClaimNode) ->
-    Params = [{target_n_val, app_helper:get_env(riak_core, target_n_val, 3)}],
+    Params = [{target_n_val, app_helper:get_env(riak_core, target_n_val, 4)}],
     choose_claim_v3(Ring, ClaimNode, Params).
 
 choose_claim_v3(Ring, _ClaimNode, Params) ->

--- a/src/riak_core_claim_sim.erl
+++ b/src/riak_core_claim_sim.erl
@@ -520,7 +520,8 @@ commission_tests_rest() ->
 
 commission_claims() ->
     [{{riak_core_claim, wants_claim_v1}, {riak_core_claim, choose_claim_v1}},
-     {{riak_core_claim, wants_claim_v2}, {riak_core_claim, choose_claim_v2}}].
+     {{riak_core_claim, wants_claim_v2}, {riak_core_claim, choose_claim_v2}},
+     {{riak_core_claim, wants_claim_v3}, {riak_core_claim, choose_claim_v3}}].
 
 
 %% -------------------------------------------------------------------


### PR DESCRIPTION
Claim V3 - unlike the v1/v2 algorithms, v3 treats claim as an optimization problem. In it's current form it creates a number of possible claim plans and evaluates them for violations, balance and diversity, choosing the 'best' plan.

Violations are a count of how many partitions owned by the same node are within target-n of one another. Lower is better, 0 is desired if at all possible.

Balance is a measure of the number of partitions owned versus the number of partitions wanted.  Want is supplied to the algorithm by the caller as a list of node/counts.  The score for deviation is the RMS of the difference between what the node wanted and what it has.  Lower is better, 0 if all wants are mets.

Diversity measures how often nodes are close to one another in the preference list.  The more diverse (spread of distances apart), the more evenly the responsibility for a failed node is spread across the cluster.  Diversity is calculated by working out the count of each distance for each node pair
(currently distances are limited up to target N) and computing the RMS on that. Lower diversity score is better, 0 if nodes are perfectly diverse.

For testing and playing around, you may want to look at running riak_core_claim_sim:commission(). which will run comparisons against the v1/v2 claim algorithm for some preset combinations of ring size, number of nodes, and target n.

You could also play with riak_core_claim_sim:print_failure_analysis(Ring, TargetN, NumFailures) which prints reports on the console for how a ring does given a target N and number of nodes to fail.

This code is based on the jdm-claim-sim branch - conflicts with the cluster management changes will need to be resolved between the three branches before we can merge.
