### PR TITLE
Fix bug that caused ring to be forcibly updated continuously

### DIFF
--- a/src/riak_core_claimant.erl
+++ b/src/riak_core_claimant.erl
@@ -470,8 +470,10 @@ tick(State) ->
     State.
 
 maybe_force_ring_update() ->
-    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
-    case riak_core_ring:claimant(Ring) == node() of
+    {ok, Ring} = riak_core_ring_manager:get_raw_ring(),
+    IsClaimant = (riak_core_ring:claimant(Ring) == node()),
+    IsReady = riak_core_ring:ring_ready(Ring),
+    case IsClaimant and IsReady of
         true ->
             maybe_force_ring_update(Ring);
         false ->


### PR DESCRIPTION
Change riak_core_claimant to only force a ring update of a stalled ring if the ring is "ready" and has therefore already converged across the cluster. Without this change, ring convergence always appears to be stalled if a node is offline and therefore the force update happens over and over.
