### PR TITLE
Fix capability bug and fix staged clustering in mixed-version clusters

### DIFF
--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -107,6 +107,9 @@ start(_StartType, _StartArgs) ->
                                           {riak_core,
                                            legacy_vnode_routing,
                                            [{true, legacy}, {false, proxy}]}),
+            riak_core_capability:register({riak_core, staged_joins},
+                                          [true, false],
+                                          false),
 
             {ok, Pid};
         {error, Reason} ->

--- a/src/riak_core_capability.erl
+++ b/src/riak_core_capability.erl
@@ -126,7 +126,7 @@ register(Capability, Supported, Default, LegacyVar) ->
 %% as the default value. The order of modes in `Supported' determines the mode
 %% preference -- modes listed earlier are more preferred.
 register(Capability, Supported, Default) ->
-    register(Capability, Supported, Default, []).
+    register(Capability, Supported, Default, undefined).
 
 %% @doc Query the current negotiated mode for a given capability, throwing an
 %%      exception if the capability is unknown or the capability system is
@@ -557,6 +557,9 @@ query_capabilities(Node, #state{registered=Registered}) ->
                            {Cap, ResolvedAcc and Resv}
                    end, true, Registered).
 
+query_capability(_, Capability, DefaultSup, undefined) ->
+    Default = {Capability, [DefaultSup]},
+    {true, Default};
 query_capability(Node, Capability, DefaultSup, {App, Var, Map}) ->
     Default = {Capability, [DefaultSup]},
     Result = rpc:call(Node, application, get_env, [App, Var]),

--- a/src/riak_core_claimant.erl
+++ b/src/riak_core_claimant.erl
@@ -687,10 +687,16 @@ are_joining_nodes(CState) ->
 %% @private
 maybe_handle_auto_joining(Node, CState) ->
     Joining = riak_core_ring:members(CState, [joining]),
-    Auto = [Member || Member <- Joining,
-                      riak_core_ring:get_member_meta(CState,
-                                                     Member,
-                                                     '$autojoin') == true],
+    Auto =
+        case riak_core_capability:get({riak_core, staged_joins}, false) of
+            false ->
+                Joining;
+            true ->
+                [Member || Member <- Joining,
+                           riak_core_ring:get_member_meta(CState,
+                                                          Member,
+                                                          '$autojoin') == true]
+        end,
     maybe_handle_joining(Node, Auto, CState).
 
 %% @private


### PR DESCRIPTION
This pull-request fixes two bugs.

Capabilities registered without legacy app var compatibility logic were broken, triggering a badmatch. This pull-request fixes this issue.

Joining a pre-staged clustering node to a newer cluster would result in the node joining the cluster in `joining` state but never transitioning to `valid`. This has also been fixed, by defaulting to 'auto-join' behavior unless a new capability `staged_joins` is negotiated.
