### PR TITLE
Vnode nonblocking reply, First draft (3rd edition), ready for some review

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -53,6 +53,7 @@
              riak_core_ring_handler,
              riak_core_ring_manager,
              riak_core_ring_util,
+             riak_core_send_msg,
              riak_core_stat,
              riak_core_stat_cache,
              riak_core_stat_calc_proc,

--- a/src/riak_core_send_msg.erl
+++ b/src/riak_core_send_msg.erl
@@ -1,0 +1,48 @@
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc OTP equivalents for sending reply- and event-like things
+%% without blocking the sender.
+
+-module(riak_core_send_msg).
+
+-export([reply_unreliable/2,
+         cast_unreliable/2,
+         send_event_unreliable/2,
+         bang_unreliable/2]).
+
+%% NOTE: We'ed peeked inside gen_server.erl's guts to see its internals.
+reply_unreliable({To, Tag}, Reply) ->
+    bang_unreliable(To, {Tag, Reply}).
+
+cast_unreliable(Dest, Request) ->
+    bang_unreliable(Dest, {'$gen_cast', Request}).
+
+%% NOTE: We'ed peeked inside gen_fsm.erl's guts to see its internals.
+send_event_unreliable({global, _Name} = GlobalTo, Event) ->
+    erlang:error({unimplemented_send, GlobalTo, Event});
+send_event_unreliable({via, _Mod, _Name} = ViaTo, Event) ->
+    erlang:error({unimplemented_send, ViaTo, Event});
+send_event_unreliable(Name, Event) ->
+    bang_unreliable(Name, {'$gen_event', Event}),
+    ok.
+
+bang_unreliable(Dest, Msg) ->
+    catch erlang:send(Dest, Msg, [noconnect, nosuspend]).
+

--- a/src/riak_core_send_msg.erl
+++ b/src/riak_core_send_msg.erl
@@ -44,5 +44,5 @@ send_event_unreliable(Name, Event) ->
     ok.
 
 bang_unreliable(Dest, Msg) ->
