### PR TITLE
Restart vnode worker pool in case of crash.

### DIFF
--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -516,6 +516,9 @@ handle_info({'EXIT', Pid, Reason},
             continue(State#state{pool_pid=undefined});
         _ ->
             lager:error("~p ~p worker pool crashed ~p\n", [Index, Mod, Reason]),
+            lager:debug("starting worker pool ~p with size"
+                        "of ~p for vnode ~p.",
+                        [WorkerModule, PoolSize, Index]),
             {pool, WorkerModule, PoolSize, WorkerArgs}=PoolConfig,
             {ok, NewPoolPid} =
                 riak_core_vnode_worker_pool:start_link(WorkerModule,

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -40,6 +40,11 @@
          core_status/1,
          handoff_error/3]).
 
+-ifdef(TEST).
+-export([test_link/2,
+         current_state/1]).
+-endif.
+
 -define(normal_reason(R),
         (R == normal orelse R == shutdown orelse
                                             (is_tuple(R) andalso element(1,R) == shutdown))).
@@ -450,6 +455,8 @@ handle_event(R=?COVERAGE_REQ{}, _StateName, State) ->
     active(R, State).
 
 
+handle_sync_event(current_state, _From, StateName, State) ->
+    {reply, {StateName, State}, StateName, State};
 handle_sync_event(get_mod_index, _From, StateName,
                   State=#state{index=Idx,mod=Mod}) ->
     {reply, {Mod, Idx}, StateName, State, State#state.inactivity_timeout};
@@ -517,7 +524,7 @@ handle_info({'EXIT', Pid, Reason},
         _ ->
             lager:error("~p ~p worker pool crashed ~p\n", [Index, Mod, Reason]),
             {pool, WorkerModule, PoolSize, WorkerArgs}=PoolConfig,
-            lager:debug("starting worker pool ~p with size"
+            lager:debug("starting worker pool ~p with size "
                         "of ~p for vnode ~p.",
                         [WorkerModule, PoolSize, Index]),
             {ok, NewPoolPid} =
@@ -677,3 +684,62 @@ stop_manager_event_timer(#state{manager_event_timer=undefined}) ->
     ok;
 stop_manager_event_timer(#state{manager_event_timer=T}) ->
     gen_fsm:cancel_timer(T).
+
+%% ===================================================================
+%% Test API
+%% ===================================================================
+
+-ifdef(TEST).
+
+%% @doc Start the garbage collection server
+test_link(Mod, Index) ->
+    gen_fsm:start_link(?MODULE, [Mod, Index, 0, node()], []).
+
+%% @doc Get the current state of the fsm for testing inspection
+-spec current_state(pid()) -> {atom(), #state{}} | {error, term()}.
+current_state(Pid) ->
+    gen_fsm:sync_send_all_state_event(Pid, current_state).
+
+pool_death_test() ->
+    meck:new(test_vnode),
+    meck:expect(test_vnode, init, fun(_) -> {ok, [], [{pool, test_pool_mod, 1, []}]} end),
+    meck:expect(test_vnode, terminate, fun(_, _) -> normal end),
+    meck:new(test_pool_mod),
+    meck:expect(test_pool_mod, init_worker, fun(_, _, _) -> {ok, []} end),
+
+    {ok, Pid} = ?MODULE:test_link(test_vnode, 0),
+    {_, StateData1} = ?MODULE:current_state(Pid),
+    PoolPid1 = StateData1#state.pool_pid,
+    exit(PoolPid1, kill),
+    wait_for_process_death(PoolPid1),
+    ?assertNot(is_process_alive(PoolPid1)),
+    wait_for_state_update(StateData1, Pid),
+    {_, StateData2} = ?MODULE:current_state(Pid),
+    PoolPid2 = StateData2#state.pool_pid,
+    ?assertNot(PoolPid2 =:= undefined),
+    exit(Pid, normal),
+    wait_for_process_death(Pid),
+    meck:validate(test_pool_mod),
+    meck:validate(test_vnode),
+    meck:unload(test_pool_mod),
+    meck:unload(test_vnode).
+
+wait_for_process_death(Pid) ->
+    wait_for_process_death(Pid, is_process_alive(Pid)).
+
+wait_for_process_death(Pid, true) ->
+    wait_for_process_death(Pid, is_process_alive(Pid));
+wait_for_process_death(_Pid, false) ->
+    ok.
+
+wait_for_state_update(OriginalStateData, Pid) ->
+    {_, CurrentStateData} = ?MODULE:current_state(Pid),
+    wait_for_state_update(OriginalStateData, CurrentStateData, Pid).
+
+wait_for_state_update(OriginalStateData, OriginalStateData, Pid) ->
+    {_, CurrentStateData} = ?MODULE:current_state(Pid),
+    wait_for_state_update(OriginalStateData, CurrentStateData, Pid);
+wait_for_state_update(_OriginalState, _StateData, _Pid) ->
+    ok.
+
+-endif.

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -41,6 +41,9 @@
          handoff_error/3]).
 
 -ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
 -export([test_link/2,
          current_state/1]).
 -endif.

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -429,7 +429,7 @@ handle_event(finish_handoff, _StateName, State=#state{mod=Mod,
     end;
 handle_event(cancel_handoff, _StateName, State=#state{mod=Mod,
                                                       modstate=ModState}) ->
-    %% it would be nice to pass {Err, Reason} to the vnode but the 
+    %% it would be nice to pass {Err, Reason} to the vnode but the
     %% API doesn't currently allow for that.
     stop_manager_event_timer(State),
     case State#state.handoff_node of
@@ -516,10 +516,10 @@ handle_info({'EXIT', Pid, Reason},
             continue(State#state{pool_pid=undefined});
         _ ->
             lager:error("~p ~p worker pool crashed ~p\n", [Index, Mod, Reason]),
+            {pool, WorkerModule, PoolSize, WorkerArgs}=PoolConfig,
             lager:debug("starting worker pool ~p with size"
                         "of ~p for vnode ~p.",
                         [WorkerModule, PoolSize, Index]),
-            {pool, WorkerModule, PoolSize, WorkerArgs}=PoolConfig,
             {ok, NewPoolPid} =
                 riak_core_vnode_worker_pool:start_link(WorkerModule,
                                                        PoolSize,


### PR DESCRIPTION
If a vnode's worker pool crashes it is not restarted and this can lead to the vnode crashing if it tries to use the pool pid since it is now just the atom undefined. Change the vnode to restart the worker pool in case of a crash.
