### PR TITLE
Make vnode check for existing handoff before starting another

### DIFF
--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -94,6 +94,7 @@ behaviour_info(_Other) ->
           modstate :: term(),
           forward :: node(),
           handoff_node=none :: none | node(),
+          handoff_pid :: pid(),
           pool_pid :: pid() | undefined,
           manager_event_timer :: reference(),
           inactivity_timeout}).
@@ -573,21 +574,29 @@ maybe_handoff(State=#state{modstate={deleted, _}}, _TargetNode) ->
     %% Modstate has been deleted, waiting for unregistered.  No handoff.
     continue(State);
 maybe_handoff(State=#state{index=Idx, mod=Mod, modstate=ModState,
-                           handoff_node=HN}, TargetNode) ->
-    case HN of
-        none ->
-            ok;
-        TargetNode ->
-            ok;
-        _ ->
-            lager:info("~s/~b: handoff request to ~p before "
-                       "finishing handoff to ~p", [Mod, Idx, TargetNode, HN])
-    end,
-    case Mod:handoff_starting(TargetNode, ModState) of
-        {true, NewModState} ->
-            start_handoff(State#state{modstate=NewModState}, TargetNode);
-        {false, NewModState} ->
-            continue(State, NewModState)
+                           handoff_node=HN, handoff_pid=HPid}, TargetNode) ->
+    ExistingHO = is_pid(HPid) andalso is_process_alive(HPid),
+    ValidHN = case HN of
+                  none ->
+                      true;
+                  TargetNode ->
+                      not ExistingHO;
+                  _ ->
+                      lager:info("~s/~b: handoff request to ~p before "
+                                 "finishing handoff to ~p",
+                                 [Mod, Idx, TargetNode, HN]),
+                      not ExistingHO
+              end,
+    case ValidHN of
+        true ->
+            case Mod:handoff_starting(TargetNode, ModState) of
+                {true, NewModState} ->
+                    start_handoff(State#state{modstate=NewModState}, TargetNode);
+                {false, NewModState} ->
+                    continue(State, NewModState)
+            end;
+        false ->
+            continue(State)
     end.
 
 start_handoff(State=#state{index=Idx, mod=Mod, modstate=ModState}, TargetNode) ->
@@ -597,8 +606,9 @@ start_handoff(State=#state{index=Idx, mod=Mod, modstate=ModState}, TargetNode) -
                                        handoff_node=TargetNode});
         {false, NewModState} ->
             case riak_core_handoff_manager:add_outbound(Mod,Idx,TargetNode,self()) of
-                {ok,_Pid} ->
+                {ok, Pid} ->
                     NewState = State#state{modstate=NewModState,
+                                           handoff_pid=Pid,
                                            handoff_node=TargetNode},
                     continue(NewState);
                 {error,_Reason} ->


### PR DESCRIPTION
Change riak_core_vnode to keep track of the handoff sender pid and not initiate a new handoff if an existing handoff is already running. In practice, this is not necessary as the handoff manager ensures that only one handoff is running per source/target pair. This change is an optimization to avoid additional work that is potentially expensive on some backends.

**Note:** This is tangentially related to basho/riak_kv#423 as one of the blocking scenarios was "double handoff". The second handoff attempt would call `bitcask:is_empty` and therefore trigger the reported blocking behavior. That issue is resolved by the Bitcask changes associated with the issue, but changing handoff behavior to not unnecessarily attempt to handoff is a reasonable optimization to do regardless.
