### PR TITLE
use custom Ranch build to support R14B03|4

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,6 +13,6 @@
   {webmachine, ".*", {git, "git://github.com/basho/webmachine",
                                 {tag, "64176ef9b"}}},
   {folsom, ".*", {git, "git://github.com/boundary/folsom.git", {branch, "master"}}},
-  {ranch, "0.4.0", {git, "git://github.com/extend/ranch.git", {tag, "0.4.0"}}}
+  {ranch, "0.4.0-p1", {git, "git://github.com/basho/ranch.git", {tag, "0.4.0-p1"}}}
 
        ]}.


### PR DESCRIPTION
custom Ranch tag excludes -callbacks so builds can occur in R14B03 + R14B04.
