### PR TITLE
Clarify error message for stale ring failures.

### DIFF
--- a/src/riak_core_capability.erl
+++ b/src/riak_core_capability.erl
@@ -412,7 +412,11 @@ negotiate_capabilities(Node, Override, State=#state{registered=Registered,
 renegotiate_capabilities(State=#state{supported=[]}) ->
     State;
 renegotiate_capabilities(State) ->
-    Caps = orddict:fetch(node(), State#state.supported),
+    Caps = 
+        case orddict:find(node(), State#state.supported) of 
+            {ok, Val} -> Val;
+            error -> error("Node name mismatch, move or remove stale ring file")                       
+        end,
     Overrides = get_overrides(Caps),
     State2 = negotiate_capabilities(node(), Overrides, State),
     process_capability_changes(State#state.negotiated,


### PR DESCRIPTION
Add a meaningful warning to the failure when the ring file
doesn't have a entry for the current node name.

Fixes issue #243