-    catch erlang:send(Dest, Msg, [noconnect, nosuspend]).
-
+    catch erlang:send(Dest, Msg, [noconnect, nosuspend]),
+    Msg.

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -312,8 +312,8 @@ vnode_handoff_command(Sender, Request, State=#state{index=Index,
             riak_core_vnode_worker_pool:handle_work(Pool, Work, From),
             continue(State, NewModState);
         {forward, NewModState} ->
-            riak_core_vnode_master:command({Index, HN}, Request, Sender,
-                                           riak_core_vnode_master:reg_name(Mod)),
+            riak_core_vnode_master:command_unreliable(
+             {Index,HN}, Request, Sender, riak_core_vnode_master:reg_name(Mod)),
             continue(State, NewModState);
         {drop, NewModState} ->
             continue(State, NewModState);
@@ -683,18 +683,19 @@ start_handoff(State=#state{index=Idx, mod=Mod, modstate=ModState}, TargetNode) -
 %%      for compatibility with pre-0.12 requestors.
 %%      If Ref is defined, send it along with the
 %%      reply.
+%%      NOTE: We *always* send the reply using unreliable delivery.
 %%
 -spec reply(sender(), term()) -> any().
 reply({fsm, undefined, From}, Reply) ->
-    gen_fsm:send_event(From, Reply);
+    riak_core_send_msg:send_event_unreliable(From, Reply);
 reply({fsm, Ref, From}, Reply) ->
-    gen_fsm:send_event(From, {Ref, Reply});
+    riak_core_send_msg:send_event_unreliable(From, {Ref, Reply});
 reply({server, undefined, From}, Reply) ->
-    gen_server:reply(From, Reply);
+    riak_core_send_msg:reply_unreliable(From, Reply);
 reply({server, Ref, From}, Reply) ->
-    gen_server:reply(From, {Ref, Reply});
+    riak_core_send_msg:reply_unreliable(From, {Ref, Reply});
 reply({raw, Ref, From}, Reply) ->
-    From ! {Ref, Reply};
+    riak_core_send_msg:bang_unreliable(From, {Ref, Reply});
 reply(ignore, _Reply) ->
     ok.
 

--- a/src/riak_core_vnode_master.erl
+++ b/src/riak_core_vnode_master.erl
@@ -26,10 +26,12 @@
 -include("riak_core_vnode.hrl").
 -behaviour(gen_server).
 -export([start_link/1, start_link/2, start_link/3, get_vnode_pid/2,
-         start_vnode/2, command/3, command/4, sync_command/3,
+         start_vnode/2,
+         command/3, command/4,
+         command_unreliable/3, command_unreliable/4,
+         sync_command/3, sync_command/4,
          coverage/5,
          command_return_vnode/4,
-         sync_command/4,
          sync_spawn_command/3, make_request/3,
          make_coverage_request/4, all_nodes/1, reg_name/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -64,23 +66,39 @@ get_vnode_pid(Index, VNodeMod) ->
     riak_core_vnode_manager:get_vnode_pid(Index, VNodeMod).
 
 command(Preflist, Msg, VMaster) ->
-    command(Preflist, Msg, ignore, VMaster).
+    command2(Preflist, Msg, ignore, VMaster, normal).
+
+command_unreliable(Preflist, Msg, VMaster) ->
+    command2(Preflist, Msg, ignore, VMaster, unreliable).
+
+command(PrefListOrCmd, Msg, Sender, VMaster) ->
+    command2(PrefListOrCmd, Msg, Sender, VMaster, normal).
+
+command_unreliable(PrefListOrCmd, Msg, Sender, VMaster) ->
+    command2(PrefListOrCmd, Msg, Sender, VMaster, unreliable).
 
 %% Send the command to the preflist given with responses going to Sender
-command([], _Msg, _Sender, _VMaster) ->
+command2([], _Msg, _Sender, _VMaster, _How) ->
     ok;
-command([{Index, Pid}|Rest], Msg, Sender, VMaster) when is_pid(Pid) ->
-    gen_fsm:send_event(Pid, make_request(Msg, Sender, Index)),
-    command(Rest, Msg, Sender, VMaster);
-command([{Index,Node}|Rest], Msg, Sender, VMaster) ->
-    proxy_cast({VMaster, Node}, make_request(Msg, Sender, Index)),
-    command(Rest, Msg, Sender, VMaster);
 
-%% Send the command to an individual Index/Node combination
-command({Index, Pid}, Msg, Sender, _VMaster) when is_pid(Pid) ->
-    gen_fsm:send_event(Pid, make_request(Msg, Sender, Index));
-command({Index,Node}, Msg, Sender, VMaster) ->
-    proxy_cast({VMaster, Node}, make_request(Msg, Sender, Index)).
+command2([{Index, Pid}|Rest], Msg, Sender, VMaster, How=normal)
+  when is_pid(Pid) ->
+    gen_fsm:send_event(Pid, make_request(Msg, Sender, Index)),
+    command2(Rest, Msg, Sender, VMaster, How);
+
+command2([{Index, Pid}|Rest], Msg, Sender, VMaster, How=unreliable)
+  when is_pid(Pid) ->
+    riak_core_send_msg:send_event_unreliable(Pid, make_request(Msg, Sender,
+                                                               Index)),
+    command2(Rest, Msg, Sender, VMaster, How);
+command2([{Index,Node}|Rest], Msg, Sender, VMaster, How) ->
+    proxy_cast({VMaster, Node}, make_request(Msg, Sender, Index), How),
+    command2(Rest, Msg, Sender, VMaster, How);
+
+command2(DestTuple, Msg, Sender, VMaster, How) when is_tuple(DestTuple) ->
+    %% Final case, tuple = single destination ... so make a list and
+    %% resubmit to this function.
+    command2([DestTuple], Msg, Sender, VMaster, How).
 
 %% Send a command to a covering set of vnodes
 coverage(Msg, CoverageVNodes, Keyspaces, {Type, Ref, From}, VMaster)
@@ -161,26 +179,43 @@ init([Service, VNodeMod, LegacyMod, _RegName]) ->
                 vnode_mod=VNodeMod,
                 legacy=LegacyMod}}.
 
-proxy_cast({VMaster, Node}, Req) ->
+proxy_cast(Who, Req) ->
+    proxy_cast(Who, Req, normal).
+
+proxy_cast({VMaster, Node}, Req, How) ->
     case riak_core_capability:get({riak_core, vnode_routing}, legacy) of
         legacy ->
-            gen_server:cast({VMaster, Node}, Req);
+            if How == normal ->
+                    gen_server:cast({VMaster, Node}, Req);
+               How == unreliable ->
+                    riak_core_send_msg:cast_unreliable({VMaster, Node}, Req)
+            end;
         proxy ->
-            do_proxy_cast({VMaster, Node}, Req)
+            do_proxy_cast({VMaster, Node}, Req, How)
     end.
 
-do_proxy_cast({VMaster, Node}, Req=?VNODE_REQ{index=Idx}) ->
+do_proxy_cast({VMaster, Node}, Req=?VNODE_REQ{index=Idx}, How) ->
     Mod = vmaster_to_vmod(VMaster),
     Proxy = riak_core_vnode_proxy:reg_name(Mod, Idx, Node),
-    gen_fsm:send_event(Proxy, Req),
+    send_an_event(Proxy, Req, How),
     ok;
-do_proxy_cast({VMaster, Node}, Req=?COVERAGE_REQ{index=Idx}) ->
+do_proxy_cast({VMaster, Node}, Req=?COVERAGE_REQ{index=Idx}, How) ->
     Mod = vmaster_to_vmod(VMaster),
     Proxy = riak_core_vnode_proxy:reg_name(Mod, Idx, Node),
-    gen_fsm:send_event(Proxy, Req),
+    send_an_event(Proxy, Req, How),
     ok;
-do_proxy_cast({VMaster, Node}, Other) ->
-    gen_server:cast({VMaster, Node}, Other).
+do_proxy_cast({VMaster, Node}, Other, How) ->
+    send_a_cast({VMaster, Node}, Other, How).
+
+send_an_event(Dest, Event, normal) ->
+    gen_fsm:send_event(Dest, Event);
+send_an_event(Dest, Event, unreliable) ->
+    riak_core_send_msg:send_event_unreliable(Dest, Event).
+
+send_a_cast(Dest, Msg, normal) ->
+    gen_server:cast(Dest, Msg);
+send_a_cast(Dest, Msg, unreliable) ->
+    riak_core_send_msg:cast_unreliable(Dest, Msg).
 
 handle_cast({wait_for_service, Service}, State) ->
     case Service of


### PR DESCRIPTION
Vnode replies always go via reply(), and reply() always uses unreliable
messaging.  (As opposed to the usual (and more reliable) send-and-pray
messaging.)

During handoff, all forwarding requests use unreliable vnode master
commands to avoid net_kernel blocking interference.

My testing procedure:
1. Use "make stagedevrel" on box A for nodes 1-4.  Configure for
   multi-box use (i.e. change all 127.0.0.1 appearances in vm.args and
   app.config as appropriate).
2. Use "make stage" on box B for node 5.  Configure for multi-box
   use.
3. Start all nodes, join them all together, and commit.
4. Run basho_bench on box A, using this config:
   
   {mode, {rate, 50}}.
   {report_interval, 1}.
   {duration, 30}.
   {concurrent, 50}.
   
   {driver, basho_bench_driver_riakc_pb}.
   {riakc_pb_ips, [
                   {{127,0,0,1}, 10017}, %% {Ip, Port}
                   {{127,0,0,1}, [10027, 10037, 10047]} %% {Ip, Ports}
                  ]}.
   {riakc_pb_replies, 1}.
   {operations, [{get, 1}, {update, 1}]}.
   {pb_timeout_general, 5000}.
   
   {key_generator, {int_to_bin, {uniform_int, 990000}}}.
   {value_generator, {fixed_bin, 10}}.
5. On box B:
   
   sh -c 'for i in 1 2 3 4 5; do date; sleep 1 ; ( date ; ifdown eth0 ; sleep 100 ; ifup eth0 ; date ) > /tmp/slf 2>& 1 ; cat /tmp/slf; sleep 70; done'
6. Check the results via:
   
   awk -F, '{if ($5 == 0) { print "ok"; } else { print "error" } }' tests/current/summary.csv | uniq -c | less
7. There's a pretty darn obvious qualitative way to view the results
   of the pre-patch and post-patch behavior.  The sampling rate used by
   the basho_bench config above, i.e., `{report_interval, 1}`, creates
   some noise in the step 6 results.  So, the best advice that I can give
   for looking at the quantative data is to look for ~100 seconds of `ok`
   stability after node 1's network interface has been shut off.

7a. Good results from step 6:

```
  1 error
 19 ok
  3 error
  2 ok
  4 error
  1 ok
 57 error (definitely down ifdown iteration  1)
  2 ok
  1 error
105 ok (about ~100 seconds of goodness after down ifdown iteration  1)
  4 error
  2 ok
  4 error
  1 ok
 61 error (definitely down ifdown iteration  2)
  1 ok
  2 error
101 ok (about ~100 seconds of goodness after down ifdown iteration  1)
  3 error
  2 ok
 55 error (definitely down ifdown iteration  3)
  2 ok
  2 error
112 ok (about ~100 seconds of goodness after down ifdown iteration  1)
  4 error
  1 ok
 58 error (definitely down ifdown iteration  4)
  1 ok
  3 error
109 ok (about ~100 seconds of goodness after down ifdown iteration  1)
  3 error
  2 ok
  4 error
  1 ok
  4 error
  1 ok
 52 error (definitely down ifdown iteration  5)
  1 ok
  4 error
188 ok  (about ~100 seconds of goodness after down ifdown iteration  1)
        (end of interface flapping, ignore the quantity here)
```

7b. Bad results from step 6:

```
  1 error
 24 ok
  4 error (probably down ifdown iteration  1)
  1 ok
 10 error (definitely down ifdown iteration  1)
  1 ok
 46 error
  1 ok
  7 error
106 ok (about ~100 seconds of goodness after down ifdown iteration  1)
  3 error
  2 ok
  4 error
  1 ok
 61 error (definitely down ifdown iteration 2 ... but this is
           where it becomes much less obvious where ifdown and
           ifup events actually happened)
  2 ok
  5 error
  1 ok
 21 error
 75 ok
  4 error
  1 ok
  5 error
  1 ok
  4 error
  1 ok
 46 error (down ifdown iteration  3?)
  1 ok
 38 error
 75 ok
  3 error
  2 ok
  4 error
  1 ok
  5 error
  1 ok
 84 error (Huge problem ... Step 7a's results never had an error
           rate larger than 61 samples in a row.)
 75 ok
  3 error
  2 ok
  5 error
  1 ok
 57 error (probably down here ifdown iteration  5)
  1 ok
 32 error (if "57 error" was ifdown, then node 1's interface is
           now up, and this error rate is too high.)
974 ok (end of interface flapping, ignore the quantity here)
```
