### PR TITLE
restructure supervision tree so that folsom is an included app

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -55,6 +55,8 @@
              riak_core_ring_util,
              riak_core_stat,
              riak_core_stat_cache,
+             riak_core_stat_sup,
+             riak_core_stats_sup,
              riak_core_status,
              riak_core_sup,
              riak_core_sysmon_handler,
@@ -76,6 +78,7 @@
              vclock
             ]},
   {registered, []},
+  {included_applications, [folsom]},
   {applications, [
                   kernel,
                   stdlib,
@@ -84,8 +87,7 @@
                   crypto,
                   riak_sysmon,
                   webmachine,
-                  os_mon,
-                  folsom
+                  os_mon
                  ]},
   {mod, { riak_core_app, []}},
   {env, [

--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -342,7 +342,7 @@ register_mod(App, Module, Type) when is_atom(Module), is_atom(Type) ->
         vnode_modules ->
             riak_core_vnode_proxy_sup:start_proxies(Module);
         stat_mods ->
-            Module:register_stats();
+            riak_core_stats_sup:start_server(Module);
         _ ->
             ok
     end,

--- a/src/riak_core_stat.erl
+++ b/src/riak_core_stat.erl
@@ -68,6 +68,7 @@ produce_stats() ->
 %% gen_server
 
 init([]) ->
+    register_stats(),
     {ok, ok}.
 
 handle_call(_Req, _From, State) ->

--- a/src/riak_core_stat_sup.erl
+++ b/src/riak_core_stat_sup.erl
@@ -20,7 +20,7 @@
 %%
 %% -------------------------------------------------------------------
 
--module(riak_core_sup).
+-module(riak_core_stat_sup).
 
 -behaviour(supervisor).
 
@@ -46,32 +46,9 @@ start_link() ->
 %% ===================================================================
 
 init([]) ->
-    RiakWebs = case lists:flatten(riak_core_web:bindings(http),
-                                  riak_core_web:bindings(https)) of
-                   [] ->
-                       %% check for old settings, in case app.config
-                       %% was not updated
-                       riak_core_web:old_binding();
-                   Binding ->
-                       Binding
-               end,
-
     Children = lists:flatten(
-                 [?CHILD(riak_core_sysmon_minder, worker),
-                  ?CHILD(riak_core_vnode_sup, supervisor, 305000),
-                  ?CHILD(riak_core_eventhandler_sup, supervisor),
-                  ?CHILD(riak_core_handoff_sup, supervisor),
-                  ?CHILD(riak_core_ring_events, worker),
-                  ?CHILD(riak_core_ring_manager, worker),
-                  ?CHILD(riak_core_vnode_proxy_sup, supervisor),
-                  ?CHILD(riak_core_node_watcher_events, worker),
-                  ?CHILD(riak_core_node_watcher, worker),
-                  ?CHILD(riak_core_vnode_manager, worker),
-                  ?CHILD(riak_core_capability, worker),
-                  ?CHILD(riak_core_gossip, worker),
-                  ?CHILD(riak_core_claimant, worker),
-                  ?CHILD(riak_core_stat_sup, supervisor),
-                  RiakWebs
+                 [?CHILD(folsom_sup, supervisor),
+                  ?CHILD(riak_core_stats_sup, supervisor)
                  ]),
 
-    {ok, {{one_for_one, 10, 10}, Children}}.
+    {ok, {{rest_for_one, 10, 10}, Children}}.

--- a/src/riak_core_stats_sup.erl
+++ b/src/riak_core_stats_sup.erl
@@ -1,0 +1,50 @@
+%% -------------------------------------------------------------------
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_stats_sup).
+-behaviour(supervisor).
+-export([start_link/0, init/1]).
+-export([start_server/1, stop_server/1]).
+
+%% Helper macro for declaring children of supervisor
+-define(CHILD(I, Type, Timeout), {I, {I, start_link, []}, permanent, Timeout, Type, [I]}).
+-define(CHILD(I, Type), ?CHILD(I, Type, 5000)).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    Children = [stat_server(Mod) || {_App, Mod} <- riak_core:stat_mods()],
+    {ok, {{one_for_one, 5, 10}, [?CHILD(riak_core_stat_cache, worker)|Children]}}.
+
+start_server(Mod) ->
+    Ref = stat_server(Mod),
+    Pid = case supervisor:start_child(?MODULE, Ref) of
+              {ok, Child} -> Child;
+              {error, {already_started, Child}} -> Child
+          end,
+    Pid.
+
+stop_server(Mod) ->
+    supervisor:terminate_child(?MODULE, Mod),
+    supervisor:delete_child(?MODULE, Mod),
+    ok.
+
+%% @private
+stat_server(Mod) ->
+    ?CHILD(Mod, worker).


### PR DESCRIPTION
All stat mods depend on folsom, yet they are not linked to it.
This change brings folsom under supervision of a core stat sup,
which also supervises the riak stat subsystem. Now when folsom exits
everyone gets to restart clean and recover.

```
riak_core_sup
   |
   riak_core_stat_sup (rest_for_one)
    \
       - folsom_sup
       - riak_core_stats_sup (one_for_one)
        \
          - riak_*_stat
          - riak_stat_cache
```

riak_core_stats_sup will start and supervise gen_server stat mods at
registration time, and will re-start them should the sup crash.
