### PR TITLE
Add riak_core_claim:never_wants_claim/2

### DIFF
--- a/src/riak_core_claim.erl
+++ b/src/riak_core_claim.erl
@@ -54,7 +54,8 @@
 -module(riak_core_claim).
 -export([default_wants_claim/1, default_wants_claim/2,
          default_choose_claim/1, default_choose_claim/2,
-         never_wants_claim/1, random_choose_claim/1]).
+         never_wants_claim/1, never_wants_claim/2,
+         random_choose_claim/1]).
 -export([wants_claim_v1/1, wants_claim_v1/2,
          wants_claim_v2/1, wants_claim_v2/2,
          choose_claim_v1/1, choose_claim_v1/2,
@@ -298,6 +299,7 @@ random_choose_claim(Ring0, Node) ->
 %% @spec never_wants_claim(riak_core_ring()) -> no
 %% @doc For use by nodes that should not claim any partitions.
 never_wants_claim(_) -> no.
+never_wants_claim(_, _) -> no.
 
 %% ===================================================================
 %% Private


### PR DESCRIPTION
Add 2-arity version of never_wants_claim because the claimant logic introduced back in Riak 1.0 uses 2-arity claim functions rather than the older 1-arity functions.

This is necessary for users to disable partition claim on their clusters, which is something we commonly do during support scenarios (add we've manually hot-patched this 2-arity fun into production clusters in recent months to do just that, given that it was missing in our releases).
