### PR TITLE
Make stats more robust in the face of failure

### DIFF
--- a/src/riak_core_stat.erl
+++ b/src/riak_core_stat.erl
@@ -134,26 +134,33 @@ register_stat(Name, duration) ->
     folsom_metrics:new_duration(Name).
 
 gossip_stats() ->
-    lists:flatten([backwards_compat(Stat, Type, folsom_metrics:get_metric_value({?APP, Stat})) ||
+    lists:flatten([backwards_compat(Stat, Type, riak_core_stat_q:calc_stat({{?APP, Stat}, Type})) ||
                       {Stat, Type} <- stats(), Stat /= riak_core_rejected_handoffs]).
 
+backwards_compat(Name, Type, unavailable) when Type =/= counter ->
+    backwards_compat(Name, Type, []);
 backwards_compat(rings_reconciled, spiral, Stats) ->
-    [{rings_reconciled_total, proplists:get_value(count, Stats)},
-    {rings_reconciled, trunc(proplists:get_value(one, Stats))}];
+    [{rings_reconciled_total, proplists:get_value(count, Stats, unavailable)},
+    {rings_reconciled, safe_trunc(proplists:get_value(one, Stats, unavailable))}];
 backwards_compat(gossip_received, spiral, Stats) ->
-    {gossip_received, trunc(proplists:get_value(one, Stats))};
+    {gossip_received, safe_trunc(proplists:get_value(one, Stats, unavailable))};
 backwards_compat(Name, counter, Stats) ->
     {Name, Stats};
 backwards_compat(Name, duration, Stats) ->
-    [{join(Name, min), trunc(proplists:get_value(min, Stats))},
-     {join(Name, max), trunc(proplists:get_value(max, Stats))},
-     {join(Name, mean), trunc(proplists:get_value(arithmetic_mean, Stats))},
-     {join(Name, last), proplists:get_value(last, Stats)}].
+    [{join(Name, min), safe_trunc(proplists:get_value(min, Stats, unavailable))},
+     {join(Name, max), safe_trunc(proplists:get_value(max, Stats, unavailable))},
+     {join(Name, mean), safe_trunc(proplists:get_value(arithmetic_mean, Stats, unavailable))},
+     {join(Name, last), proplists:get_value(last, Stats, unavailable)}].
 
 join(Atom1, Atom2) ->
     Bin1 = atom_to_binary(Atom1, latin1),
     Bin2 = atom_to_binary(Atom2, latin1),
     binary_to_atom(<<Bin1/binary, $_, Bin2/binary>>, latin1).
+
+safe_trunc(N) when is_number(N) ->
+    trunc(N);
+safe_trunc(X) ->
+    X.
 
 %% Provide aggregate stats for vnode queues.  Compute instantaneously for now,
 %% may need to cache if stats are called heavily (multiple times per seconds)

--- a/src/riak_core_stat_cache.erl
+++ b/src/riak_core_stat_cache.erl
@@ -127,7 +127,12 @@ handle_call(_Request, _From, State) ->
     {reply, Reply, State}.
 
 %% @doc call back from process executig the stat calculation
-handle_cast({stats, App, Stats, TS}, State0=#state{tab=Tab, active=Active, apps=Apps}) ->
+handle_cast({stats, App, Stats0, TS}, State0=#state{tab=Tab, active=Active, apps=Apps}) ->
+    %% @TODO standardise stat mods return type with a behaviour
+    Stats = case Stats0 of
+                {App, Stats1} -> Stats1;
+                Stats1 -> Stats1
+            end,
     ets:insert(Tab, {App, TS, Stats}),
     State = case orddict:find(App, Active) of
                 {ok, {_Pid, Awaiting}} ->

--- a/src/riak_core_stat_q.erl
+++ b/src/riak_core_stat_q.erl
@@ -83,24 +83,36 @@ size_guard(N) ->
     {'>=', {size, '$1'}, N}.
 
 calculate_stats(NamesAndTypes) ->
-    [{Name, get_stat(Stat)} || {Name, _Type}=Stat <- NamesAndTypes].
+    [{Name, get_stat({Name, Type})} || {Name, {metric, _, Type, _}} <- NamesAndTypes].
 
 %% Create/lookup a cache/calculation process
 get_stat(Stat) ->
     Pid = riak_core_stat_calc_sup:calc_proc(Stat),
     riak_core_stat_calc_proc:value(Pid).
 
-%% BAD uses internl knowledge of folsom metrics record
-%% This is a callback function used by
-%% riak_core_stat_calc_proc when it calculates a stat's
-%% current value.
-calc_stat({Name, {metric, _Tags, gauge, _HistLen}}) ->
-    GuageVal = folsom_metrics:get_metric_value(Name),
-    calc_guage(GuageVal);
-calc_stat({Name, {metric, _Tags, histogram, _HistLen}}) ->
-    folsom_metrics:get_histogram_statistics(Name);
-calc_stat({Name, {metric, _Tags, _Type, _HistLen}}) ->
-    folsom_metrics:get_metric_value(Name).
+%% Encapsulate getting a stat value from folsom.
+%%
+%% If for any reason we can't get a stats value
+%% return 'unavailable'.
+%% @TODO experience shows that once a stat is
+%% broken it stays that way. Should we delete
+%% stats that are broken?
+calc_stat({Name, gauge}) ->
+    try
+        GuageVal = folsom_metrics:get_metric_value(Name),
+        calc_guage(GuageVal)
+    catch _:_ ->
+            unavailable
+    end;
+calc_stat({Name, histogram}) ->
+    try
+        folsom_metrics:get_histogram_statistics(Name)
+    catch _:_ -> unavailable
+    end;
+calc_stat({Name, _Type}) ->
+    try folsom_metrics:get_metric_value(Name)
+    catch _:_ -> unavailable
+    end.
 
 %% some crazy people put funs in folsom gauges
 %% so that they can have a consistent interface


### PR DESCRIPTION
In some cases underlying ets tables for stats go away. When this
happens the effected stats break and stay broken.

When a stat is broken the stat calculation throws an error. For
the sake of robustness this commit wraps stat calculation in a try
catch, and returns the atom `unavailable` if a stat cannot be
calculated. Broken stats are expected to be detected and repaired
when they are updated.
