### PR TITLE
fix core vnode eqc

### DIFF
--- a/test/core_vnode_eqc.erl
+++ b/test/core_vnode_eqc.erl
@@ -62,7 +62,10 @@ simple_test_() ->
 setup_simple() ->
     Vars = [{ring_creation_size, 8},
             {ring_state_dir, "<nostore>"},
-            {cluster_name, "test"}],
+            {cluster_name, "test"},
+            %% Don't allow rolling start of vnodes as it will cause a
+            %% race condition with `all_nodes'.
+            {vnode_rolling_start, 0}],
     OldVars = [begin
                    Old = app_helper:get_env(riak_core, AppKey),
                    ok = application:set_env(riak_core, AppKey, Val),


### PR DESCRIPTION
This PR addresses two things:
1. Return useful msgs when a post-condtition fails rather than just saying it failed.
2. Disable rolling vnode starts to avoid hitting race condition in the `all_nodes` post-condition.
