### PR TITLE
Fix handoff_ip bug in mixed version clusters

### DIFF
--- a/src/riak_core_handoff_listener.erl
+++ b/src/riak_core_handoff_listener.erl
@@ -27,7 +27,7 @@
 -export([start_link/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
--export([sock_opts/0, new_connection/2]).
+-export([get_handoff_ip/0, sock_opts/0, new_connection/2]).
 -record(state, {
           ipaddr :: string(),
           portnum :: integer(),
@@ -39,6 +39,9 @@ start_link() ->
     IpAddr = app_helper:get_env(riak_core, handoff_ip),
     SslOpts = riak_core_handoff_sender:get_handoff_ssl_options(),
     gen_nb_server:start_link(?MODULE, IpAddr, PortNum, [IpAddr, PortNum, SslOpts]).
+
+get_handoff_ip() ->
+    gen_server2:call(?MODULE, handoff_ip, infinity).
 
 init([IpAddr, PortNum, SslOpts]) ->
     register(?MODULE, self()),

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -279,11 +279,12 @@ visit_item(K, V, Acc) ->
     end.
 
 get_handoff_ip(Node) when is_atom(Node) ->
-    try
-        gen_server2:call({riak_core_handoff_listener, Node}, handoff_ip, infinity)
-    catch
-        _:_ ->
-            error
+    case rpc:call(Node, riak_core_handoff_listener, get_handoff_ip, [],
+                  infinity) of
+        {badrpc, _} ->
+            error;
+        Res ->
+            Res
     end.
 
 get_handoff_port(Node) when is_atom(Node) ->


### PR DESCRIPTION
This pull-request fixes the handoff ip bug identified by @rzezeski when investigating failures in the rolling upgrade basho_expect test. The change replaces the use of a `gen_server:call` with an `rpc:call` to prevent older nodes from crashes because they do not expect the `handoff_ip` message.

This pull-request also addresses another issue with cluster transitions stalling due to either missing ring change events, or due to a race between cluster capabilities negotiation and claimant transitions. This bug was hit when working on an automated test to trigger the original handoff ip bug that was being fixed.

I've also added a new `verify_basic_upgrade` to `riak_test` that verifies correct behavior after these changes (failing without). We will need to re-build packages and verify against the basho_expect rolling upgrade test to see if there are any other issues.
