### PR TITLE
Update RINGTOP calculation

### DIFF
--- a/src/chash.erl
+++ b/src/chash.erl
@@ -52,7 +52,7 @@
 
 -export_type([chash/0]).
     
--define(RINGTOP, trunc(math:pow(2,160))-1).  % SHA-1 space
+-define(RINGTOP, trunc(math:pow(2,160))).  % SHA-1 space
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/chash.erl
+++ b/src/chash.erl
@@ -52,7 +52,7 @@
 
 -export_type([chash/0]).
     
--define(RINGTOP, trunc(math:pow(2,160)-1)).  % SHA-1 space
+-define(RINGTOP, trunc(math:pow(2,160))-1).  % SHA-1 space
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/test/chash_eqc.erl
+++ b/test/chash_eqc.erl
@@ -34,7 +34,7 @@
 -define(TEST_ITERATIONS, 50).
 -define(QC_OUT(P),
         eqc:on_output(fun(Str, Args) -> io:format(user, Str, Args) end, P)).
--define(RINGTOP, trunc(math:pow(2,160))-1).  % SHA-1 space
+-define(RINGTOP, trunc(math:pow(2,160))).  % SHA-1 space
 
 -export([check/0,
          test/0,

--- a/test/chash_eqc.erl
+++ b/test/chash_eqc.erl
@@ -34,7 +34,7 @@
 -define(TEST_ITERATIONS, 50).
 -define(QC_OUT(P),
         eqc:on_output(fun(Str, Args) -> io:format(user, Str, Args) end, P)).
--define(RINGTOP, trunc(math:pow(2,160)-1)).  % SHA-1 space
+-define(RINGTOP, trunc(math:pow(2,160))-1).  % SHA-1 space
 
 -export([check/0,
          test/0,


### PR DESCRIPTION
RINGTOP is calcuated incorrectly as 

``` erlang
trunc(math:pow(2,160)-1)
```

because substracting one from such a large float before the trunc call has no
effect. Subtracting one after the trunc call results in the correct
value.

``` erlang
trunc(math:pow(2,160))-1
```
