### PR TITLE
Move riak-admin reference to riak_kv

### DIFF
--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -491,9 +491,6 @@ transfer_limit([]) ->
                           io:format("(offline)    ~p~n", [Node])
                   end, Down),
     io:format("~79..-s~n", [""]),
-    io:format("Note: You can change transfer limits with "
-              "'riak-admin transfer_limit <limit>'~n"
-              "      and 'riak-admin transfer_limit <node> <limit>'~n"),
     ok;
 transfer_limit([LimitStr]) ->
     {Valid, Limit} = check_limit(LimitStr),


### PR DESCRIPTION
riak-admin is a Riak specific script, so refactoring to avoid mention in
riak_core.

riak_kv takes over this message in basho/riak_kv#497 and basho/riak#284 points the script to the kv console
