### PR TITLE
Fix vnode eqc test regression

### DIFF
--- a/src/bloom.erl
+++ b/src/bloom.erl
@@ -198,6 +198,9 @@ simple_shuffle(L) ->
     {_, L3} = lists:unzip(lists:keysort(1, L2)),
     L3.
 
+fixed_case_test_() ->
+    {timeout, 100, fun() -> fixed_case(bloom(5000), 5000, 0.001) end}.
+
 fixed_case(Bloom, Size, FalseRate) ->
     ?assert(bloom:capacity(Bloom) > Size),
     ?assertEqual(0, bloom:size(Bloom)),
@@ -226,7 +229,6 @@ scalable_case(Bloom, Size, FalseRate) ->
     ok.
 
 bloom_test() ->
-    fixed_case(bloom(5000), 5000, 0.001),
     scalable_case(sbf(1000, 0.2), 1000, 0.2),
     ok.
     

--- a/test/core_vnode_eqc.erl
+++ b/test/core_vnode_eqc.erl
@@ -56,7 +56,7 @@ simple_test_() ->
              [ok = application:set_env(riak_core, K, V) || {K,V} <- OldVars],
              ok
      end,
-     {timeout, 120,
+     {timeout, 180,
       ?_assertEqual(true, quickcheck(?QC_OUT(numtests(100, prop_simple()))))}}.
 
 setup_simple() ->
@@ -294,7 +294,12 @@ prepare(AsyncSize) ->
 
 
 start_vnode(I) ->
-    ok = mock_vnode:start_vnode(I).
+    ok = mock_vnode:start_vnode(I),
+    %% NOTE: The return value from this call is currently not being
+    %%       used.  This call is made to ensure that all msgs sent to
+    %%       the vnode mgr before this call have been handled.  This
+    %%       guarantees that the vnode mgr ets tab is up-to-date.
+    riak_core_vnode_manager:get_vnode_pid(I, mock_vnode).
 
 returnreply(Preflist) ->
     {ok, Ref} = mock_vnode:returnreply(Preflist),

--- a/test/core_vnode_eqc.erl
+++ b/test/core_vnode_eqc.erl
@@ -56,7 +56,7 @@ simple_test_() ->
              [ok = application:set_env(riak_core, K, V) || {K,V} <- OldVars],
              ok
      end,
-     {timeout, 180,
+     {timeout, 600,
       ?_assertEqual(true, quickcheck(?QC_OUT(numtests(100, prop_simple()))))}}.
 
 setup_simple() ->
@@ -159,7 +159,7 @@ next_state_data(_From,_To,S=#qcst{started=Started, counters=Counters, crash_reas
 
     %% give the vnode a chance to shut down so that the index isn't present
     %% if the next command is to list the vnodes
-    timer:sleep(100),
+    timer:sleep(200),
     S#qcst{started=Started -- [Index],
            counters=orddict:store(Index, 0, Counters),
            crash_reasons=orddict:store(Index, undefined, CRs)};


### PR DESCRIPTION
The commit d769cfb2645050aa3abd053e260840d1a2893ae6 broke the test
because now instead of always going through the mgr it will
shortcut and hit the ets tab directly.  This means there can be a
slice of time where the supervisor reports a vnode pid but the ets tab
hasn't indexed it yet.  Calling `get_vnode_pid` after starting the
vnode ensures that all previous msgs in vnode mgr mailbox have been
handled and the ets tab is up-to-date for all subsequent calls.
