### PR TITLE
Remove publish_capabilities race

### DIFF
--- a/src/riak_core_capability.erl
+++ b/src/riak_core_capability.erl
@@ -377,9 +377,7 @@ publish_supported(State) ->
                         ignore
                 end
         end,
-    spawn(fun() ->
-                  riak_core_ring_manager:ring_trans(F, ok)
-          end),
+    riak_core_ring_manager:ring_trans(F, ok),
     ok.
 
 %% Add a node's capabilities to the provided ring


### PR DESCRIPTION
See commit message for more detail.

To exhibit the bug, I ran a fresh single-node cluster with the following diff:

``` patch

diff --git a/src/riak_core_capability.erl b/src/riak_core_capability.erl
index a3a4fe6..e6e371c 100644
--- a/src/riak_core_capability.erl
+++ b/src/riak_core_capability.erl
@@ -378,6 +378,7 @@ publish_supported(State) ->
                 end
         end,
     spawn(fun() ->
+                  timer:sleep(crypto:rand_uniform(1, 1000)),
                   riak_core_ring_manager:ring_trans(F, ok)
           end),
     ok.
```

After running this a few times, I observed missing capabilities in the ring, as seen by
`riak_core_ring_manager:get_my_ring()`.

All credit goes to @jonmeredith for being suspicious of this call in a spawn.
