### PR TITLE
global:safe_whereis_name/1 has been removed

### DIFF
--- a/src/gen_server2.erl
+++ b/src/gen_server2.erl
@@ -956,7 +956,7 @@ get_proc_name({local, Name}) ->
 	    exit(process_not_registered)
     end;    
 get_proc_name({global, Name}) ->
-    case global:safe_whereis_name(Name) of
+    case global:whereis_name(Name) of
 	undefined ->
 	    exit(process_not_registered_globally);
 	Pid when Pid =:= self() ->
@@ -978,7 +978,7 @@ get_parent() ->
 name_to_pid(Name) ->
     case whereis(Name) of
 	undefined ->
-	    case global:safe_whereis_name(Name) of
+	    case global:whereis_name(Name) of
 		undefined ->
 		    exit(could_not_find_registerd_name);
 		Pid ->


### PR DESCRIPTION
There is no such function global:safe_whereis_name/1 in R15B anymore. RabbitMQ folks already replaced it with a plain global:whereis_name/1 function  - see rabbitmq/rabbitmq-server@0d3001e0e167ea2463e4c0a7ca45c3b0cb230c1f.
