### PR TITLE
Change all gen_server:call() calls to use infinity timeout

### DIFF
--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -93,8 +93,6 @@ xfer({SrcPartition, SrcOwner}, {Module, TargetPartition}, FilterModFun) ->
 %% @doc Associate `Data' with the inbound handoff `Recv'.
 -spec set_recv_data(pid(), proplists:proplist()) -> ok.
 set_recv_data(Recv, Data) ->
-    %% Let this timeout and crash receiver if handoff mgr is
-    %% unresponsive.
     gen_server:call(?MODULE, {set_recv_data, Recv, Data}, infinity).
 
 status() ->

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -74,10 +74,10 @@ init([]) ->
     {ok, #state{excl=ordsets:new(), handoffs=[]}}.
 
 add_outbound(Module,Idx,Node,VnodePid) ->
-    gen_server:call(?MODULE,{add_outbound,Module,Idx,Node,VnodePid}).
+    gen_server:call(?MODULE,{add_outbound,Module,Idx,Node,VnodePid},infinity).
 
 add_inbound(SSLOpts) ->
-    gen_server:call(?MODULE,{add_inbound,SSLOpts}).
+    gen_server:call(?MODULE,{add_inbound,SSLOpts},infinity).
 
 %% @doc Initiate a transfer from `SrcPartition' to `TargetPartition'
 %%      for the given `Module' using the `FilterModFun' filter.
@@ -95,13 +95,13 @@ xfer({SrcPartition, SrcOwner}, {Module, TargetPartition}, FilterModFun) ->
 set_recv_data(Recv, Data) ->
     %% Let this timeout and crash receiver if handoff mgr is
     %% unresponsive.
-    gen_server:call(?MODULE, {set_recv_data, Recv, Data}).
+    gen_server:call(?MODULE, {set_recv_data, Recv, Data}, infinity).
 
 status() ->
     status(none).
 
 status(Filter) ->
-    gen_server:call(?MODULE, {status, Filter}).
+    gen_server:call(?MODULE, {status, Filter}, infinity).
 
 %% @doc Send status updates `Stats' to the handoff manager for a
 %%      particular handoff identified by `ModSrcTgt'.
@@ -110,10 +110,10 @@ status_update(ModSrcTgt, Stats) ->
     gen_server:cast(?MODULE, {status_update, ModSrcTgt, Stats}).
 
 set_concurrency(Limit) ->
-    gen_server:call(?MODULE,{set_concurrency,Limit}).
+    gen_server:call(?MODULE,{set_concurrency,Limit}, infinity).
 
 get_concurrency() ->
-    gen_server:call(?MODULE, get_concurrency).
+    gen_server:call(?MODULE, get_concurrency, infinity).
 
 %% @doc Kill the transfer of `ModSrcTarget' with `Reason'.
 -spec kill_xfer(node(), tuple(), any()) -> ok.


### PR DESCRIPTION
If the handoff manager gets busy enough to not reply in the
5 second default timeout, then the clients that time out and
crash can cause a supervisor to fail due to too many failures,
which in turn can trigger other supervisor failures that will
cause the entire app to shut down.  E.g.,

```
2012-10-31 01:04:43.370 UTC [error] <0.214.0> Supervisor riak_core_handoff_listener_sup had child riak_core_handoff_listener started with riak_core_handoff_listener:start_link() at {restarting,<0.16005.43>} exit with reason reached_max_restart_intensity in context shutdown
```
