### PR TITLE
Add ability to selectively disable incoming/outgoing handoff

### DIFF
--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -74,10 +74,20 @@ init([]) ->
     {ok, #state{excl=ordsets:new(), handoffs=[]}}.
 
 add_outbound(Module,Idx,Node,VnodePid) ->
-    gen_server:call(?MODULE,{add_outbound,Module,Idx,Node,VnodePid},infinity).
+    case application:get_env(riak_core, disable_outbound_handoff) of
+        {ok, true} ->
+            {error, max_concurrency};
+        _ ->
+            gen_server:call(?MODULE,{add_outbound,Module,Idx,Node,VnodePid},infinity)
+    end.
 
 add_inbound(SSLOpts) ->
-    gen_server:call(?MODULE,{add_inbound,SSLOpts},infinity).
+    case application:get_env(riak_core, disable_inbound_handoff) of
+        {ok, true} ->
+            {error, max_concurrency};
+        _ ->
+            gen_server:call(?MODULE,{add_inbound,SSLOpts},infinity)
+    end.
 
 %% @doc Initiate a transfer from `SrcPartition' to `TargetPartition'
 %%      for the given `Module' using the `FilterModFun' filter.


### PR DESCRIPTION
This pull-request provides the ability to selectively disable incoming or outgoing handoff by setting an app var. This is designed mostly for support/recovery scenarios in which getting data onto or off-of a particular node is more important than the normal balanced in/out behavior of Riak.

Ideally, we would change `handoff_concurrency` to support an inbound and outbound concurrency rate, but this current approach is straightforward, simple, and has been used in certain customer clusters as a hotpatch in support situations. Might as well get it in to Riak proper for Riak 1.3, and re-evaluate alternate approaches in the future.
