### PR TITLE
Change ticks from timer to more efficient erlang:send_after

### DIFF
--- a/src/riak_core_capability.erl
+++ b/src/riak_core_capability.erl
@@ -215,14 +215,17 @@ handle_call({ring_changed, Ring}, _From, State) ->
     State2 = update_supported(Ring, State),
     {reply, ok, State2}.
 
-handle_cast(tick, State) ->
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(tick, State) ->
     schedule_tick(),
     State2 =
         lists:foldl(fun(Node, StateAcc) ->
                             add_node(Node, [], StateAcc)
                     end, State, State#state.unknown),
     State3 = renegotiate_capabilities(State2),
-    {noreply, State3}.
+    {noreply, State3};
 
 handle_info(_Info, State) ->
     {noreply, State}.
@@ -244,7 +247,7 @@ schedule_tick() ->
     Tick = app_helper:get_env(riak_core,
                               capability_tick,
                               10000),
-    timer:apply_after(Tick, gen_server, cast, [?MODULE, tick]).
+    erlang:send_after(Tick, ?MODULE, tick).
 
 %% Capabilities are re-initialized if riak_core_capability server crashes
 reload(State=#state{registered=[]}) ->


### PR DESCRIPTION
Title says it all: replace certain uses of `timer` with `erlang:send_after`. Thanks go to @Vagabond for mentioning that `erlang:send_after` uses a timer-wheel built into erts and is more efficient than the user-space `timer` module.
