### PR TITLE
Vnode shutdown message severity should be info

### DIFF
--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -200,10 +200,6 @@ continue(State, NewModState) ->
 %% In the forwarding state, all vnode commands and coverage commands are
 %% forwarded to the new owner for processing.
 
-vnode_command(Sender, FOO, State) when is_tuple(FOO), element(1,FOO) == riak_core_fold_req_v1 ->
-    error_logger:warning_msg("Ha, caught a FOO ~p\n", [FOO]),
-    reply(Sender, {error, vnode_shutdown}),
-    continue(State);
 vnode_command(Sender, Request, State=#state{index=Index,
                                             mod=Mod,
                                             modstate=ModState,
@@ -269,10 +265,6 @@ vnode_coverage(Sender, Request, KeySpaces, State=#state{index=Index,
             {stop, Reason, State#state{modstate=NewModState}}
     end.
 
-vnode_handoff_command(Sender, FOO, State) when is_tuple(FOO), element(1,FOO) == riak_core_fold_req_v1 ->
-    error_logger:warning_msg("Ha, caught a FOO ~p\n", [FOO]),
-    reply(Sender, {error, vnode_shutdown}),
-    continue(State);
 vnode_handoff_command(Sender, Request, State=#state{index=Index,
                                                     mod=Mod,
                                                     modstate=ModState,

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -200,6 +200,10 @@ continue(State, NewModState) ->
 %% In the forwarding state, all vnode commands and coverage commands are
 %% forwarded to the new owner for processing.
 
+vnode_command(Sender, FOO, State) when is_tuple(FOO), element(1,FOO) == riak_core_fold_req_v1 ->
+    error_logger:warning_msg("Ha, caught a FOO ~p\n", [FOO]),
+    reply(Sender, {error, vnode_shutdown}),
+    continue(State);
 vnode_command(Sender, Request, State=#state{index=Index,
                                             mod=Mod,
                                             modstate=ModState,
@@ -265,6 +269,10 @@ vnode_coverage(Sender, Request, KeySpaces, State=#state{index=Index,
             {stop, Reason, State#state{modstate=NewModState}}
     end.
 
+vnode_handoff_command(Sender, FOO, State) when is_tuple(FOO), element(1,FOO) == riak_core_fold_req_v1 ->
+    error_logger:warning_msg("Ha, caught a FOO ~p\n", [FOO]),
+    reply(Sender, {error, vnode_shutdown}),
+    continue(State);
 vnode_handoff_command(Sender, Request, State=#state{index=Index,
                                                     mod=Mod,
                                                     modstate=ModState,


### PR DESCRIPTION
Currently, when a vnode is shutdown, it's possible for handoffs in progress to be aborted and generate a warning severity message like this:

```
2012-10-26 20:22:09.489 UTC [error] <0.7853.42>@riak_core_handoff_sender:start_fold:215 ownership_handoff transfer of riak_kv_vnode from 'riak@10.10.0.51' 158424493890361546797469742608893960138484875264 to 'riak@10.10.0.53' 158424493890361546797469742608893960138484875264 failed because of error:{badmatch,{error,vnode_shutdown}} [{riak_core_handoff_sender,start_fold,5,[{file,"src/riak_core_handoff_sender.erl"},{line,161}]}]
```

This PR changes the error severity to an info message and also omits the stack trace, see below for an example.

There are two extra commits here, one to add a bit of bogus demo code to simulate the vnode shutdown without resorting to trying to provoke a race (in case any reviewer were curious).  The other commit removes that code. The tell-tale sign that the artificial trigger is hit and the new info severity response looks like this:

```
2012-10-26 19:08:47.897 [warning] <0.26559.0> Ha, caught a FOO {riak_core_fold_req_v1,#Fun<riak_core_handoff_sender.1..........
2012-10-26 19:08:47.897 [info] <0.27857.0>@riak_core_handoff_sender:start_fold:161 ownership_handoff transfer of riak_kv_vnode from 'dev3@127.0.0.1' 296867520082839655260123481645494988367611297792 to dev4@127.0.0.1' 296867520082839655260123481645494988367611297792 failed because the local vnode was shutdown
```
