### PR TITLE
Enable riak_core apps to provide a health_check callback

### DIFF
--- a/src/riak_core_ring_handler.erl
+++ b/src/riak_core_ring_handler.erl
@@ -129,7 +129,14 @@ ensure_vnodes_started({App,Mod}, Ring) ->
                                %% Mark the service as up.
                                SupName = list_to_atom(atom_to_list(App) ++ "_sup"),
                                SupPid = erlang:whereis(SupName),
-                               riak_core_node_watcher:service_up(App, SupPid),
+                               case riak_core:health_check(App) of
+                                   undefined ->
+                                       riak_core_node_watcher:service_up(App, SupPid);
+                                   HealthMFA ->
+                                       riak_core_node_watcher:service_up(App,
+                                                                         SupPid,
+                                                                         HealthMFA)
+                               end,
                                exit(normal);
                            {error, Reason} ->
                                lager:critical("Failed to start application: ~p", [App]),


### PR DESCRIPTION
This pull-request enables applications built on riak_core to provide {health_check, MFA} as an option during registration. The provided health check will then be passed on to `riak_core_node_watcher:service_up` when the service is marked as up. This enables riak_core applications to take advantage of the new health check functionality added to `riak_core_node_watcher` in #240

This pull-request provides the basis for a sister pull-request to riak_kv that adds a health check to Riak K/V.

This PR also includes a commit that changes certain `riak_core_vnode_manager` API calls to be more efficient by directly accessing a protected ETS table when possible, rather than always using calls to the `riak_core_vnode_manager`. This fixes a long standing issue with the vnode manager, and is a necessary change to make the health check added to Riak K/V efficient.
