### PR TITLE
Address high memory use by riak_core_sysmon_handler

### DIFF
--- a/src/riak_core_sysmon_handler.erl
+++ b/src/riak_core_sysmon_handler.erl
@@ -87,7 +87,6 @@ handle_event({monitor, Pid, Type, _Info},
     %% Reset the inactivity timeout
     NewTimerRef = reset_timer(TimerRef),
     maybe_collect_garbage(Type),
-    erlang:garbage_collect(),
     {ok, State#state{timer_ref=NewTimerRef}};
 handle_event({monitor, Pid, Type, Info}, State=#state{timer_ref=TimerRef}) ->
     %% Reset the inactivity timeout


### PR DESCRIPTION
Change `riak_core_sysmon_handler` to use hibernation to free up resources when it is idle since it does not do a good job of freeing these resources on its own. Also force garbage collection on the `riak_core_sysmon_handler` process if it receives a `large_heap` message about itself. This is to avoid a feedback loop that can lead to severe memory usage by the handler, node slowness, and even cause the node to crash after consuming all available memory.

Ryan mentioned [this](http://www.lshift.net/blog/2010/02/28/memory-matters-even-in-erlang) blog post by LShift about some troubles rabbitmq had with process hibernation. I do not feel that it should be a concern here because there are no resources used by this module that are referenced between hibernation periods (_i.e._ It just processes transient events), but it would be good for someone else to consider this as well.
