### PR TITLE
Fix worker pool races

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \
 	public_key mnesia syntax_tools compiler
 COMBO_PLT = $(HOME)/.riak_core_combo_dialyzer_plt
+PULSE_TESTS = worker_pool_pulse
 
 .PHONY: deps test
 
@@ -20,6 +21,12 @@ distclean: clean
 
 test: all
 	./rebar skip_deps=true eunit
+
+# You should 'clean' before your first run of this target
+# so that deps get built with PULSE where needed.
+pulse:
+	./rebar compile -D PULSE
+	./rebar eunit -D PULSE skip_deps=true suite=$(PULSE_TESTS)
 
 docs: deps
 	./rebar skip_deps=true doc

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -51,6 +51,13 @@
          current_state/1]).
 -endif.
 
+-ifdef(PULSE).
+-compile(export_all).
+-compile({parse_transform, pulse_instrument}).
+-compile({pulse_replace_module, [{gen_fsm, pulse_gen_fsm},
+                                 {gen_server, pulse_gen_server}]}).
+-endif.
+
 -define(normal_reason(R),
         (R == normal orelse R == shutdown orelse
                                             (is_tuple(R) andalso element(1,R) == shutdown))).

--- a/src/riak_core_vnode_worker.erl
+++ b/src/riak_core_vnode_worker.erl
@@ -25,6 +25,13 @@
         code_change/3]).
 -export([start_link/1, handle_work/4, handle_work/5]).
 
