### PR TITLE
Add Health callback option to node watcher

### DIFF
--- a/test/node_watcher_qc.erl
+++ b/test/node_watcher_qc.erl
@@ -424,7 +424,7 @@ ring_update(Nodes) ->
 healthy_service(Service) ->
     Pid = spawn(fun() -> service_loop() end),
     Self = self(),
-    meck:expect(mod_health, callback, fun (InPid, true) when is_pid(Pid) ->
+    meck:expect(mod_health, callback, fun (InPid, true) when is_pid(InPid) ->
         Self ! {meck_done, InPid},
         true
     end),

--- a/test/node_watcher_qc.erl
+++ b/test/node_watcher_qc.erl
@@ -265,7 +265,7 @@ postcondition(S, {call, _, healthy_new_service, [Service]}, _Res) ->
 
 postcondition(S, {call, _, healthy_existing_service, [Service]}, _Res) ->
     S2 = service_up(node(), Service, S),
-    ?assert(meck:valdiate(mod_health)),
+    ?assert(meck:validate(mod_health)),
     deep_validate(S2);
 
 postcondition(S, {call, _, unhealthy_service, [Service]}, _Res) ->

--- a/test/node_watcher_qc.erl
+++ b/test/node_watcher_qc.erl
@@ -417,7 +417,7 @@ health_service_up(Service, S) ->
         true
     end),
     Avsn0 = riak_core_node_watcher:avsn(),
-    riak_core_node_watcher ! {check_health, Service},
+    riak_core_node_watcher:check_health(Service),
     receive meck_done -> ok after 100 -> erlang:error(timeout) end,
     case is_service_up(node(), Service, S) of
         true -> ok;
@@ -432,7 +432,7 @@ health_service_down(Service, S) ->
         false
     end),
     Avsn0 = riak_core_node_watcher:avsn(),
-    riak_core_node_watcher ! {check_health, Service},
+    riak_core_node_watcher:check_health(Service),
     receive meck_done -> ok after 100 -> erlang:error(timeout) end,
     case is_service_up(node(), Service, S) of
         true -> wait_for_avsn(Avsn0);
@@ -447,7 +447,7 @@ health_service_error(Service, S) ->
         meck:exception(badarg)
     end),
     Avsn0 = riak_core_node_watcher:avsn(),
-    riak_core_node_watcher ! {check_health, Service},
+    riak_core_node_watcher:check_health(Service),
     receive meck_done -> ok after 100 -> erlang:error(timeout) end,
     case is_service_up(node(), Service, S) of
         true -> wait_for_avsn(Avsn0);

--- a/test/node_watcher_qc.erl
+++ b/test/node_watcher_qc.erl
@@ -323,6 +323,9 @@ deep_validate(S) ->
 
 validate_broadcast(S0, Sfinal, Op) ->
     Bcasts = broadcasts(),
+    validate_broadcast(S0, Sfinal, Op, Bcasts).
+
+validate_broadcast(S0, Sfinal, Op, Bcasts) ->
     Transition = {is_node_up(node(), S0), is_node_up(node(), Sfinal), Op},
     ExpPeers = Sfinal#state.peers,
     case Transition of
@@ -341,6 +344,18 @@ validate_broadcast(S0, Sfinal, Op) ->
             ?assertEqual([], Bcasts)
     end,
     true.
+
+validate_broadcasts(States, Op) ->
+    Bcasts = broadcasts(),
+    ?assertEqual(length(Bcasts) + 1,  length(States)),
+    validate_broadcasts(States, Op, Bcasts).
+
+validate_broadcasts([S0, Sfinal], Op, [Bcast]) ->
+    validate_broadcast(S0, Sfinal, Op, [Bcast]);
+
+validate_broadcasts([S0, Sfinal | STail], Op, [Bcast | BTail]) ->
+    true = validate_broadcast(S0, Sfinal, Op, [Bcast]),
+    validate_broadcasts([Sfinal | STail], Op, BTail).
 
 
 %% ====================================================================

