### PR TITLE
Add encoding capability for handoff.

### DIFF
--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -78,7 +78,7 @@ start(_StartType, _StartArgs) ->
             riak_core:register(riak_core, [{stat_mod, riak_core_stat}]),
             ok = riak_core_ring_events:add_guarded_handler(riak_core_ring_handler, []),
 
-            %% Register capabilities
+            %% Register capabilities (note: first setting in capability list is default ):
             riak_core_capability:register({riak_core, vnode_routing},
                                           [proxy, legacy],
                                           legacy,
@@ -89,7 +89,7 @@ start(_StartType, _StartArgs) ->
                                           [true, false],
                                           false),
             riak_core_capability:register({riak_core, handoff_data_encoding},
-                                          [encode_zlib, encode_raw],
+                                         [encode_raw, encode_zlib],
                                           encode_raw),
 
             {ok, Pid};

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -88,6 +88,9 @@ start(_StartType, _StartArgs) ->
             riak_core_capability:register({riak_core, staged_joins},
                                           [true, false],
                                           false),
+            riak_core_capability:register({riak_core, handoff_data_encoding},
+                                          [encode_zlib, encode_raw],
+                                          encode_raw),
 
             {ok, Pid};
         {error, Reason} ->

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -272,7 +272,7 @@ visit_item(K, V, Acc) ->
 
     case Filter(K) of
         true ->
-            { BinObj, _EncodingMethod } = Module:encode_handoff_item(K, V),
+            BinObj = Module:encode_handoff_item(K, V),
 
             M = <<?PT_MSG_OBJ:8,BinObj/binary>>,
             NumBytes = byte_size(M),

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -272,7 +272,18 @@ visit_item(K, V, Acc) ->
 
     case Filter(K) of
         true ->
-            BinObj = Module:encode_handoff_item(K, V),
+lager:debug("JFW: riak_core_handoff_sender() filter(k) is true."),
+            { BinObj, EncodingMethod } = Module:encode_handoff_item(K, V),
+lager:debug("JFW: encoding method was ~p", [EncodingMethod]),
+lager:debug("JFW: BinObj is: ~p", [EncodingMethod]),
+       
+%% JFW: next, figure out what to do... 
+            case EncodingMethod of
+                encode_raw  -> false;
+                encode_zlib -> true;
+                _           -> throw({unimplemented_encoding_method, EncodingMethod})
+            end,
+
             M = <<?PT_MSG_OBJ:8,BinObj/binary>>,
             NumBytes = byte_size(M),
 

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -272,17 +272,7 @@ visit_item(K, V, Acc) ->
 
     case Filter(K) of
         true ->
-lager:debug("JFW: riak_core_handoff_sender() filter(k) is true."),
-            { BinObj, EncodingMethod } = Module:encode_handoff_item(K, V),
-lager:debug("JFW: encoding method was ~p", [EncodingMethod]),
-lager:debug("JFW: BinObj is: ~p", [EncodingMethod]),
-       
-%% JFW: next, figure out what to do... 
-            case EncodingMethod of
-                encode_raw  -> false;
-                encode_zlib -> true;
-                _           -> throw({unimplemented_encoding_method, EncodingMethod})
-            end,
+            { BinObj, _EncodingMethod } = Module:encode_handoff_item(K, V),
 
             M = <<?PT_MSG_OBJ:8,BinObj/binary>>,
             NumBytes = byte_size(M),


### PR DESCRIPTION
Motivation:
Zlib forces serialization on an internal Erlang lock when opening new port drivers, which we are concerned may adversely affect scalability on larger systems. This feature provides a new capability for specifying the encoding method used for handoff, and offers a new option to use raw encoding so that users may choose a tuning most appropriate for their situation.

Note: Since capabilities are not re-negotiated, in some corner cases of rolling upgrade, it's possible for handoff to crash if a capability changes mid-up/downgrade; in this case, handoff will still finish, as it is designed to crash and will restart. Future work is expected to eliminate this case by encoding capabilities for the entire handoff rather than per-session.

See also:
https://github.com/basho/riak_kv/pull/495
https://github.com/basho/riak_test/pull/223
