### PR TITLE
Fix riak_core_wm_urlmap

### DIFF
--- a/src/riak_core_wm_urlmap.erl
+++ b/src/riak_core_wm_urlmap.erl
@@ -75,7 +75,7 @@ to_json(RD, Services) ->
     {mochijson:encode({struct, Services}), RD, Services}.
 
 service_list() ->
-    {ok, Dispatch} = application:get_env(webmachine, dispatch_list),
+    Dispatch = webmachine_router:get_routes(),
     lists:usort(
       [{atom_to_list(Resource), "/"++UriBase}
        || {[UriBase|_], Resource, _} <- Dispatch]).


### PR DESCRIPTION
When the webmachine dispatch list was moved to ETS, this resource was not changed to reflect that, and so it still hit the application env for the dispatch list, resulting in a badmatch error because the key was not set.

This addresses the Ruby client failures on GiddyUp, e.g. http://giddyup.basho.com/#/projects/riak/scorecards/9/9-285-client_ruby_verify-centos-6-64-memory/3036