--- a/test/node_watcher_qc.erl
+++ b/test/node_watcher_qc.erl
@@ -96,21 +96,21 @@ initial_state() ->
 
 command(S) ->
     oneof([
-           {call, ?MODULE, ring_update, [g_ring_nodes()]},
-           {call, ?MODULE, local_service_up, [g_service()]},
-           {call, ?MODULE, local_service_down, [g_service()]},
-           {call, ?MODULE, local_service_kill, [g_service(), S]},
-           {call, ?MODULE, local_node_up, []},
-           {call, ?MODULE, local_node_down, []},
-           {call, ?MODULE, remote_service_up, [g_node(), g_services()]},
-           {call, ?MODULE, remote_service_down, [g_node()]},
-           {call, ?MODULE, remote_service_down_disterl, [g_node()]},
-           {call, ?MODULE, wait_for_bcast, []},
-           {call, ?MODULE, healthy_service, [g_service()]},
-           {call, ?MODULE, unhealthy_service, [g_service()]},
-           {call, ?MODULE, recovering_service, [g_service()]},
-           {call, ?MODULE, faulty_health_check_callback_once, [g_service()]},
-           {call, ?MODULE, faulty_health_check_callback_many, [g_service()]}
+           %{call, ?MODULE, ring_update, [g_ring_nodes()]},
+           %{call, ?MODULE, local_service_up, [g_service()]},
+           %{call, ?MODULE, local_service_down, [g_service()]},
+           %{call, ?MODULE, local_service_kill, [g_service(), S]},
+           %{call, ?MODULE, local_node_up, []},
+           %{call, ?MODULE, local_node_down, []},
+           %{call, ?MODULE, remote_service_up, [g_node(), g_services()]},
+           %{call, ?MODULE, remote_service_down, [g_node()]},
+           %{call, ?MODULE, remote_service_down_disterl, [g_node()]},
+           %{call, ?MODULE, wait_for_bcast, []},
+           %{call, ?MODULE, healthy_service, [g_service()]},
+           {call, ?MODULE, unhealthy_service, [g_service()]}%,
+           %{call, ?MODULE, recovering_service, [g_service()]},
+           %{call, ?MODULE, faulty_health_check_callback_once, [g_service()]},
+           %{call, ?MODULE, faulty_health_check_callback_many, [g_service()]}
           ]).
 
 precondition(S, {call, _, local_service_kill, [Service, S]}) ->
@@ -158,10 +158,15 @@ next_state(S, Res, {call, _, healthy_service, [Service]}) ->
     S2#state { service_pids = Pids };
 
 next_state(S, Res, {call, M, unhealthy_service, [Service]}) ->
-    meck:expect(mod_health, callback, fun (Pid, false) when is_pid(Pid) ->
-        false
-    end),
-    next_state(S, Res, {call, M, local_service_up, [Service]});
+    ?debugFmt("Next state:\n"
+    "   in state:  ~p\n"
+    "   last res:  ~p\n"
+    "   service:  ~p",
+    [S,Res,Service]),
+    S;
+    %S2 = service_up(node(), Service, S),
+    %Pids = orddict:store(Service, Res, S2#state.service_pids),
+    %S2#state { service_pids = Pids };
 
 next_state(S, Res, {call, M, recovering_service, [Service]}) ->
     meck:sequence(mod_health, callback, 2, [false, true]),
@@ -255,16 +260,17 @@ postcondition(S, {call, _, healthy_service, [Service]}, _Res) ->
     ?assert(meck:validate(mod_health)),
     deep_validate(S2);
 
-postcondition(S, {call, _, healthy_existing_service, [Service]}, _Res) ->
+postcondition(S, {call, _, unhealthy_service, [Service]}, Res) ->
+    ?debugFmt("postcondition:\n"
+    "   in state:  ~p\n"
+    "   service:  ~p\n"
+    "   in res:  ~p",
+    [S, Service, Res]),
     S2 = service_up(node(), Service, S),
+    S3 = service_down(node(), Service, S2),
+    validate_broadcasts([S,S2,S3], Service),
     ?assert(meck:validate(mod_health)),
-    deep_validate(S2);
-
-postcondition(S, {call, _, unhealthy_service, [Service]}, _Res) ->
-    S2 = service_down(node(), Service, S),
-    validate_broadcast(S, S2, service),
-    ?assert(meck:validate(mod_health)),
-    deep_validate(S2);
+    deep_validate(S3);
 
 postcondition(S, {call, _, recovering_service, [Service]}, _Res) ->
     S2 = service_down(node(), Service, S),
@@ -338,6 +344,7 @@ validate_broadcast(S0, Sfinal, Op, Bcasts) ->
 
 validate_broadcasts(States, Op) ->
     Bcasts = broadcasts(),
+    ?debugFmt("broadcasts:  ~p", [Bcasts]),
     ?assertEqual(length(Bcasts) + 1,  length(States)),
     validate_broadcasts(States, Op, Bcasts).
 
@@ -440,9 +447,19 @@ healthy_service(Service) ->
 
 unhealthy_service(Service) ->
     Pid = spawn(fun() -> service_loop() end),
-    ok = riak_core_node_watcher:service_up(Service, Pid),
+    Self = self(),
+    meck:expect(mod_health, callback, fun (InPid, false) when is_pid(InPid) ->
+        Self ! {meck_done, InPid},
+        false
+    end),
     ok = riak_core_node_watcher:service_up(Service, Pid, {mod_health, callback, [false]}),
     gen_server:cast(riak_core_node_watcher, {force_health_check, Service}),
+    receive
+        {meck_done, MeckInPid} ->
+            ?assertEqual(Pid, MeckInPid)
+    after 1000 ->
+        erlang:error(timeout)
+    end,
     Pid.
 
 recovering_service(Service) ->


### PR DESCRIPTION
Add a second way to monitor a service, allowing for a callback to be used to determine health, and automatically set a service up or down.
