### PR TITLE
Graceful Shutdown

### DIFF
--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -25,7 +25,7 @@
 -behaviour(application).
 
 %% Application callbacks
--export([start/2, stop/1]).
+-export([start/2, prep_stop/1, stop/1]).
 
 %% ===================================================================
 %% Application callbacks
@@ -94,5 +94,11 @@ start(_StartType, _StartArgs) ->
             {error, Reason}
     end.
 
+prep_stop(_State) ->
+    lager:info("Stopping application riak_core - disabling web services\n", []),
+    riak_core_sup:stop_webs(),
+    stopping.
+
 stop(_State) ->
+    lager:info("Stopped  application riak_core\n", []),
     ok.

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -94,11 +94,18 @@ start(_StartType, _StartArgs) ->
             {error, Reason}
     end.
 
+%% @doc Prepare to stop - called before the supervisor tree is shutdown
 prep_stop(_State) ->
-    lager:info("Stopping application riak_core - disabling web services\n", []),
-    riak_core_sup:stop_webs(),
+    try %% wrap with a try/catch - application carries on regardless,
+        %% no error message or logging about the failure otherwise.
+        lager:info("Stopping application riak_core - disabling web services.\n", []),
+        riak_core_sup:stop_webs()
+    catch
+        Type:Reason ->
+            lager:error("Stopping application riak_core - ~p:~p.\n", [Type, Reason])
+    end,
     stopping.
 
 stop(_State) ->
-    lager:info("Stopped  application riak_core\n", []),
+    lager:info("Stopped  application riak_core.\n", []),
     ok.

--- a/src/riak_core_sup.erl
+++ b/src/riak_core_sup.erl
@@ -43,11 +43,11 @@ start_link() ->
 
 stop_webs() ->
     Specs = riak_web_childspecs(),
-    [supervisor:terminate_child(Id) || {Id, _, _, _, _, _} <- Specs].
+    [supervisor:terminate_child(?MODULE, Id) || {Id, _, _, _, _, _} <- Specs].
 
 restart_webs() ->
     Specs = riak_web_childspecs(),
-    [supervisor:restart_child(Id) || {Id, _, _, _, _, _} <- Specs].
+    [supervisor:restart_child(?MODULE, Id) || {Id, _, _, _, _, _} <- Specs].
 
 %% ===================================================================
 %% Supervisor callbacks


### PR DESCRIPTION
Adds calls to the riak_core_sup to start/stop the mochiweb listener and calls it on shutdown.

It's a little pointless as that's one of the first things to be shutdown when the riak_core_sup exits, however it would have been helpful to shutdown the web listener on customer deployments.
