### PR TITLE
Export path and stat_name types from riak_core_stat_q

### DIFF
--- a/src/riak_core_stat_q.erl
+++ b/src/riak_core_stat_q.erl
@@ -31,6 +31,9 @@
 
 -compile(export_all).
 
+-export_type([path/0,
+              stat_name/0]).
+
 -type path() :: [] | [atom()|binary()].
 -type stats() :: [stat()].
 -type stat() :: {stat_name(), stat_value()}.


### PR DESCRIPTION
These types are useful in other modules providing stats (a riak_pipe PR will make use of them shortly).
