### PR TITLE
capabilities can `badmatch` during `update_ring`

### DIFF
--- a/src/riak_core_capability.erl
+++ b/src/riak_core_capability.erl
@@ -165,12 +165,18 @@ update_ring(Ring) ->
     %% possible that the ETS table does not yet exist, or that the
     %% '$supported' key has not yet been written. Therefore, we catch
     %% any errors and return an unmodified ring.
-    try
-        [{_, Supported}] = ets:lookup(?ETS, '$supported'),
-        add_supported_to_ring(node(), Supported, Ring)
-    catch
-        _:_ ->
-            Ring
+    Supported = try
+                    [{_, Sup}] = ets:lookup(?ETS, '$supported'),
+                    Sup
+                catch
+                    _:_ ->
+                        error
+                end,
+    case Supported of
+        error ->
+            {false, Ring};
+        _ ->
+            add_supported_to_ring(node(), Supported, Ring)
     end.
 
 %% @doc Internal callback used by `riak_core_ring_handler' to notify the

--- a/src/riak_core_capability.erl
+++ b/src/riak_core_capability.erl
@@ -161,8 +161,17 @@ all() ->
 %% @doc Add the local node's supported capabilities to the given
 %% ring. Currently used during the `riak-admin join' process
 update_ring(Ring) ->
-    [{_, Supported}] = ets:lookup(?ETS, '$supported'),
-    add_supported_to_ring(node(), Supported, Ring).
+    %% If a join occurs immediately after a node has started, it is
+    %% possible that the ETS table does not yet exist, or that the
+    %% '$supported' key has not yet been written. Therefore, we catch
+    %% any errors and return an unmodified ring.
+    try
+        [{_, Supported}] = ets:lookup(?ETS, '$supported'),
+        add_supported_to_ring(node(), Supported, Ring)
+    catch
+        _:_ ->
+            Ring
+    end.
 
 %% @doc Internal callback used by `riak_core_ring_handler' to notify the
 %%      capability manager of a new ring


### PR DESCRIPTION
I've noticed this several times now while running tests for the repair
work.  There is some race condition or something causing the
`$supported` entry not to be written when this code path is hit.
Looking at the code I'm not sure how it is possible but coding for
this case would probably be smart anyways to future proof things.

Probably want to fix this before 1.2 @jtuple.

```
10:58:28.373 [debug] [join] 'dev2@127.0.0.1' to ('dev1@127.0.0.1'): {badrpc,{'EXIT',{{badmatch,[]},[{riak_core_capability,update_ring,1},{riak_core,standard_join,3},{rpc,'-handle
_call_call/6-fun-0-',5}]}}}
escript: exception error: {assertEqual_failed,
                  [{module,rt},
                   {line,87},
                   {expression,"R"},
                   {expected,ok},
                   {value,
                    {badrpc,
                     {'EXIT',
                      {{badmatch,[]},
                       [{riak_core_capability,update_ring,1},
                        {riak_core,standard_join,3},
                        {rpc,'-handle_call_call/6-fun-0-',5}]}}}}]}
  in function  rt:'-join/2-fun-0-'/2
  in call from rt:join/2
  in call from rt:'-build_cluster/2-lc$^1/1-1-'/2
  in call from rt:build_cluster/2
  in call from partition_repair:partition_repair/0
  in call from riak_test:main/1
```
