### PR TITLE
Unpin the protobuffs dependency.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,8 +7,8 @@
 {deps, [
   {lager, ".*", {git, "git://github.com/basho/lager", {branch, "master"}}},
   {poolboy, ".*", {git, "git://github.com/basho/poolboy", {branch, "master"}}},
-  {protobuffs, "0.6.0", {git, "git://github.com/basho/erlang_protobuffs",
-                              {tag, "protobuffs-0.6.0"}}},
+  {protobuffs, "0.6.*", {git, "git://github.com/basho/erlang_protobuffs",
+                              {branch, "master"}}},
   {basho_stats, ".*", {git, "git://github.com/basho/basho_stats", "HEAD"}},
   {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon", {branch, "master"}}},
   {webmachine, ".*", {git, "git://github.com/basho/webmachine",


### PR DESCRIPTION
When using the tag, this prevents riak_pb from using the correct dependency version, breaking lots of functionality. riak_core should be using the same version as riak_pb.
