### PR TITLE
Rather than calculate stats on demand when stale, backfill the cache

### DIFF
--- a/src/riak_core_stat.erl
+++ b/src/riak_core_stat.erl
@@ -134,26 +134,33 @@ register_stat(Name, duration) ->
     folsom_metrics:new_duration(Name).
 
 gossip_stats() ->
-    lists:flatten([backwards_compat(Stat, Type, folsom_metrics:get_metric_value({?APP, Stat})) ||
+    lists:flatten([backwards_compat(Stat, Type, riak_core_stat_q:calc_stat({{?APP, Stat}, Type})) ||
                       {Stat, Type} <- stats(), Stat /= riak_core_rejected_handoffs]).
 
+backwards_compat(Name, Type, unavailable) when Type =/= counter ->
+    backwards_compat(Name, Type, []);
 backwards_compat(rings_reconciled, spiral, Stats) ->
-    [{rings_reconciled_total, proplists:get_value(count, Stats)},
-    {rings_reconciled, trunc(proplists:get_value(one, Stats))}];
+    [{rings_reconciled_total, proplists:get_value(count, Stats, unavailable)},
+    {rings_reconciled, safe_trunc(proplists:get_value(one, Stats, unavailable))}];
 backwards_compat(gossip_received, spiral, Stats) ->
-    {gossip_received, trunc(proplists:get_value(one, Stats))};
+    {gossip_received, safe_trunc(proplists:get_value(one, Stats, unavailable))};
 backwards_compat(Name, counter, Stats) ->
     {Name, Stats};
 backwards_compat(Name, duration, Stats) ->
-    [{join(Name, min), trunc(proplists:get_value(min, Stats))},
-     {join(Name, max), trunc(proplists:get_value(max, Stats))},
-     {join(Name, mean), trunc(proplists:get_value(arithmetic_mean, Stats))},
-     {join(Name, last), proplists:get_value(last, Stats)}].
+    [{join(Name, min), safe_trunc(proplists:get_value(min, Stats, unavailable))},
+     {join(Name, max), safe_trunc(proplists:get_value(max, Stats, unavailable))},
+     {join(Name, mean), safe_trunc(proplists:get_value(arithmetic_mean, Stats, unavailable))},
+     {join(Name, last), proplists:get_value(last, Stats, unavailable)}].
 
 join(Atom1, Atom2) ->
     Bin1 = atom_to_binary(Atom1, latin1),
     Bin2 = atom_to_binary(Atom2, latin1),
     binary_to_atom(<<Bin1/binary, $_, Bin2/binary>>, latin1).
+
+safe_trunc(N) when is_number(N) ->
+    trunc(N);
+safe_trunc(X) ->
+    X.
 
 %% Provide aggregate stats for vnode queues.  Compute instantaneously for now,
 %% may need to cache if stats are called heavily (multiple times per seconds)

--- a/src/riak_core_stat_cache.erl
+++ b/src/riak_core_stat_cache.erl
@@ -18,14 +18,20 @@
 %%
 %% -------------------------------------------------------------------
 
+%% @ doc fetches stats for registered modules and stores them
+%% in an ets backed cache.
+%% Only ever allows one process at a time to calculate stats.
+%% Will always serve the stats that are in the cache.
+%% Adds a stat `{stat_mod_ts, timestamp()}' to the stats returned
+%% from `get_stats/1' which is the time those stats were calculated.
+
 -module(riak_core_stat_cache).
 
 -behaviour(gen_server).
 
-
 %% API
 -export([start_link/0, get_stats/1, register_app/2, register_app/3,
-        stop/0]).
+        clear_cache/1, stop/0]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -36,8 +42,9 @@
 -endif.
 
 -define(SERVER, ?MODULE).
-%% @doc Cache item time to live in seconds
--define(TTL, 5).
+%% @doc Cache item refresh rate in seconds
+-define(REFRESH_RATE, 1).
+-define(REFRSH_MILLIS(N), timer:seconds(N)).
 -define(ENOTREG(App), {error, {not_registered, App}}).
 
 -record(state, {tab, active=orddict:new(), apps=orddict:new()}).
@@ -50,14 +57,17 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_app(App, {M, F, A}) ->
-    TTL = app_helper:get_env(riak_core, stat_cache_ttl, ?TTL),
-    register_app(App, {M, F, A}, TTL).
+    RefreshRate = app_helper:get_env(riak_core, stat_cache_ttl, ?REFRESH_RATE),
+    register_app(App, {M, F, A}, RefreshRate).
 
-register_app(App, {M, F, A}, TTL) ->
-    gen_server:call(?SERVER, {register, App, {M, F, A}, TTL}).
+register_app(App, {M, F, A}, RefreshRateSecs) ->
+    gen_server:call(?SERVER, {register, App, {M, F, A}, ?REFRSH_MILLIS(RefreshRateSecs)}).
 
 get_stats(App) ->
     gen_server:call(?SERVER, {get_stats, App}, infinity).
+
+clear_cache(App) ->
+    gen_server:call(?SERVER, {clear, App}, infinity).
 
 stop() ->
     gen_server:cast(?SERVER, stop).
@@ -67,18 +77,22 @@ stop() ->
 init([]) ->
     process_flag(trap_exit, true),
     Tab = ets:new(?MODULE, [protected, set, named_table]),
-    TTL = app_helper:get_env(riak_core, stat_cache_ttl, ?TTL),
+    RefreshRateSecs = app_helper:get_env(riak_core, stat_cache_ttl, ?REFRESH_RATE),
+    RefreshRateMillis = ?REFRSH_MILLIS(RefreshRateSecs),
     %% re-register mods, if this is a restart after a crash
-    RegisteredMods = lists:foldl(fun({App, Mod}, Registerd) ->
-                                         register_mod(App, Mod, produce_stats, [], TTL, Registerd) end,
+    RegisteredMods = lists:foldl(fun({App, Mod}, Registered) ->
+                                         register_mod(App, Mod, produce_stats, [], RefreshRateMillis, Registered),
+                                         schedule_get_stats(RefreshRateMillis, App, {Mod, produce_stats, []}) end,
                                  orddict:new(),
                                  riak_core:stat_mods()),
     {ok, #state{tab=Tab, apps=orddict:from_list(RegisteredMods)}}.
 
-handle_call({register, App, {Mod, Fun, Args}, TTL}, _From, State0=#state{apps=Apps0}) ->
+handle_call({register, App, {Mod, Fun, Args}=MFA, RefreshRateMillis}, _From, State0=#state{apps=Apps0}) ->
     Apps = case registered(App, Apps0) of
                false ->
-                   register_mod(App, Mod, Fun, Args, TTL, Apps0);
+                   Apps1 = register_mod(App, Mod, Fun, Args, RefreshRateMillis, Apps0),
+                   schedule_get_stats(RefreshRateMillis, App, MFA),
+                   Apps1;
                {true, _} ->
                    Apps0
            end,
@@ -87,29 +101,42 @@ handle_call({get_stats, App}, From, State0=#state{apps=Apps, active=Active0, tab
     Reply = case registered(App, Apps) of
                 false ->
                     {reply, ?ENOTREG(App), State0};
-                {true, {M, F, A, TTL}} ->
-                    case cache_get(App, Tab, TTL) of
-                        No when No == miss; No == stale ->
+                {true, {M, F, A, _RefreshRateMillis}} ->
+                    case cache_get(App, Tab) of
+                        No when No == miss ->
                             Active = maybe_get_stats(App, From, Active0, {M, F, A}),
                             {noreply, State0#state{active=Active}};
                         {hit, Stats, TS} ->
-                            {reply, {ok, Stats, TS}, State0}
+                            FreshnessStat = make_freshness_stat(App, TS),
+                            {reply, {ok, [FreshnessStat | Stats], TS}, State0}
                     end
+            end,
+    Reply;
+handle_call({clear, App}, _From, State=#state{apps=Apps, tab=Tab}) ->
+    Reply = case registered(App, Apps) of
+                false ->
+                    {reply, ?ENOTREG(App), State};
+                {true, _} ->
+                    true = ets:delete(Tab, App),
+                    {reply, ok, State}
             end,
     Reply;
 handle_call(_Request, _From, State) ->
     Reply = ok,
     {reply, Reply, State}.
 
-handle_cast({stats, App, Stats, TS}, State0=#state{tab=Tab, active=Active}) ->
+%% @doc call back from process executig the stat calculation
+handle_cast({stats, App, Stats, TS}, State0=#state{tab=Tab, active=Active, apps=Apps}) ->
     ets:insert(Tab, {App, TS, Stats}),
     State = case orddict:find(App, Active) of
                 {ok, {_Pid, Awaiting}} ->
-                    [gen_server:reply(From, {ok, Stats, TS}) || From <- Awaiting],
+                    [gen_server:reply(From, {ok, [make_freshness_stat(App, TS) |Stats], TS}) || From <- Awaiting, From /= ?SERVER],
                     State0#state{active=orddict:erase(App, Active)};
                 error ->
                     State0
             end,
+    {ok, {M, F, A, RefreshRateMillis}} = orddict:find(App, Apps),
+    schedule_get_stats(RefreshRateMillis, App, {M, F, A}),
     {noreply, State};
 handle_cast(stop, State) ->
     {stop, normal, State};
@@ -122,10 +149,14 @@ handle_info({'EXIT', FromPid, Reason}, State0=#state{active=Active}) when Reason
                  not_found ->
                      {stop, Reason, State0};
                  {ok, {App, Awaiting}} ->
-                     [gen_server:reply(From, {error, Reason}) || From <- Awaiting],
+                     [gen_server:reply(From, {error, Reason}) || From <- Awaiting, From /= ?SERVER],
                      {noreply, State0#state{active=orddict:erase(App, Active)}}
              end,
      Reply;
+%% @doc callback on timer timeout to keep cache fresh
+handle_info({get_stats, {App, MFA}}, State) ->
+    Active =  maybe_get_stats(App, ?SERVER, State#state.active, MFA),
+    {noreply, State#state{active=Active}};
 handle_info(_Info, State) ->
     {noreply, State}.
 
@@ -136,10 +167,19 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
 %% internal
-register_mod(App, Mod, Fun, Args, TTL, Apps) ->
+schedule_get_stats(After, App, MFA) ->
+    erlang:send_after(After, ?SERVER, {get_stats, {App, MFA}}).
+
+make_freshness_stat(App, TS) ->
+    {make_freshness_stat_name(App), TS}.
+
+make_freshness_stat_name(App) ->
+    list_to_atom(atom_to_list(App) ++ "_stat_ts").
+
+register_mod(App, Mod, Fun, Args, RefreshRateMillis, Apps) ->
     folsom_metrics:new_histogram({?MODULE, Mod}),
     folsom_metrics:new_meter({?MODULE, App}),
-    orddict:store(App, {Mod, Fun, Args, TTL}, Apps).
+    orddict:store(App, {Mod, Fun, Args, RefreshRateMillis}, Apps).
 
 registered(App, Apps) ->
     registered(orddict:find(App, Apps)).
@@ -149,28 +189,20 @@ registered(error) ->
 registered({ok, Val}) ->
     {true, Val}.
 
-cache_get(App, Tab, TTL) ->
+cache_get(App, Tab) ->
     Res = case ets:lookup(Tab, App) of
               [] ->
                   miss;
-              [Hit] ->
-                  check_freshness(Hit, TTL)
+              [{App, TStamp, Stats}] ->
+                  {hit, Stats, TStamp}
           end,
     Res.
-
-check_freshness({_App, TStamp, Stats}, TTL) ->
-    case (TStamp + TTL) > folsom_utils:now_epoch() of
-        true ->
-             {hit, Stats, TStamp};
-        false ->
-            stale
-    end.
 
 maybe_get_stats(App, From, Active, {M, F, A}) ->
     %% if a get stats is not under way start one
     Awaiting = case orddict:find(App, Active) of
                    error ->
-                      Pid = do_get_stats(App, {M, F, A}),
+                       Pid = do_get_stats(App, {M, F, A}),
                        {Pid, [From]};
                    {ok, {Pid, Froms}} ->
                        {Pid, [From|Froms]}
@@ -194,7 +226,10 @@ awaiting_for_pid(Pid, Active) ->
 -ifdef(TEST).
 
 -define(MOCKS, [folsom_utils, riak_core_stat, riak_kv_stat]).
--define(STATS, [{stat1, 0, stat2, 1, stat3, 2}]).
+-define(STATS, [{stat1, 0}, {stat2, 1}, {stat3, 2}]).
+
+cached(App, Time) ->
+    [make_freshness_stat(App, Time) | ?STATS].
 
 cache_test_() ->
     {setup,
@@ -228,8 +263,8 @@ register() ->
     riak_core_stat_cache:register_app(riak_core, {riak_core_stat, produce_stats, []}, 5),
     riak_core_stat_cache:register_app(riak_kv, {riak_kv_stat, produce_stats, []}, 5),
     NonSuch = riak_core_stat_cache:get_stats(nonsuch),
-    ?assertEqual({ok, ?STATS, Now}, riak_core_stat_cache:get_stats(riak_core)),
-    ?assertEqual({ok, ?STATS, Now}, riak_core_stat_cache:get_stats(riak_kv)),
+    ?assertEqual({ok, cached(riak_core, Now), Now}, riak_core_stat_cache:get_stats(riak_core)),
+    ?assertEqual({ok, cached(riak_kv, Now), Now}, riak_core_stat_cache:get_stats(riak_kv)),
     ?assertEqual(?ENOTREG(nonsuch), NonSuch),
     %% and check the cache has the correct values
     [?assertEqual([{App, Now, ?STATS}], ets:lookup(riak_core_stat_cache, App))
@@ -242,15 +277,17 @@ register() ->
 
 get_cached() ->
     Now = tick(1000, 0),
-    [?assertEqual({ok, ?STATS, Now}, riak_core_stat_cache:get_stats(riak_core))
+    [?assertEqual({ok, cached(riak_core, Now), Now}, riak_core_stat_cache:get_stats(riak_core))
      || _ <- lists:seq(1, 20)],
     ?assertEqual(1, meck:num_calls(riak_core_stat, produce_stats, [])).
 
 get_expired() ->
-    Now = tick(1000, ?TTL+?TTL),
-    [?assertEqual({ok, ?STATS, Now}, riak_core_stat_cache:get_stats(riak_core))
+    CalcTime = 1000,
+    _Expired = tick(CalcTime, ?REFRESH_RATE+?REFRESH_RATE),
+    [?assertEqual({ok, cached(riak_core, CalcTime), CalcTime}, riak_core_stat_cache:get_stats(riak_core))
      || _ <- lists:seq(1, 20)],
-    ?assertEqual(2, meck:num_calls(riak_core_stat, produce_stats, [])).
+    %% Stale stats should no longer trigger a stat calculation
+    ?assertEqual(1, meck:num_calls(riak_core_stat, produce_stats, [])).
 
 serialize_calls() ->
     %% many processes can call get stats at once
@@ -262,13 +299,17 @@ serialize_calls() ->
     %% call get stats for core to show the server is not blocked
     %% return from the kv call and show a) all have same result
     %% b) only one call to produce_stats
+    %% But ONLY in the case that the cache is empty. At any other time,
+    %% that cached answer should be returned.
+    riak_core_stat_cache:clear_cache(riak_kv),
     Procs = 20,
+    Then = 1000,
     Now = tick(2000, 0),
     meck:expect(riak_kv_stat, produce_stats, fun() -> register(blocked, self()), receive release -> ?STATS  end end),
     Coordinator = self(),
     Collector  = spawn_link(fun() -> collect_results(Coordinator, [], Procs) end),
     Pids = [spawn_link(fun() -> Stats = riak_core_stat_cache:get_stats(riak_kv), Collector ! {res, Stats} end) || _ <- lists:seq(1, Procs)],
-    ?assertEqual({ok, ?STATS, Now}, riak_core_stat_cache:get_stats(riak_core)),
+    ?assertEqual({ok, cached(riak_core, Then), Then}, riak_core_stat_cache:get_stats(riak_core)),
     [?assertEqual({status, waiting}, process_info(Pid, status)) || Pid <- Pids],
 
     timer:sleep(100), %% time for register
@@ -284,18 +325,20 @@ serialize_calls() ->
 
     [?assertEqual(undefined, process_info(Pid)) || Pid <- Pids],
     ?assertEqual(Procs, length(Results)),
-    [?assertEqual({ok, ?STATS, Now}, Res) || Res <- Results],
+    [?assertEqual({ok, cached(riak_kv, Now), Now}, Res) || Res <- Results],
     ?assertEqual(2, meck:num_calls(riak_kv_stat, produce_stats, [])).
 
 crasher() ->
+    riak_core_stat_cache:clear_cache(riak_kv),
     Pid = whereis(riak_core_stat_cache),
+    Then = tick(1000, 0),
     Now = tick(10000, 0),
     meck:expect(riak_core_stat, produce_stats, fun() ->
                                                        ?STATS end),
     meck:expect(riak_kv_stat, produce_stats, fun() -> erlang:error(boom)  end),
     ?assertMatch({error, {boom, _Stack}}, riak_core_stat_cache:get_stats(riak_kv)),
     ?assertEqual(Pid, whereis(riak_core_stat_cache)),
-    ?assertEqual({ok, ?STATS, Now}, riak_core_stat_cache:get_stats(riak_core)).
+    ?assertEqual({ok, cached(riak_core, Then), Then}, riak_core_stat_cache:get_stats(riak_core)).
 
 tick(Moment, IncrBy) ->
     meck:expect(folsom_utils, now_epoch, fun() -> Moment + IncrBy end),

--- a/src/riak_core_stat_cache.erl
+++ b/src/riak_core_stat_cache.erl
@@ -84,8 +84,7 @@ init([]) ->
     RefreshRateMillis = ?REFRSH_MILLIS(RefreshRateSecs),
     %% re-register mods, if this is a restart after a crash
     RegisteredMods = lists:foldl(fun({App, Mod}, Registered) ->
-                                         register_mod(App, ?DEFAULT_REG(Mod, RefreshRateMillis), Registered),
-                                         schedule_get_stats(RefreshRateMillis, App, {Mod, produce_stats, []}) end,
+                                         register_mod(App, ?DEFAULT_REG(Mod, RefreshRateMillis), Registered) end,
                                  orddict:new(),
                                  riak_core:stat_mods()),
     {ok, #state{tab=Tab, apps=orddict:from_list(RegisteredMods)}}.
@@ -93,9 +92,7 @@ init([]) ->
 handle_call({register, App, {MFA, RefreshRateMillis}}, _From, State0=#state{apps=Apps0}) ->
     Apps = case registered(App, Apps0) of
                false ->
-                   Apps1 = register_mod(App,{MFA, RefreshRateMillis}, Apps0),
-                   schedule_get_stats(RefreshRateMillis, App, MFA),
-                   Apps1;
+                   register_mod(App,{MFA, RefreshRateMillis}, Apps0);
                {true, _} ->
                    Apps0
            end,
@@ -169,7 +166,8 @@ code_change(_OldVsn, State, _Extra) ->
 
 %% internal
 schedule_get_stats(After, App, MFA) ->
-    erlang:send_after(After, ?SERVER, {get_stats, {App, MFA}}).
+    Pid = self(),
+    erlang:send_after(After, Pid, {get_stats, {App, MFA}}).
 
 make_freshness_stat(App, TS) ->
     {make_freshness_stat_name(App), TS}.
@@ -178,11 +176,13 @@ make_freshness_stat_name(App) ->
     list_to_atom(atom_to_list(App) ++ "_stat_ts").
 
 -spec register_mod(atom(), registered_app(), orddict:orddict()) -> orddict:orddict().
-register_mod(App, AppRegistration, Apps) ->
-    {{Mod, _, _}, _} = AppRegistration,
+register_mod(App, AppRegistration, Apps0) ->
+    {{Mod, _, _}=MFA, RefreshRateMillis} = AppRegistration,
     folsom_metrics:new_histogram({?MODULE, Mod}),
     folsom_metrics:new_meter({?MODULE, App}),
-    orddict:store(App, AppRegistration, Apps).
+    Apps = orddict:store(App, AppRegistration, Apps0),
+    schedule_get_stats(RefreshRateMillis, App, MFA),
+    Apps.
 
 registered(App, Apps) ->
     registered(orddict:find(App, Apps)).

--- a/src/riak_core_stat_cache.erl
+++ b/src/riak_core_stat_cache.erl
@@ -127,7 +127,12 @@ handle_call(_Request, _From, State) ->
     {reply, Reply, State}.
 
 %% @doc call back from process executig the stat calculation
-handle_cast({stats, App, Stats, TS}, State0=#state{tab=Tab, active=Active, apps=Apps}) ->
+handle_cast({stats, App, Stats0, TS}, State0=#state{tab=Tab, active=Active, apps=Apps}) ->
+    %% @TODO standardise stat mods return type with a behaviour
+    Stats = case Stats0 of
+                {App, Stats1} -> Stats1;
+                Stats1 -> Stats1
+            end,
     ets:insert(Tab, {App, TS, Stats}),
     State = case orddict:find(App, Active) of
                 {ok, {_Pid, Awaiting}} ->

--- a/src/riak_core_stat_q.erl
+++ b/src/riak_core_stat_q.erl
@@ -83,24 +83,36 @@ size_guard(N) ->
     {'>=', {size, '$1'}, N}.
 
 calculate_stats(NamesAndTypes) ->
-    [{Name, get_stat(Stat)} || {Name, _Type}=Stat <- NamesAndTypes].
+    [{Name, get_stat({Name, Type})} || {Name, {metric, _, Type, _}} <- NamesAndTypes].
 
 %% Create/lookup a cache/calculation process
 get_stat(Stat) ->
     Pid = riak_core_stat_calc_sup:calc_proc(Stat),
     riak_core_stat_calc_proc:value(Pid).
 
-%% BAD uses internl knowledge of folsom metrics record
-%% This is a callback function used by
-%% riak_core_stat_calc_proc when it calculates a stat's
-%% current value.
-calc_stat({Name, {metric, _Tags, gauge, _HistLen}}) ->
-    GuageVal = folsom_metrics:get_metric_value(Name),
-    calc_guage(GuageVal);
-calc_stat({Name, {metric, _Tags, histogram, _HistLen}}) ->
-    folsom_metrics:get_histogram_statistics(Name);
-calc_stat({Name, {metric, _Tags, _Type, _HistLen}}) ->
-    folsom_metrics:get_metric_value(Name).
+%% Encapsulate getting a stat value from folsom.
+%%
+%% If for any reason we can't get a stats value
+%% return 'unavailable'.
+%% @TODO experience shows that once a stat is
+%% broken it stays that way. Should we delete
+%% stats that are broken?
+calc_stat({Name, gauge}) ->
+    try
+        GuageVal = folsom_metrics:get_metric_value(Name),
+        calc_guage(GuageVal)
+    catch _:_ ->
+            unavailable
+    end;
+calc_stat({Name, histogram}) ->
+    try
+        folsom_metrics:get_histogram_statistics(Name)
+    catch _:_ -> unavailable
+    end;
+calc_stat({Name, _Type}) ->
+    try folsom_metrics:get_metric_value(Name)
+    catch _:_ -> unavailable
+    end.
 
 %% some crazy people put funs in folsom gauges
 %% so that they can have a consistent interface


### PR DESCRIPTION
Always server the stats that are in the cache, no matter how old they are.
Add a timestamp to the stats so consumers know how stale they are.
Fill the cache continuously in the background.

See https://github.com/basho/riak_kv/issues/505 and https://github.com/basho/riak_kv/issues/506 for graphs, bench configs etc.
