### PR TITLE
Notify caller of sync/spawn command errors

### DIFF
--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -207,14 +207,20 @@ vnode_command(Sender, Request, State=#state{index=Index,
                                             forward=Forward,
                                             pool_pid=Pool}) ->
     %% Check if we should forward
-    case Forward of
+    Action = case Forward of
         undefined ->
-            Action = Mod:handle_command(Request, Sender, ModState);
+            case catch Mod:handle_command(Request, Sender, ModState) of
+                {'EXIT', ExitReason} ->
+                    reply(Sender, {vnode_error, ExitReason}),
+                    lager:error("~p command failed ~p", [Mod, ExitReason]),
+                    {stop, ExitReason, ModState};
+                Else -> Else
+            end;
         NextOwner ->
             lager:debug("Forwarding ~p -> ~p: ~p~n", [node(), NextOwner, Index]),
             riak_core_vnode_master:command({Index, NextOwner}, Request, Sender,
                                            riak_core_vnode_master:reg_name(Mod)),
-            Action = continue
+            continue
     end,
     case Action of
         continue ->

--- a/src/riak_core_vnode_master.erl
+++ b/src/riak_core_vnode_master.erl
@@ -117,16 +117,23 @@ sync_command({Index,Node}, Msg, VMaster, Timeout) ->
     %% Issue the call to the master, it will update the Sender with
     %% the From for handle_call so that the {reply} return gets
     %% sent here.
-    gen_server:call({VMaster, Node},
-                    make_request(Msg, {server, undefined, undefined}, Index), Timeout).
+    Request = make_request(Msg, {server, undefined, undefined}, Index),
+    case gen_server:call({VMaster, Node}, Request, Timeout) of
+        {vnode_error, {Error, _Args}} -> error(Error);
+        {vnode_error, Error} -> error(Error);
+        Else -> Else
+    end.
 
 %% Send a synchronous spawned command to an individual Index/Node combination.
 %% Will not return until the vnode has returned, but the vnode_master will
 %% continue to handle requests.
 sync_spawn_command({Index,Node}, Msg, VMaster) ->
-    gen_server:call({VMaster, Node},
-                    {spawn, make_request(Msg, {server, undefined, undefined}, Index)},
-                    infinity).
+    Request = make_request(Msg, {server, undefined, undefined}, Index),
+    case gen_server:call({VMaster, Node}, {spawn, Request}, infinity) of
+        {vnode_error, {Error, _Args}} -> error(Error);
+        {vnode_error, Error} -> error(Error);
+        Else -> Else
+    end.
 
 
 %% Make a request record - exported for use by legacy modules

--- a/test/sync_command_test.erl
+++ b/test/sync_command_test.erl
@@ -1,0 +1,111 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(sync_command_test).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("riak_core_vnode.hrl").
+
+sync_test_() ->
+    {foreach,
+     fun setup_simple/0,
+     fun stop_servers/1,
+     [ {<<"Assert ok throw">>, 
+        fun() ->
+            ?assertEqual(ok, mock_vnode:sync_error({0, node()}, goodthrow))
+        end},
+       {<<"Assert error throw">>,
+        fun() ->
+            ?assertEqual({error, terrible}, mock_vnode:sync_error({0, node()}, badthrow))
+        end},
+       {<<"Assert sync error">>,
+        fun() ->
+            ?assertError(core_breach, mock_vnode:sync_error({0, node()}, error))
+        end},
+       {<<"Assert sync exit">>,
+        fun() ->
+            ?assertError(core_breach, mock_vnode:sync_error({0, node()}, exit))
+        end},
+       {<<"Assert non-blocking sync error">>,
+        fun() ->
+            ?assertError(core_breach, mock_vnode:spawn_error({0, node()}, error))
+        end},
+       {<<"Assert non-blocking sync exit">>,
+        fun() ->
+            ?assertError(core_breach, mock_vnode:spawn_error({0, node()}, exit))
+        end}
+       ]
+    }.
+
+
+setup_simple() ->
+    stop_servers(self()),
+    Vars = [{ring_creation_size, 8},
+            {ring_state_dir, "<nostore>"},
+            %% Don't allow rolling start of vnodes as it will cause a
+            %% race condition with `all_nodes'.
+            {core_vnode_eqc_pool_size, 0},
+            {vnode_rolling_start, 0}],
+    _ = [begin
+        Old = app_helper:get_env(riak_core, AppKey),
+        ok = application:set_env(riak_core, AppKey, Val),
+        {AppKey, Old}
+     end || {AppKey, Val} <- Vars],
+    riak_core_ring_events:start_link(),
+    riak_core_ring_manager:start_link(test),
+    riak_core_vnode_proxy_sup:start_link(),
+
+    {ok, _Sup} = riak_core_vnode_sup:start_link(),
+    {ok, _} = riak_core_vnode_manager:start_link(),
+    {ok, _VMaster} = riak_core_vnode_master:start_link(mock_vnode),
+
+
+    ok = mock_vnode:start_vnode(0),
+    %% NOTE: The return value from this call is currently not being
+    %%       used.  This call is made to ensure that all msgs sent to
+    %%       the vnode mgr before this call have been handled.  This
+    %%       guarantees that the vnode mgr ets tab is up-to-date
+
+    riak_core:register([{vnode_module, mock_vnode}]).
+
+
+stop_servers(_Pid) ->
+    %% Make sure VMaster is killed before sup as start_vnode is a cast
+    %% and there may be a pending request to start the vnode.
+    stop_pid(whereis(mock_vnode_master)),
+    stop_pid(whereis(riak_core_vnode_manager)),
+    stop_pid(whereis(riak_core_vnode_events)),
+    stop_pid(whereis(riak_core_vnode_sup)).
+
+stop_pid(undefined) ->
+    ok;
+stop_pid(Pid) ->
+    unlink(Pid),
+    exit(Pid, shutdown),
+    ok = wait_for_pid(Pid).
+
+wait_for_pid(Pid) ->
+    Mref = erlang:monitor(process, Pid),
+    receive
+        {'DOWN',Mref,process,_,_} ->
+            ok
+    after
+        5000 ->
+            {error, didnotexit}
+    end.


### PR DESCRIPTION
sync_command times out when a vnode command errors or exits.. 
sync_spawn_command will wait for infinity under the same condition.
