### PR TITLE
Add support for tracking progress of individual handoffs

### DIFF
--- a/include/riak_core_handoff.hrl
+++ b/include/riak_core_handoff.hrl
@@ -34,6 +34,7 @@
           vnode_mon             :: reference(),
           type                  :: ho_type(),
           req_origin            :: node(),
-          filter_mod_fun        :: {module(), atom()}
+          filter_mod_fun        :: {module(), atom()},
+          size                  :: {non_neg_integer(), bytes | objects}
         }).
 -type handoff_status() :: #handoff_status{}.


### PR DESCRIPTION
Vnodes can optionally provide the size of their data (in bytes or # of objects/keys) when returning from `is_empty/1` (the original API is also preserved). The size returned should be considered an upper-bound on the amount of bytes/objects that may be sent during handoff. For vnodes whose size may change during handoff (e.g. a non read-isolated iterator in riak_kv like ets) a function may be provided instead. The function is called to calculate the size of the vnode each time transfer stats are requested from the handoff manager. The provided size as well as the existing handoff stats are used to calculate completion percentage. 

This PR also moves the `transfers/1` console function from `riak_kv_console` to `riak_core_console`. It is not specific to kv and other applications should be able to take advantage of it. ~~In addition, `transfers/1` now prints completion percentage w/ progress bar and can optionally take a number of seconds, N, and a maximum, M. The output
is printed every N seconds a total of M times. If M is not given or is not a number the output will be printed every N seconds until CTRL+C is pressed or the nodetool timeout is reached. If N is not a number it is ignored.~~

EDIT: based on review, the  support for calling `transfers/1` passing in seconds/max calls was removed since this can be done in the shell.
