### PR TITLE
Eunit cleanups

### DIFF
--- a/src/merkerl.erl
+++ b/src/merkerl.erl
@@ -50,8 +50,6 @@
 -module(merkerl).
 -export([insert/2,delete/2,build_tree/1,diff/2,allkeys/1]).
 
--include_lib("eunit/include/eunit.hrl").
-
 % TODO: fix doc, userdata is the ONLY user-exposed key
 -record(merk, {nodetype,           % atom: expected values are 'leaf' or 'inner'
                key=undefined,      % if nodetype=leaf, then this is binary/160
@@ -328,6 +326,9 @@ getkids(Tree) ->
 sha(X) ->
     crypto:sha(term_to_binary(X)).
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
 % @spec merkle_test() -> bool()
 % @doc A test function and example code.
 %
@@ -365,4 +366,4 @@ merkle_test() ->
     I2 = build_tree(I),
     ?assertEqual(2, length(allkeys(I2))).
 
-
+-endif.

--- a/src/riak_core_dtrace.erl
+++ b/src/riak_core_dtrace.erl
@@ -40,8 +40,6 @@
 
 -module(riak_core_dtrace).
 
--include_lib("eunit/include/eunit.hrl").
-
 -export([dtrace/1, dtrace/3, dtrace/4, dtrace/6]).
 -export([enabled/0, put_tag/1]).
 -export([timeit0/1, timeit_mg/1, timeit_best/1]).   % debugging/testing only
@@ -187,6 +185,7 @@ timeit_best(ArgList) ->
     dtrace(ArgList).
 
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 
 timeit_naive_test() ->
     test_common("timeit_naive",

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -23,7 +23,6 @@
 %% @doc the local view of the cluster's ring configuration
 
 -module(riak_core_ring_manager).
--include_lib("eunit/include/eunit.hrl").
 -define(RING_KEY, riak_ring).
 -behaviour(gen_server2).
 


### PR DESCRIPTION
This pull request consists of two small patches. One just removes duplicated eunit inclusion. Another one ensures that all eunit includes are surrounded by -if..-endif block to prevent compiling with implicit compile(all) directive when it's not required etc. Both patches looks to be pretty safe to apply.
