### PR TITLE
Use riak_core_capabilities:get_supported/2 to avoid crash

### DIFF
--- a/src/riak_core_capability.erl
+++ b/src/riak_core_capability.erl
@@ -412,7 +412,7 @@ negotiate_capabilities(Node, Override, State=#state{registered=Registered,
 renegotiate_capabilities(State=#state{supported=[]}) ->
     State;
 renegotiate_capabilities(State) ->
-    Caps = orddict:fetch(node(), State#state.supported),
+    Caps = get_supported(node(), State),
     Overrides = get_overrides(Caps),
     State2 = negotiate_capabilities(node(), Overrides, State),
     process_capability_changes(State#state.negotiated,


### PR DESCRIPTION
I'm quite new to erlang and riak_core but i think i just found a bug which can cause a crash. Two weeks ago i already created an issue for Sean Cribbs' riak_id (see seancribbs/riak_id#3 for further details) because i thought the bug is located within riak_id. Since i got no response for about two weeks i tried to debug the error and found `orddict:fetch(node(), State#state.supported)` which will raise an error if `node()` cannot be found in `State#state.supported`. It seems like `get_supported/2` is already handling that case so i changed `orddict:fetch(...)` to `get_supported(...)`.