+-ifdef(PULSE).
+-compile(export_all).
+-compile({parse_transform, pulse_instrument}).
+-compile({pulse_replace_module, [{gen_fsm, pulse_gen_fsm},
+                                 {gen_server, pulse_gen_server}]}).
+-endif.
+
 -record(state, {
         module :: atom(),
         modstate :: any()

--- a/src/riak_core_vnode_worker.erl
+++ b/src/riak_core_vnode_worker.erl
@@ -23,7 +23,7 @@
 -export([behaviour_info/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
         code_change/3]).
--export([start_link/1, handle_work/4, handle_work/5]).
+-export([start_link/1, handle_work/3, handle_work/4]).
 
 -ifdef(PULSE).
 -compile(export_all).
@@ -46,24 +46,26 @@ behaviour_info(_Other) ->
 
 start_link(Args) ->
     WorkerMod = proplists:get_value(worker_callback_mod, Args),
-    [VNodeIndex, WorkerArgs, WorkerProps] = proplists:get_value(worker_args, Args),
-    gen_server:start_link(?MODULE, [WorkerMod, VNodeIndex, WorkerArgs, WorkerProps], []).
+    [VNodeIndex, WorkerArgs, WorkerProps, Caller] = proplists:get_value(worker_args, Args),
+    gen_server:start_link(?MODULE, [WorkerMod, VNodeIndex, WorkerArgs, WorkerProps, Caller], []).
 
-handle_work(Worker, Pool, Work, From) ->
-    handle_work(Worker, Pool, Work, From, self()).
+handle_work(Worker, Work, From) ->
+    handle_work(Worker, Work, From, self()).
 
-handle_work(Worker, Pool, Work, From, Caller) ->
-    gen_server:cast(Worker, {work, Pool, Work, From, Caller}).
+handle_work(Worker, Work, From, Caller) ->
+    gen_server:cast(Worker, {work, Work, From, Caller}).
 
-init([Module, VNodeIndex, WorkerArgs, WorkerProps]) ->
+init([Module, VNodeIndex, WorkerArgs, WorkerProps, Caller]) ->
     {ok, WorkerState} = Module:init_worker(VNodeIndex, WorkerArgs, WorkerProps),
+    %% let the pool queue manager know there might be a worker to checkout
+    gen_fsm:send_all_state_event(Caller, worker_start),
     {ok, #state{module=Module, modstate=WorkerState}}.
 
 handle_call(Event, _From, State) ->
     lager:debug("Vnode worker received synchronous event: ~p.", [Event]),
     {reply, ok, State}.
 
-handle_cast({work, Pool, Work, WorkFrom, Caller},
+handle_cast({work, Work, WorkFrom, Caller},
             #state{module = Mod, modstate = ModState} = State) ->
     NewModState = case Mod:handle_work(Work, WorkFrom, ModState) of
         {reply, Reply, NS} ->
@@ -73,7 +75,6 @@ handle_cast({work, Pool, Work, WorkFrom, Caller},
             NS
     end,
     %% check the worker back into the pool
-    poolboy:checkin(Pool, self()),
     gen_fsm:send_all_state_event(Caller, {checkin, self()}),
     {noreply, State#state{modstate=NewModState}};
 handle_cast(_Event, State) ->

--- a/src/riak_core_vnode_worker_pool.erl
+++ b/src/riak_core_vnode_worker_pool.erl
@@ -30,6 +30,12 @@
 %% API
 -export([start_link/5, stop/2, shutdown_pool/2, handle_work/3]).
 
+-ifdef(PULSE).
+-compile(export_all).
+-compile({parse_transform, pulse_instrument}).
+-compile({pulse_replace_module, [{gen_fsm, pulse_gen_fsm}]}).
+-endif.
+
 -record(state, {
         queue = queue:new(),
         pool :: pid(),

--- a/src/riak_core_vnode_worker_pool.erl
+++ b/src/riak_core_vnode_worker_pool.erl
@@ -16,6 +16,27 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
+
+%% @doc This is a wrapper around a poolboy pool, that implements a
+%% queue. That is, this process maintains a queue of work, and checks
+%% workers out of a poolboy pool to consume it.
+%%
+%% The workers it uses send two messages to this process.
+%%
+%% The first message is at startup, the bare atom
+%% `worker_started'. This is a clue to this process that a worker was
+%% just added to the poolboy pool, so a checkout request has a chance
+%% of succeeding. This is most useful after an old worker has exited -
+%% `worker_started' is a trigger guaranteed to arrive at a time that
+%% will mean an immediate poolboy:checkout will not beat the worker
+%% into the pool.
+%%
+%% The second message is when the worker finishes work it has been
+%% handed, the two-tuple, `{checkin, WorkerPid}'. This message gives
+%% this process the choice of whether to give the worker more work or
+%% check it back into poolboy's pool at this point. Note: the worker
+%% should *never* call poolboy:checkin itself, because that will
+%% confuse (or cause a race) with this module's checkout management.
 -module(riak_core_vnode_worker_pool).
 
 -behaviour(gen_fsm).
@@ -58,7 +79,7 @@ shutdown_pool(Pid, Wait) ->
 
 init([WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps]) ->
     {ok, Pid} = poolboy:start_link([{worker_module, riak_core_vnode_worker},
-            {worker_args, [VNodeIndex, WorkerArgs, WorkerProps]},
+            {worker_args, [VNodeIndex, WorkerArgs, WorkerProps, self()]},
             {worker_callback_mod, WorkerMod},
             {size, PoolSize}, {max_overflow, 0}]),
     {ok, ready, #state{pool=Pid}}.
@@ -72,7 +93,7 @@ ready({work, Work, From} = Msg, #state{pool=Pool, queue=Q, monitors=Monitors} = 
             {next_state, queueing, State#state{queue=queue:in(Msg, Q)}};
         Pid when is_pid(Pid) ->
             NewMonitors = monitor_worker(Pid, From, Work, Monitors),
-            riak_core_vnode_worker:handle_work(Pid, Pool, Work, From),
+            riak_core_vnode_worker:handle_work(Pid, Work, From),
             {next_state, ready, State#state{monitors=NewMonitors}}
     end;
 ready(_Event, State) ->
@@ -96,8 +117,9 @@ shutdown({work, _Work, From}, State) ->
 shutdown(_Event, State) ->
     {next_state, shutdown, State}.
 
-handle_event({checkin, Pid}, shutdown, #state{monitors=Monitors0} = State) ->
+handle_event({checkin, Pid}, shutdown, #state{pool=Pool, monitors=Monitors0} = State) ->
     Monitors = demonitor_worker(Pid, Monitors0),
+    poolboy:checkin(Pool, Pid),
     case Monitors of
         [] -> %% work all done, time to exit!
             {stop, shutdown, State};
@@ -107,19 +129,32 @@ handle_event({checkin, Pid}, shutdown, #state{monitors=Monitors0} = State) ->
 handle_event({checkin, Worker}, _, #state{pool = Pool, queue=Q, monitors=Monitors} = State) ->
     case queue:out(Q) of
         {{value, {work, Work, From}}, Rem} ->
-            case poolboy:checkout(Pool, false) of
-                full ->
-                    {next_state, queueing, State#state{queue=Q,
-                            monitors=Monitors}};
-                Pid when is_pid(Pid) ->
-                    NewMonitors = monitor_worker(Pid, From, Work, Monitors),
-                    riak_core_vnode_worker:handle_work(Pid, Pool, Work, From),
-                    {next_state, queueing, State#state{queue=Rem,
-                            monitors=NewMonitors}}
-            end;
+            %% there is outstanding work to do - instead of checking
+            %% the worker back in, just hand it more work to do
+            NewMonitors = monitor_worker(Worker, From, Work, Monitors),
+            riak_core_vnode_worker:handle_work(Worker, Work, From),
+            {next_state, queueing, State#state{queue=Rem,
+                                               monitors=NewMonitors}};
         {empty, Empty} ->
             NewMonitors = demonitor_worker(Worker, Monitors),
+            poolboy:checkin(Pool, Worker),
             {next_state, ready, State#state{queue=Empty, monitors=NewMonitors}}
+    end;
+handle_event(worker_start, StateName, #state{pool=Pool, queue=Q, monitors=Monitors}=State) ->
+    %% a new worker just started - if we have work pending, try to do it
+    case queue:out(Q) of
+        {{value, {work, Work, From}}, Rem} ->
+            case poolboy:checkout(Pool, false) of
+                full ->
+                    {next_state, queueing, State};
+                Pid when is_pid(Pid) ->
+                    NewMonitors = monitor_worker(Pid, From, Work, Monitors),
+                    riak_core_vnode_worker:handle_work(Pid, Work, From),
+                    {next_state, queueing, State#state{queue=Rem, monitors=NewMonitors}}
+            end;
+        {empty, _} ->
+            %% StateName might be either 'ready' or 'shutdown'
+            {next_state, StateName, State}
     end;
 handle_event(_Event, StateName, State) ->
     {next_state, StateName, State}.
@@ -150,9 +185,9 @@ handle_info({'DOWN', _Ref, _, Pid, Info}, StateName, #state{monitors=Monitors} =
         {Pid, _, From, Work} ->
             riak_core_vnode:reply(From, {error, {worker_crash, Info, Work}}),
             NewMonitors = lists:keydelete(Pid, 1, Monitors),
-            %% pretend a worker just checked in so that any queued work can
-            %% sent to the new worker just started to replace this dead one
-            gen_fsm:send_all_state_event(self(), {checkin, undefined}),
+            %% trigger to do more work will be 'worker_start' message
+            %% when poolboy replaces this worker (if not a 'checkin'
+            %% or 'handle_work')
             {next_state, StateName, State#state{monitors=NewMonitors}};
         false ->
             {next_state, StateName, State}

--- a/test/worker_pool_pulse.erl
+++ b/test/worker_pool_pulse.erl
@@ -1,0 +1,139 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Test riak_core_vnode_worker_pool's interaction with poolboy
+%% under PULSE. This requires that riak_core, poolboy, and this module
+%% be compiled with the 'PULSE' macro defined.
+-module(worker_pool_pulse).
+
+-behaviour(riak_core_vnode_worker).
+-ifdef(EQC).
+-include_lib("eqc/include/eqc.hrl").
+-endif.
+-include_lib("eunit/include/eunit.hrl").
+
+%% riak_core_vnode_worker behavior
+-export([init_worker/3, handle_work/3]).
+%% console debugging convenience
+-compile(export_all).
+
+-ifdef(PULSE).
+-include_lib("pulse/include/pulse.hrl").
+%% have to transform the 'receive' of the work results
+-compile({parse_transform, pulse_instrument}).
+%% don't trasnform toplevel test functions
+-compile({pulse_skip,[{prop_any_pool,0},
+                      {prop_small_pool,0},
+                      {pool_test_,0}]}).
+-endif.
+
+%%% Worker Definition - does nothing but reply with what it is given
+
+init_worker(_VnodeIndex, Noreply, _WorkerProps) ->
+    {ok, Noreply}.
+
+handle_work(die, _From, _State) ->
+    exit(test_die);
+handle_work(Work, _From, State) ->
+    {reply, Work, State}.
+
+%% none of these tests make sense if PULSE is not used
+-ifdef(PULSE).
+
+%% @doc Any amount of work should complete through any size pool.
+prop_any_pool() ->
+    ?FORALL({Seed, ExtraWork, WorkList},
+            {pulse:seed(),
+             frequency([{10,true},{1,false}]),
+             list(frequency([{10,nat()}, {1,die}]))},
+            aggregate([{{extra_work,
+                         pool_size(ExtraWork, WorkList) < length(WorkList) },
+                        {deaths, lists:member(die, WorkList)}}],
+            ?WHENFAIL(
+               io:format(user,
+                         "PoolSize: ~b~n"
+                         "WorkList: ~p~n"
+                         "Schedule: ~p~n",
+                         [pool_size(ExtraWork, WorkList),
+                          WorkList,
+                          pulse:get_schedule()]),
+               begin
+                   PoolSize = pool_size(ExtraWork, WorkList),
+                   true == all_work_gets_done(Seed, PoolSize, WorkList)
+               end))).
+
+pool_size(false, WorkList) ->
+    length(WorkList);
+pool_size(true, WorkList) ->
+    case length(WorkList) div 2 of
+        0 ->
+            1;
+        Size ->
+            Size
+    end.
+
+%% @doc Minimal case for the issue this test was created to probe: one
+%% worker, two inputs.
+prop_small_pool() ->
+    ?PULSE(Result, all_work_gets_done(1, [1,2]), true == Result).
+
+all_work_gets_done(Seed, PoolSize, WorkList) ->
+    pulse:run_with_seed(
+      fun() -> all_work_gets_done(PoolSize, WorkList) end,
+      Seed).
+
+all_work_gets_done(PoolSize, WorkList) ->
+    %% get the pool up
+    {ok, Pool} = riak_core_vnode_worker_pool:start_link(
+                   ?MODULE, PoolSize, 10, false, []),
+
+    %% send all the work
+    [ riak_core_vnode_worker_pool:handle_work(
+        Pool, W, {raw, N, self()})
+      || {N, W} <- lists:zip(lists:seq(1, length(WorkList)), WorkList) ],
+
+    %% wait for all the work
+    Results = [ receive {N, _} -> ok end
+                || N <- lists:seq(1, length(WorkList)) ],
+    riak_core_vnode_worker_pool:stop(Pool, normal),
+
+    %% check that we got a response for every piece of work
+    %% TODO: actually not needed, since the bug is deadlock, and will
+    %% thus never get here
+    length(Results) == length(WorkList).
+
+pool_test_() ->
+    {setup,
+        fun() ->
+                error_logger:tty(false),
+                pulse:start()
+        end,
+        fun(_) ->
+                pulse:stop(),
+                error_logger:tty(true)
+        end,
+        [
+         %% not necessary to run both tests here, but why not anyway?
+         ?_assert(eqc:quickcheck(prop_small_pool())),
+         ?_assert(eqc:quickcheck(prop_any_pool()))
+        ]
+    }.
+
+-endif.


### PR DESCRIPTION
Races in the vnode worker pool, which could cause the pool to become frozen, were described in #298. This PR resolves those races.
## Resolutions

The fix for the checkin race is for the worker to only checkin to riak_core_vnode_worker_pool, and allow riak_core_vnode_worker_pool to decide when to checkin to poolboy. If there is outstanding work in the queue, the worker will just be reused immediately instead of being checked in.

The fix for the DOWN race is for the worker to send a 'worker_started' message to riak_core_vnode_worker_pool, when the worker starts. While the worker is sending this message, poolboy is blocking, so riak_core_vnode_worker_pool can send poolboy a checkout message immediately, and still be guaranteed that it will be received after poolboy has put the worker in its pool.
## Testing

The new test `worker_pool_pulse` requires modules to be compiled with the `PULSE` macro defined, so it must be run on its own. A new make target, `pulse`, has been added to do just this. Before running the `pulse` target, ensure three things:
1. You have [Quviq's pulse_otp](https://github.com/Quviq/pulse_otp) on your path.
2. You have a copy of poolboy with PULSE annotations (currently in [the bwf-pool-race branch of basho/poolboy](https://github.com/basho/poolboy/tree/bwf-pool-race)
3. You have not yet built beams for `riak_core` or `poolboy` (so, either right after `./rebar get-deps` or `make clean`)

Running the tests using just the first commit in this PR should fail with EQC/PULSE complaining of `deadlock`. If it fails for another reason, you may have missed one of the three requirements above (or I only achieved WOMM status). Using both commits, the tests should pass.

Only `worker_pool_pulse` will run when using the `pulse` make target. After running this test, and before running other tests, you should clean and recompile, or the PULSE annotations may cause other tests to fail.
