### PR TITLE
Dialyzer Fixes

### DIFF
--- a/include/riak_core_handoff.hrl
+++ b/include/riak_core_handoff.hrl
@@ -17,7 +17,7 @@
 -type predicate() :: fun((any()) -> boolean()).
 
 -type index() :: integer().
--type mod_src_tgt() :: {module(), index(), index()}.
+-type mod_src_tgt() :: {module(), index(), index()} | {undefined, undefined, undefined}.
 -type mod_partition() :: {module(), index()}.
 
 -record(handoff_status,

--- a/src/riak_core_node_watcher.erl
+++ b/src/riak_core_node_watcher.erl
@@ -54,7 +54,7 @@
                  bcast_mod = {gen_server, abcast}}).
 
 -record(health_check, { state = 'waiting' :: 'waiting' | 'checking' | 'suspend',
-                        callback :: mfa(),
+                        callback :: {atom(), atom(), [any()]},
                         service_pid :: pid(),
                         checking_pid :: pid(),
                         health_failures = 0 :: non_neg_integer(),

--- a/src/riak_core_repair.erl
+++ b/src/riak_core_repair.erl
@@ -112,7 +112,7 @@ gen_range_fun(RangeMap, Default) ->
 %%      must fall into to be included for repair on the `Target'
 %%      partition.
 -spec gen_range_map(partition(), riak_core_ring:riak_core_ring(), list()) ->
-                           [{B::riak_object:bucket(), Range::hash_range()}].
+                           [{Bucket::binary(), Range::hash_range()}].
 gen_range_map(Target, Ring, NValMap) ->
     [{I, gen_range(Target, Ring, N)} || {I, N} <- NValMap, N > 1].
 

--- a/src/riak_core_ring_handler.erl
+++ b/src/riak_core_ring_handler.erl
@@ -121,27 +121,23 @@ ensure_vnodes_started({App,Mod}, Ring) ->
                        end,
 
                        %% Let the app finish starting...
-                       case riak_core:wait_for_application(App) of
-                           ok ->
-                               %% Start the vnodes.
-                               Mod:start_vnode(Startable),
+                       ok = riak_core:wait_for_application(App),
 
-                               %% Mark the service as up.
-                               SupName = list_to_atom(atom_to_list(App) ++ "_sup"),
-                               SupPid = erlang:whereis(SupName),
-                               case riak_core:health_check(App) of
-                                   undefined ->
-                                       riak_core_node_watcher:service_up(App, SupPid);
-                                   HealthMFA ->
-                                       riak_core_node_watcher:service_up(App,
-                                                                         SupPid,
-                                                                         HealthMFA)
-                               end,
-                               exit(normal);
-                           {error, Reason} ->
-                               lager:critical("Failed to start application: ~p", [App]),
-                               throw({error, Reason})
-                       end
+                       %% Start the vnodes.
+                       Mod:start_vnode(Startable),
+
+                       %% Mark the service as up.
+                       SupName = list_to_atom(atom_to_list(App) ++ "_sup"),
+                       SupPid = erlang:whereis(SupName),
+                       case riak_core:health_check(App) of
+                           undefined ->
+                               riak_core_node_watcher:service_up(App, SupPid);
+                           HealthMFA ->
+                               riak_core_node_watcher:service_up(App,
+                                                                 SupPid,
+                                                                 HealthMFA)
+                       end,
+                       exit(normal)
                end),
     Startable.
 

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -59,8 +59,8 @@
 -type repairs() :: [repair()].
 
 -record(state, {idxtab,
-                forwarding :: [pid()],
-                handoff :: [{term(), integer(), pid(), node()}],
+                forwarding :: [{{module(), integer()}, term()}],
+                handoff :: [{{module(), integer()}, term()}],
                 known_modules :: [term()],
                 never_started :: [{integer(), term()}],
                 vnode_start_tokens :: integer(),


### PR DESCRIPTION
Addresses some warnings found in dialyzer mostly by correcting type specs. One dead code branch is removed. Complete list of warnings found on master (db17fcc515c): https://gist.github.com/176895ea43b1f41ea3c2. Notes about which warnings are fixed can be found in the commit messages. 

Note: you will need a rebar that contains [this commit](https://github.com/rebar/rebar/commit/e7be6874d7dded06659a055d497247aba1c90b4c) in order to run dialyzer without crashing on `riak_core_pb` not being compiled with `debug_info`. I used `basho/rebar` master. This PR does not include a change to rebar (figured that could be done separately when we decide what version).  
