### PR TITLE
Logical Deletion of Ring Meta & Bucket Properties

### DIFF
--- a/src/riak_core_bucket.erl
+++ b/src/riak_core_bucket.erl
@@ -29,6 +29,7 @@
          set_bucket/2,
          get_bucket/1,
          get_bucket/2,
+         reset_bucket/1,
          get_buckets/1,
          merge_props/2,
          name/1,
@@ -109,6 +110,15 @@ get_bucket(Name, Ring) ->
              |app_helper:get_env(riak_core, default_bucket_props)];
         {ok, Bucket} -> Bucket
     end.
+
+%% @spec reset_bucket(binary()) -> ok
+%% @doc Reset the bucket properties for Bucket to the default settings
+reset_bucket(Bucket) ->
+    F = fun(Ring, _Args) ->
+                {new_ring, riak_core_ring:remove_meta({bucket, Bucket}, Ring)}
+        end,
+    {ok, _NewRing} = riak_core_ring_manager:ring_trans(F, undefined),
+    ok.
 
 %% @doc Get bucket properties `Props' for all the buckets in the given
 %%      `Ring'

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -506,7 +506,10 @@ update_meta(Key, Val, State) ->
 %% @doc Logical delete of a key in the cluster metadata dict
 -spec remove_meta(Key :: term(), State :: chstate()) -> chstate().
 remove_meta(Key, State) ->
-    update_meta(Key, '$removed', State).
+    case dict:find(Key, State?CHSTATE.meta) of
+        {ok, _} -> update_meta(Key, '$removed', State);
+       error -> State
+    end.
 
 %% @doc Return the current claimant.
 -spec claimant(State :: chstate()) -> node().
@@ -1354,6 +1357,7 @@ metadata_inequality_test() ->
 
 metadata_remove_test() ->
     Ring0 = fresh(2, node()),
+    ?assert(equal_rings(Ring0, remove_meta(key, Ring0))),
     Ring1 = update_meta(key,val,Ring0),
     timer:sleep(1001), % ensure that lastmod is at least one second later
     Ring2 = remove_meta(key,Ring1),

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -508,7 +508,7 @@ update_meta(Key, Val, State) ->
 remove_meta(Key, State) ->
     case dict:find(Key, State?CHSTATE.meta) of
         {ok, _} -> update_meta(Key, '$removed', State);
-       error -> State
+        error -> State
     end.
 
 %% @doc Return the current claimant.

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -51,7 +51,8 @@
          rename_node/3,
          responsible_index/2,
          transfer_node/3,
-         update_meta/3]).
+         update_meta/3,
+         remove_meta/2]).
 
 -export([cluster_name/1,
          legacy_ring/1,
@@ -334,6 +335,8 @@ fresh(RingSize, NodeName) ->
 get_meta(Key, State) -> 
     case dict:find(Key, State?CHSTATE.meta) of
         error -> undefined;
+        {ok, '$removed'} -> undefined;
+        {ok, M} when M#meta_entry.value =:= '$removed' -> undefined;
         {ok, M} -> {ok, M#meta_entry.value}
     end.
 
@@ -499,6 +502,11 @@ update_meta(Key, Val, State) ->
        true ->
             State
     end.
+
+%% @doc Logical delete of a key in the cluster metadata dict
+-spec remove_meta(Key :: term(), State :: chstate()) -> chstate().
+remove_meta(Key, State) ->
+    update_meta(Key, '$removed', State).
 
 %% @doc Return the current claimant.
 -spec claimant(State :: chstate()) -> node().
@@ -1343,6 +1351,16 @@ metadata_inequality_test() ->
                  get_meta(key,?CHSTATE{meta=
                             merge_meta(Ring2?CHSTATE.meta,
                                        Ring1?CHSTATE.meta)})).
+
+metadata_remove_test() ->
+    Ring0 = fresh(2, node()),
+    Ring1 = update_meta(key,val,Ring0),
+    timer:sleep(1001), % ensure that lastmod is at least one second later
+    Ring2 = remove_meta(key,Ring1),
+    ?assertEqual(undefined, get_meta(key, Ring2)),
+    ?assertEqual(undefined, get_meta(key, ?CHSTATE{meta=merge_meta(Ring1?CHSTATE.meta, Ring2?CHSTATE.meta)})),
+    ?assertEqual(undefined, get_meta(key, ?CHSTATE{meta=merge_meta(Ring2?CHSTATE.meta, Ring1?CHSTATE.meta)})).
+
 rename_test() ->
     Ring0 = fresh(2, node()),
     Ring = rename_node(Ring0, node(), 'new@new'),


### PR DESCRIPTION
Ability to reset bucket properties to default and remove other ring metadata as described in https://github.com/basho/riak_core/issues/197 and originally implemented in https://github.com/basho/riak_core/pull/202. The difference between this implementation and the original is deletion is logical (a tombstone value is written) instead of physical. Tombstones are never reaped currently but it is possible to do so in the future. 

Corresponding `riak_test` for this functionality can be found here: https://github.com/basho/riak_test/pull/81
