### PR TITLE
Stuck a 30s time limit on adjacency test with 60s eunit timeout.

### DIFF
--- a/src/riak_core_claim_util.erl
+++ b/src/riak_core_claim_util.erl
@@ -610,8 +610,8 @@ substitute(Names, Mapping, L) ->
 -ifdef(TEST).
 -ifdef(EQC).
 
-prop_adjacency_summary_test() ->
-    ?assert(eqc:quickcheck(prop_adjacency_summary())).
+prop_adjacency_summary_test_() ->
+    {timeout, 60, ?_test(eqc:quickcheck(eqc:testing_time(30, prop_adjacency_summary())))}.
 
 longer_list(K, G) ->
     ?SIZED(Size, resize(trunc(K*Size), list(resize(Size, G)))).


### PR DESCRIPTION
Should unbreak eunit.
