### PR TITLE
Ring Resizing

### DIFF
--- a/docs/ring-resizing.md
+++ b/docs/ring-resizing.md
@@ -1,0 +1,175 @@
+There are two primary components to ring resizing operation. The
+first, which is similar to cluster membership operations,
+is determining what the future ring will look like once the operation
+has completed. The second is facilitating that transition.
+
+### The Claimant
+
+Determining what the future ring will look like when resizing is
+primarly about determining future ownership. Like normal cluster
+operations this is the responsibility of `riak_core_claimant`.  Ring
+resizing is also staged, planned, and commited via th claimant. The
+claimant determines the ownership of the future ring and what
+transfers will be necessary to safely make the transition. How the
+future ring is determined is slightly different though, and is described
+below.
+
+If the ring is expanded all the existing partitions will be in bolth
+the old and new ring. The new parittions are initially assigned to a
+dummy node, before being assigned through claim. If the ring is
+shrunk, some partitions will be removed. The claimant does this and
+then runs the ring through claim, rebalcing it. Some existing
+partitions may change owners as part of this process.
+
+Like other ownership changes, after the claimant determines the future
+ring it schedules transfers using the "next list" (a field in Riak's
+gossip structure). However, some additional information is needed in
+the case of resize operations. This is discussed in more detail below
+in "Transfer Scheduling". The future ownership information also needs
+to be carried in the gossip structure because unlike other ownership
+changes the future ring cannot be calculated using only the next
+list. This information is stored in the metadata dictionary that is
+part of the gossip structure.
+
+If the plan to resize the ring is committed, the claimant will not
+install the new ring until all of the scheduled transfers have
+completed. This is necessary to ensure a safe transition. This has the
+side-effect that, with the exception of `force-replace`, other cluster
+operations will be delayed until resizing completes. The claimant also
+provides the ability to cancel while resizing is in-flight.
+
+### Transfer Scheduling
+
+To safely transition the cluster between different sized rings,
+partitions must transfer there data not only to new owners of the
+same partitions but to different partitions. This is because when the
+size of the ring changes so does every preflist. The figure below
+illustrates this for a couple bucket/key pairs.
+
+![preflist](http://data.riakcs.net:8080/jrw-public/dynamic-ring/expand-preflist.png)
+
+In the image on the left a key in the old ring is owned by N (3 in
+this case) partitions, as expected. In the middle image, each
+partition is divided in half to show, relatively, where the keys fall
+within the keyspace owned by each partition. The image on the right
+shows which partitions should own the key in the new ring.
+
+![transfers](http://data.riakcs.net:8080/jrw-public/dynamic-ring/expand-preflist-transfers.png)
+
+To safely transfer this key between the old and new ring there are
+five necessary transfers (there would be a 6th, the top arrow in the
+image above, but the owner of that portion of the keyspace is the same
+node). The number of transfers is dependent on the growth factor (new
+ring size / old ring size) and the largest N value in the
+cluster. A similar process takes place when the ring is shrinking.
+
+The first transfers are scheduled as part of the claimant operation
+that determines ownership in the new ring. The claimant schedules a
+single *resize operation* for each vnode in the existing ring. The
+*resize operation* is an entry in the next list with a special value,
+`$resize`, in the next owner field. It is intended to indicate the
+existing vnode has several actual tranfers to complete before it has
+safely handed off all of its data. The claimant will also schedule a
+single *resize transfer* for each index. The *resize transfer*
+represents a single handoff of a portion of the keyspace between two
+partitions, that may or may not have different owners (most likely
+they will). The *resize transfer* that is scheduled depends on several
+factors:
+
+1. If the ring is shrinking and the partition will no longer exist in the new ring,
+the transfer is scheduled to the owner of the first successor.
+1. If the ring is expanding and the existing partition is not being
+moved to a new owner, the transfer is scheduled to the owner for the
+first predecessor.
+1. If the ring is expanding and the existing partition is being moved
+to a new owner, the transfer is scheduled to the new owner.
+
+A *resize transfer* is similar to repair in that not all keys are
+transferred. Since repair was added to Riak, the handoff subsystem has
+had the ability to take a filter function which determines which keys
+will be sent. This implementation augments that support to allow an
+addtional function to be provided, which is called when a key is not
+sent. *Resize transfers* use this to determine when a key should be
+sent to the partition it is transfering to and to determine what
+partitions unsent keys need to be transferred to before the *resize
+operation* can complete. This list of partitions is used to schedule
+further *resize transfers*. This is performed for each *resize
+transfer* that a partition takes part in, in order to ensure new
+writes to buckets with a larger N value are not lost. Once all
+scheduled *resize transfers* have completed and no new partitions are
+discovered to transfer to, the *resize operation* for the partitions
+has completed.
+
+#### Determining Future Ownership
+
+Given the hashed value of a key, the preflist for the hashed value is
+calculated in bolth the current and resized ring. To determine
+if a partition should transfer a given key to another, the position of
+the source and target partition in the current and future preflist,
+respectively, are compared. If the position is the same the key should
+be sent. To determine which target partition the key should be
+transferred to, in the event it should not be sent to the current
+target, the partition at the same position in the future preflist as
+the source partition in the current preflist is chosen. 
+
+### Request Forwarding
+
+Like ownership transfer, vnodes may forward requests to the new owner
+during and after handoff (until the ownership change is
+installed). But there are some differences. Ownership transfer
+involves only a single new owner and always attemps to progress to the
+future ring. Ring resizing is cancelable and this requires some special
+handling to not lose writes in this case.
+
+Typical forwarding comes in two flavors: *explicit*
+(`handle_handoff_command`) and *implicit*. Forwarding during resizing
+only uses *explicit* forwarding. *Explicit* forwarding gives the local
+vnode the option to effect a write locally before possibly choosing to
+forward it on to the new owner. *Implicit* forwarding does not -- all
+requests are immediately forwarded.  Since, the *resize operation* can
+be cancelled at any time, and since the time a vnode forwards during
+the operation is significant, it is necessary to allow the local vnode
+to perform the write before forwarding even after transferring all of
+its data. Because of this assumption, this also means that reads can
+be performed locally and not forwarded the entire time the ring is
+resizing.
+
+What partition to forward to is determined in the same manner that
+*resize transfers* use to determine the proper target partition for an
+unsent key.
+
+All coverage requests are handled locally.
+
+### Application Changes
+
+There are two changes that must be made to any `riak_core` application
+that wishes to support dynamic ring:
+
+1. A function `object_info(term()) -> {undefined | binary(),binary()}`
+must be defined. The argument to the function is key being transferred
+during a *resize transfer* (the key passed to the handoff fold
+function). The return value is a 2-tuple whose first element is either
+undefined or the bucket the key is in and whose second element is the
+hashed value of the key (e.g. value returned from
+`riak_core_util:chash_key/1` in the case of `riak_kv`).
+2. A function `request_hash(term()) -> undefined | binary()` must be
+defined. The function takes the request being processed as an argument
+and should return the hashed value of the key the request will act
+upon or `undefined`. If `undefined` is returned, the request will never be
+forwarded during ring resizing (`handle_command` will always be called).
+
+### Cleaning Up
+
+To ensure data is not lost in the case the operation fails or is
+aborted, after transfers complete the data is not immediately
+removed. Data is removed after the resized ring is
+installed. The claimant will schedule another special operation using
+the "next list", `$delete`. This operation will be scheduled for any
+partition that no longer exists in the new ring or that was moved during
+resizing. The end result is that each of these partitions delete their data and
+shut down.
+
+The same will happen to new partitions when the ring is
+expanded but the operation does not complete. Any data transferred to them
+will be deleted since it will not be reachable until the operation
+is resubmitted.

--- a/include/riak_core_handoff.hrl
+++ b/include/riak_core_handoff.hrl
@@ -13,7 +13,7 @@
         }).
 
 -type ho_stats() :: #ho_stats{}.
--type ho_type() :: ownership_handoff | hinted_handoff | repair.
+-type ho_type() :: ownership_handoff | hinted_handoff | repair | resize_transfer.
 -type predicate() :: fun((any()) -> boolean()).
 
 -type index() :: integer().

--- a/src/chash.erl
+++ b/src/chash.erl
@@ -143,14 +143,16 @@ ordered_from(Index, {NumPartitions, Nodes}) ->
 
 %% @doc Given an object key, return all NodeEntries in reverse order
 %%      starting at Index.
--spec predecessors(Index :: index(), CHash :: chash()) -> [node_entry()].
+-spec predecessors(Index :: index() | index_as_int(), CHash :: chash()) -> [node_entry()].
 predecessors(Index, CHash) ->
     {NumPartitions, _Nodes} = CHash,
     predecessors(Index, CHash, NumPartitions).
 %% @doc Given an object key, return the next N NodeEntries in reverse order
 %%      starting at Index.
--spec predecessors(Index :: index(), CHash :: chash(), N :: integer())
+-spec predecessors(Index :: index() | index_as_int(), CHash :: chash(), N :: integer())
                   -> [node_entry()].
+predecessors(Index, CHash, N) when is_integer(Index) ->
+    predecessors(<<Index:160/integer>>, CHash, N);
 predecessors(Index, CHash, N) ->
     Num = max_n(N, CHash),
     {Res, _} = lists:split(Num, lists:reverse(ordered_from(Index,CHash))),

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -88,6 +88,9 @@ start(_StartType, _StartArgs) ->
             riak_core_capability:register({riak_core, staged_joins},
                                           [true, false],
                                           false),
+            riak_core_capability:register({riak_core, resizable_ring},
+                                          [true, false],
+                                          false),
 
             {ok, Pid};
         {error, Reason} ->

--- a/src/riak_core_bucket.erl
+++ b/src/riak_core_bucket.erl
@@ -31,6 +31,8 @@
          get_bucket/2,
          reset_bucket/1,
          get_buckets/1,
+         bucket_nval_map/1,
+         default_object_nval/0,
          merge_props/2,
          name/1,
          n_val/1]).
@@ -127,6 +129,17 @@ reset_bucket(Bucket) ->
 get_buckets(Ring) ->
     Names = riak_core_ring:get_buckets(Ring),
     [get_bucket(Name, Ring) || Name <- Names].
+
+%% @doc returns a proplist containing all buckets and their respective N values
+-spec bucket_nval_map(riak_core_ring:riak_core_ring()) -> [{binary(),integer()}].
+bucket_nval_map(Ring) ->
+    [{riak_core_bucket:name(B), riak_core_bucket:n_val(B)} ||
+        B <- riak_core_bucket:get_buckets(Ring)].
+
+%% @doc returns the default n value for buckets that have not explicitly set the property
+-spec default_object_nval() -> integer().
+default_object_nval() ->
+    riak_core_bucket:n_val(riak_core_config:default_bucket_props()).
 
 %% @private
 -spec validate_props(BucketProps::list({PropName::atom(), Value::any()}),

--- a/src/riak_core_claimant.erl
+++ b/src/riak_core_claimant.erl
@@ -461,12 +461,14 @@ valid_resize_request(NewRingSize, [], Ring) ->
     %%            the cluster is capable. core knowing about search/kv is :(
     ControlRunning = app_helper:get_env(riak_control, enabled, false),
     SearchRunning = app_helper:get_env(riak_search, enabled, false),
-    case {ControlRunning, SearchRunning, Capable, IsResizing} of
-        {false, false, true, true} -> true;
-        {true, _, _, _} -> {error, control_running};
-        {_,  true, _, _} -> {error, search_running};
-        {_, _, false, _} -> {error, not_capable};
-        {_, _, _, false} -> {error, same_size}
+    NodeCount = length(riak_core_ring:all_members(Ring)),
+    case {ControlRunning, SearchRunning, Capable, IsResizing, NodeCount} of
+        {false, false, true, true, N} when N > 1 -> true;
+        {true, _, _, _, _} -> {error, control_running};
+        {_,  true, _, _, _} -> {error, search_running};
+        {_, _, false, _, _} -> {error, not_capable};
+        {_, _, _, false, _} -> {error, same_size};
+        {_, _, _, _, 1} -> {error, single_node}
     end.
 
 

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -360,6 +360,9 @@ stage_resize_ring(NewRingSize) ->
                 error;
             {error, search_running} ->
                 io:format("Failed: cannot resize ring with Riak Search~n"),
+                error;
+            {error, single_node} ->
+                io:format("Failed: cannot resize single node~n"),
                 error
         end
     catch

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -317,6 +317,23 @@ stage_force_replace(Node1, Node2) ->
             error
     end.
 
+stage_resize_ring(["abort"]) ->
+    try
+        case riak_core_claimant:abort_resize() of
+            ok ->
+                io:format("Success: staged abort resize ring request~n"),
+                ok;
+            {error, not_resizing} ->
+                io:format("Failed: ring is not resizing or resize has completed"),
+                error
+        end
+    catch
+        Exception:Reason ->
+            lager:error("Abort resize ring request failed ~p:~p",
+                        [Exception, Reason]),
+            io:format("Abort resize ring request failed, see log for details~n"),
+            error
+    end;
 stage_resize_ring([SizeStr]) ->
     try list_to_integer(SizeStr) of
         Size -> stage_resize_ring(Size)

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -354,6 +354,12 @@ stage_resize_ring(NewRingSize) ->
             {error, same_size} ->
                 io:format("Failed: current ring size is already ~p~n",
                           [NewRingSize]),
+                error;
+            {error, control_running} ->
+                io:format("Failed: cannot resize ring with Riak Control running~n"),
+                error;
+            {error, search_running} ->
+                io:format("Failed: cannot resize ring with Riak Search~n"),
                 error
         end
     catch

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -432,7 +432,10 @@ print_plan(Changes, Ring, NextRings) ->
                       io:format("force-replace  ~p with ~p~n", [Node, NewNode]);
                  ({_, {resize, NewRingSize}}) ->
                       CurrentSize = riak_core_ring:num_partitions(Ring),
-                      io:format("resize-ring    ~p to ~p partitions~n",[CurrentSize,NewRingSize])
+                      io:format("resize-ring    ~p to ~p partitions~n",[CurrentSize,NewRingSize]);
+                 ({_, abort_resize}) ->
+                      CurrentSize = riak_core_ring:num_partitions(Ring),
+                      io:format("resize-ring    abort. current size: ~p~n", [CurrentSize])
               end, Changes),
     io:format("~79..-s~n", [""]),
     io:format("~n"),

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -20,7 +20,7 @@
 
 -module(riak_core_console).
 -export([member_status/1, ring_status/1, print_member_status/2,
-         stage_leave/1, stage_remove/1, stage_replace/1,
+         stage_leave/1, stage_remove/1, stage_replace/1, stage_resize_ring/1,
          stage_force_replace/1, print_staged/1, commit_staged/1,
          clear_staged/1, transfer_limit/1, pending_claim_percentage/2,
          pending_nodes_and_claim_percentages/1]).
@@ -34,10 +34,11 @@ pending_nodes_and_claim_percentages(Ring) ->
 %% anticipated after the transitions have been completed.
 pending_claim_percentage(Ring, Node) ->
     RingSize = riak_core_ring:num_partitions(Ring),
+    FutureRingSize = riak_core_ring:future_num_partitions(Ring),
     Indices = riak_core_ring:indices(Ring, Node),
     NextIndices = riak_core_ring:future_indices(Ring, Node),
     RingPercent = length(Indices) * 100 / RingSize,
-    NextPercent = length(NextIndices) * 100 / RingSize,
+    NextPercent = length(NextIndices) * 100 / FutureRingSize,
     {RingPercent, NextPercent}.
 
 member_status([]) ->
@@ -316,6 +317,36 @@ stage_force_replace(Node1, Node2) ->
             error
     end.
 
+stage_resize_ring([SizeStr]) ->
+    try list_to_integer(SizeStr) of
+        Size -> stage_resize_ring(Size)
+    catch
+        error:badarg ->
+            io:format("Failed: Ring size must be an integer.")
+    end;
+stage_resize_ring(NewRingSize) ->
+    try
+        case riak_core_claimant:resize_ring(NewRingSize) of
+            ok ->
+                io:format("Success: staged resize ring request with new size: ~p~n",
+                          [NewRingSize]),
+                ok;
+            {error, not_capable} ->
+                io:format("Failed: at least one node is not capable of performing the operation~n"),
+                error;
+            {error, same_size} ->
+                io:format("Failed: current ring size is already ~p~n",
+                          [NewRingSize]),
+                error
+        end
+    catch
+        Exception:Reason ->
+            lager:error("Resize ring request failed ~p:~p",
+                        [Exception, Reason]),
+            io:format("Resize ring request failed, see log for details~n"),
+            error
+    end.
+
 clear_staged([]) ->
     try
         case riak_core_claimant:clear() of
@@ -361,9 +392,9 @@ print_staged([]) ->
 
 print_plan([], _, _) ->
     io:format("There are no staged changes~n");
-print_plan(Changes, _Ring, NextRings) ->
+print_plan(Changes, Ring, NextRings) ->
     io:format("~31..=s Staged Changes ~32..=s~n", ["", ""]),
-    io:format("Action         Nodes(s)~n"),
+    io:format("Action         Details(s)~n"),
     io:format("~79..-s~n", [""]),
 
     lists:map(fun({Node, join}) ->
@@ -375,7 +406,10 @@ print_plan(Changes, _Ring, NextRings) ->
                  ({Node, {replace, NewNode}}) ->
                       io:format("replace        ~p with ~p~n", [Node, NewNode]);
                  ({Node, {force_replace, NewNode}}) ->
-                      io:format("force-replace  ~p with ~p~n", [Node, NewNode])
+                      io:format("force-replace  ~p with ~p~n", [Node, NewNode]);
+                 ({_, {resize, NewRingSize}}) ->
+                      CurrentSize = riak_core_ring:num_partitions(Ring),
+                      io:format("resize-ring    ~p to ~p partitions~n",[CurrentSize,NewRingSize])
               end, Changes),
     io:format("~79..-s~n", [""]),
     io:format("~n"),
@@ -434,6 +468,7 @@ output(Ring, NextRing) ->
     Pending = riak_core_ring:pending_changes(NextRing),
     Next = [{Idx, PrevOwner, NewOwner} || {Idx, PrevOwner, NewOwner, _, _} <- Pending],
     NextTally = tally(Next),
+    Resizing = riak_core_ring:is_resizing(NextRing),
 
     case Reassigned of
         [] ->
@@ -447,9 +482,11 @@ output(Ring, NextRing) ->
             ok
     end,
 
-    case Next of
-        [] ->
+    case {Resizing, Next} of
+        {_, []} ->
             ok;
+        {true, _} ->
+            io:format("Ring is resizing. see riak-admin ring-status for transfer details.~n");
         _ ->
             io:format("Transfers resulting from cluster changes: ~p~n",
                       [length(Next)]),

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -609,7 +609,8 @@ simple_handoff () ->
     %% clear handoff_concurrency and make sure a handoff fails
     ?assertEqual(ok,set_concurrency(0)),
     ?assertEqual({error,max_concurrency},add_inbound([])),
-    ?assertEqual({error,max_concurrency},add_outbound(riak_kv,0,node(),self())),
+    ?assertEqual({error,max_concurrency},add_outbound(ownership_transfer,riak_kv_vnode,
+                                                      0,node(),self())),
 
     %% allow for a single handoff
     ?assertEqual(ok,set_concurrency(1)),

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -411,7 +411,7 @@ resize_transfer_notsent_fun(Ring, Mod, Src) ->
     case Shrinking of
         false -> NValMap = DefaultN = undefined;
         true ->
-            NValMap = riak_core_bucket:bucket_nval_map(Ring),
+            NValMap = Mod:nval_map(Ring),
             DefaultN = riak_core_bucket:default_object_nval()
     end,
     fun(Key, Acc) -> record_seen_index(Ring, Shrinking, NValMap, DefaultN, Mod, Src, Key, Acc) end.

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -424,10 +424,7 @@ record_seen_index(Ring, Shrinking, NValMap, DefaultN, Mod, Src, Key, Seen) ->
                 end,
     case riak_core_ring:future_index(Hashed, Src, CheckNVal, Ring) of
         undefined -> Seen;
-        FutureIndex ->
-            lager:info("resize transfer from ~p recording ~p as seen for key ~p",
-                       [Src, FutureIndex, Key]),
-            ordsets:add_element(FutureIndex, Seen)
+        FutureIndex -> ordsets:add_element(FutureIndex, Seen)
     end.
 
 get_concurrency_limit () ->

--- a/src/riak_core_handoff_sender_sup.erl
+++ b/src/riak_core_handoff_sender_sup.erl
@@ -27,9 +27,7 @@
         ]).
 
 %% API
--export([start_handoff/5,
-         start_repair/6
-        ]).
+-export([start_sender/5]).
 
 -include("riak_core_handoff.hrl").
 -define(CHILD(I,Type), {I,{I,start_link,[]},temporary,brutal_kill,Type,[I]}).
@@ -38,32 +36,26 @@
 %%% API
 %%%===================================================================
 
-start_link () ->
+start_link() ->
     supervisor:start_link({local,?MODULE},?MODULE,[]).
 
 %% @doc Start the handoff process for the module (`Module'), partition
 %%      (`Partition'), and vnode (`VNode') from the local node to the
-%%      target node (`TargetNode').
--spec start_handoff(ho_type(), module(), any(), pid(), node()) -> {ok, pid()}.
-start_handoff(Type, Module, Partition, VNode, TargetNode) ->
-    Opts = [{src_partition, Partition},
-            {target_partition, Partition},
-            {filter, none}],
+%%      target node (`TargetNode') with options `Opts'.
+%%
+%%      Options:
+%%        * src_partition - required. the integer index of the source vnode
+%%        * target_partition - required. the integer index of the target vnode
+%%        * filter - optional. an arity one function that takes the key and returns
+%%                   a boolean. If false, the key is not sent
+%%        * unsent_fun - optional. an arity 2 function that takes a key that was not sent
+%%                       (based on filter) and an accumulator. This function is called
+%%                       for each unsent key.
+%%        * unsent_acc0 - optional. The intial accumulator value passed to unsent_fun
+%%                        for the first unsent key
+-spec start_sender(ho_type(), atom(), term(), pid(), [{atom(), term()}]) -> {ok, pid()}.
+start_sender(Type, Module, TargetNode, VNode, Opts) ->
     supervisor:start_child(?MODULE, [TargetNode, Module, {Type, Opts}, VNode]).
-
-%% @doc Start the repair process for the given module (`Module') from
-%%      the local partition (`SrcPartition') to the remote partition
-%%      (`TargetNode' and `TargetPartition') using the filter
-%%      (`Filter').
--spec start_repair(module(), any(), any(), pid(), node(), predicate() | none) ->
-                          {ok, pid()}.
-start_repair(Module, SrcPartition, TargetPartition, VNode, TargetNode, Filter) ->
-    Type = repair,
-    Opts = [{src_partition, SrcPartition},
-            {target_partition, TargetPartition},
-            {filter, Filter}],
-    supervisor:start_child(?MODULE, [TargetNode, Module, {Type, Opts}, VNode]).
-
 
 %%%===================================================================
 %%% Callbacks

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -798,7 +798,7 @@ disowning_indices(State, Node) ->
 disowned_during_resize(CState, Idx, Owner) ->
     %% catch error when index doesn't exist, we are disowning it if its going away
     NextOwner = try future_owner(CState, Idx)
-                catch _ -> undefined
+                catch _:_ -> undefined
                 end,
     case NextOwner of
         Owner -> false;

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -126,6 +126,7 @@
          resized_ring/1,
          set_resized_ring/2,
          future_index/3,
+         future_index/4,
          is_future_index/4,
          future_owner/2,
          future_num_partitions/1,
@@ -534,30 +535,76 @@ responsible_index(ChashKey, ?CHSTATE{chring=Ring}) ->
 %%      for `CHashKey' in the future ring. For regular transitions
 %%      the returned index will always be `OrigIdx'. If the ring is
 %%      resizing the index may be different
--spec future_index(chash:index(), integer(), chstate()) -> integer().
+-spec future_index(chash:index(),
+                   integer(),
+                   chstate()) -> integer() | undefined.
 future_index(CHashKey, OrigIdx, State) ->
-    FutureState = future_ring(State),
-    Preflist = preflist(CHashKey, State),
-    FuturePreflist = preflist(CHashKey, FutureState),
-    Position = preflist_position(Preflist, OrigIdx),
-    {FutureIdx, _} = lists:nth(Position, FuturePreflist),
-    FutureIdx.
+    future_index(CHashKey, OrigIdx, undefined, State).
+
+-spec future_index(chash:index(),
+                   integer(),
+                   undefined | integer(),
+                   chstate()) -> integer() | undefined.
+future_index(CHashKey, OrigIdx, NValCheck, State) ->
+    <<CHashInt:160/integer>> = CHashKey,
+    OrigCount = num_partitions(State),
+    NextCount = future_num_partitions(State),
+    OrigInc = chash:ring_increment(OrigCount),
+    NextInc = chash:ring_increment(NextCount),
+
+    %% Determine position in the ring of partition that owns key (head of preflist)
+    %% Position is 1-based starting from partition (0 + ring increment), e.g.
+    %% index 0 is always position N.
+    OwnerPos = ((CHashInt div OrigInc) + 1),
+
+    %% Determine position of the source partition in the ring
+    %% if OrigIdx is 0 we know the position is OrigCount (number of partitions)
+    OrigPos = case OrigIdx of
+                  0 -> OrigCount;
+                  _ -> OrigIdx div OrigInc
+              end,
+
+    %% The distance between the key's owner (head of preflist) and the source partition
+    %% is the position of the source in the preflist, the distance may be negative
+    %% in which case we have wrapped around the ring. distance of zero means the source
+    %% is the head of the preflist.
+    OrigDist = case OrigPos - OwnerPos of
+                  P when P < 0 -> OrigCount + P;
+                  P -> P
+               end,
+
+    %% In the case that the ring is shrinking the future index for a key whose position
+    %% in the preflist is >= ring size may be calculated, any transfer is invalid in
+    %% this case, return undefined. The position may also be >= an optional N value for
+    %% the key, if this is true undefined is also returned
+    case check_invalid_future_index(OrigDist, NextCount, NValCheck) of
+        true -> undefined;
+        false ->
+            %% Determine the partition (head of preflist) that will own the key in the future ring
+            FuturePos =  ((CHashInt div NextInc) + 1),
+            NextOwner = FuturePos * NextInc,
+
+            %% Determine the partition that the key should be transferred to (has same position
+            %% in future preflist as source partition does in current preflist)
+            RingTop = trunc(math:pow(2,160)-1),
+            case NextOwner + (NextInc * OrigDist) of
+                FutureIndex when FutureIndex >= RingTop -> FutureIndex - RingTop;
+                FutureIndex -> FutureIndex
+            end
+    end.
+
+check_invalid_future_index(OrigDist, NextCount, NValCheck) ->
+    OverRingSize = OrigDist >= NextCount,
+    OverNVal = case NValCheck of
+                   undefined -> false;
+                   _ -> OrigDist >= NValCheck
+               end,
+    OverRingSize orelse OverNVal.
 
 -spec is_future_index(chash:index(), integer(), integer(), chstate()) -> boolean().
 is_future_index(CHashKey, OrigIdx, TargetIdx, State) ->
-    FutureIndex = future_index(CHashKey, OrigIdx, State),
+    FutureIndex = future_index(CHashKey, OrigIdx, undefined, State),
     FutureIndex =:= TargetIdx.
-
-%% @private
-%% returns a 1-based index that is the position of `Idx' in `Preflist'
-preflist_position(Preflist, Idx) ->
-    preflist_position(Preflist, Idx, 1).
-
-%% @private
-preflist_position([{Idx, _} | _], Idx, Acc) ->
-    Acc;
-preflist_position([_ | Rest], Idx, Acc) ->
-    preflist_position(Rest, Idx, Acc+1).
 
 -spec transfer_node(Idx :: integer(), Node :: term(), MyState :: chstate()) ->
            chstate().
@@ -1929,8 +1976,8 @@ resize_test() ->
     Key = <<0:160/integer>>,
     OrigIdx = element(1, hd(preflist(Key, Ring0))),
     %% for non-resize transitions index should be the same
-    ?assertEqual(OrigIdx, future_index(Key, OrigIdx, Ring0)),
-    ?assertEqual(element(1, hd(preflist(Key, Ring2))), future_index(Key, OrigIdx, Ring3)).
+    ?assertEqual(OrigIdx, future_index(Key, OrigIdx, undefined, Ring0)),
+    ?assertEqual(element(1, hd(preflist(Key, Ring2))), future_index(Key, OrigIdx, undefined, Ring3)).
 
 resize_xfer_test_() ->
     {setup,

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -108,7 +108,21 @@
          reconcile_names/2,
          reconcile_members/2,
          is_primary/2,
-         chash/1]).
+         chash/1,
+         resize/2,
+         set_pending_resize/2,
+         schedule_resize_transfer/3,
+         awaiting_resize_transfer/3,
+         resize_transfer_status/4,
+         resize_transfer_complete/4,
+         complete_resize_transfers/3,
+         is_resizing/1,
+         is_resize_complete/1,
+         future_index/3,
+         is_future_index/4,
+         future_owner/2,
+         future_num_partitions/1,
+         vnode_type/2]).
 
 -export_type([riak_core_ring/0]).
 
@@ -256,6 +270,9 @@ is_primary(Ring, IdxNode) ->
 chash(?CHSTATE{chring=CHash}) ->
     CHash.
 
+set_chash(State, CHash) ->
+    State?CHSTATE{chring=CHash}.
+
 %% @doc Produce a list of all nodes that are members of the cluster
 -spec all_members(State :: chstate()) -> [Node :: term()].
 all_members(?CHSTATE{members=Members}) ->
@@ -330,6 +347,18 @@ fresh(RingSize, NodeName) ->
              vclock=VClock,
              meta=dict:new()}.
 
+%% @doc change the size of the ring to `NewRingSize'. If the ring
+%%      is larger than the current ring any new indexes will be owned
+%%      by a dummy host
+-spec resize(chstate(), integer()) -> chstate().
+resize(State, NewRingSize) ->
+    NewRing = lists:foldl(fun({Idx,Owner}, RingAcc) ->
+                                  chash:update(Idx, Owner, RingAcc)
+                          end,
+                          chash:fresh(NewRingSize, '$dummyhost@resized'),
+                          all_owners(State)),
+    set_chash(State, NewRing).
+
 % @doc Return a value from the cluster metadata dict
 -spec get_meta(Key :: term(), State :: chstate()) -> 
     {ok, term()} | undefined.
@@ -339,6 +368,13 @@ get_meta(Key, State) ->
         {ok, '$removed'} -> undefined;
         {ok, M} when M#meta_entry.value =:= '$removed' -> undefined;
         {ok, M} -> {ok, M#meta_entry.value}
+    end.
+
+-spec get_meta(term(), term(), chstate()) -> {ok, term()}.
+get_meta(Key, Default, State) ->
+    case get_meta(Key, State) of
+        undefined -> {ok, Default};
+        Res -> Res
     end.
 
 %% @doc return the names of all the custom buckets stored in the ring.
@@ -357,6 +393,13 @@ get_buckets(State) ->
 index_owner(State, Idx) ->
     hd([Owner || {I, Owner} <- ?MODULE:all_owners(State), I =:= Idx]).
 
+%% @doc Return the node that will own this index after transtions have completed
+%%      this function will error if the ring is shrinking and Idx no longer exists
+%%      in it
+-spec future_owner(chstate(), integer()) -> term().
+future_owner(State, Idx) ->
+    index_owner(future_ring(State), Idx).
+
 %% @doc Return all partition indices owned by the node executing this function.
 -spec my_indices(State :: chstate()) -> [integer()].
 my_indices(State) ->
@@ -366,6 +409,11 @@ my_indices(State) ->
 -spec num_partitions(State :: chstate()) -> integer().
 num_partitions(State) ->
     chash:size(State?CHSTATE.chring).
+
+-spec future_num_partitions(chstate()) -> integer().
+future_num_partitions(State=?CHSTATE{chring=CHRing}) ->
+    {ok, C} = get_meta('$resized_ring', CHRing, State),
+    chash:size(C).
 
 %% @doc Return the node that is responsible for a given chstate.
 -spec owner_node(State :: chstate()) -> Node :: term().
@@ -467,6 +515,39 @@ rename_node(State=?CHSTATE{chring=Ring, nodename=ThisNode, members=Members,
 responsible_index(ChashKey, ?CHSTATE{chring=Ring}) ->
     <<IndexAsInt:160/integer>> = ChashKey,
     chash:next_index(IndexAsInt, Ring).
+
+%% @doc Given a key and an index in the current ring, determine
+%%      which index will own the key in the future ring. `OrigIdx'
+%%      may or may not be the responsible index for that key
+%%      (`OrigIdx' may not be the first index in `CHashKey''s preflist).
+%%      The returned index will be in the same position in the preflist
+%%      for `CHashKey' in the future ring. For regular transitions
+%%      the returned index will always be `OrigIdx'. If the ring is
+%%      resizing the index may be different
+-spec future_index(chash:index(), integer(), chstate()) -> integer().
+future_index(CHashKey, OrigIdx, State) ->
+    FutureState = future_ring(State),
+    Preflist = preflist(CHashKey, State),
+    FuturePreflist = preflist(CHashKey, FutureState),
+    Position = preflist_position(Preflist, OrigIdx),
+    {FutureIdx, _} = lists:nth(Position, FuturePreflist),
+    FutureIdx.
+
+-spec is_future_index(chash:index(), integer(), integer(), chstate()) -> boolean().
+is_future_index(CHashKey, OrigIdx, TargetIdx, State) ->
+    FutureIndex = future_index(CHashKey, OrigIdx, State),
+    FutureIndex =:= TargetIdx.
+
+%% @private
+%% returns a 1-based index that is the position of `Idx' in `Preflist'
+preflist_position(Preflist, Idx) ->
+    preflist_position(Preflist, Idx, 1).
+
+%% @private
+preflist_position([{Idx, _} | _], Idx, Acc) ->
+    Acc;
+preflist_position([_ | Rest], Idx, Acc) ->
+    preflist_position(Rest, Idx, Acc+1).
 
 -spec transfer_node(Idx :: integer(), Node :: term(), MyState :: chstate()) ->
            chstate().
@@ -674,24 +755,51 @@ indices(State, Node) ->
 %%      pending ownership transfers have completed.
 -spec future_indices(State :: chstate(), Node :: node()) -> [integer()].
 future_indices(State, Node) ->
-    FutureState = change_owners(State, all_next_owners(State)),
-    indices(FutureState, Node).
+    indices(future_ring(State), Node).
 
-%% @private
+-spec all_next_owners(chstate()) -> [{integer(), term()}].
 all_next_owners(CState) ->
-    Next = riak_core_ring:pending_changes(CState),
-    [{Idx, NextOwner} || {Idx, _, NextOwner, _, _} <- Next].
+    case is_resizing(CState) of
+        false ->
+            Next = riak_core_ring:pending_changes(CState),
+            [{Idx, NextOwner} || {Idx, _, NextOwner, _, _} <- Next];
+        true ->
+            {ok, FutureRing} = get_meta('$resized_ring', CState),
+            chash:nodes(FutureRing)
+    end.
 
 %% @private
 change_owners(CState, Reassign) ->
     lists:foldl(fun({Idx, NewOwner}, CState0) ->
-                        riak_core_ring:transfer_node(Idx, NewOwner, CState0)
+                        %% if called for indexes not in the current ring (during resizing)
+                        %% ignore the error
+                        try riak_core_ring:transfer_node(Idx, NewOwner, CState0)
+                        catch
+                            error:{badmatch, _} -> CState0
+                        end
                 end, CState, Reassign).
 
 %% @doc Return all indices that a node is scheduled to give to another.
 disowning_indices(State, Node) ->
-    [Idx || {Idx, Owner, _NextOwner, _Mods, _Status} <- State?CHSTATE.next,
-            Owner =:= Node].
+    case is_resizing(State) of
+        false ->
+            [Idx || {Idx, Owner, _NextOwner, _Mods, _Status} <- State?CHSTATE.next,
+                    Owner =:= Node];
+        true ->
+            [Idx || {Idx, Owner} <- all_owners(State),
+                    Owner =:= Node,
+                    disowned_during_resize(State, Idx, Owner)]
+    end.
+
+disowned_during_resize(CState, Idx, Owner) ->
+    %% catch error when index doesn't exist, we are disowning it if its going away
+    NextOwner = try future_owner(CState, Idx)
+                catch _ -> undefined
+                end,
+    case NextOwner of
+        Owner -> false;
+        _  -> true
+    end.
 
 %% @doc Returns a list of all pending ownership transfers.
 pending_changes(State) ->
@@ -700,6 +808,165 @@ pending_changes(State) ->
 
 set_pending_changes(State, Transfers) ->
     State?CHSTATE{next=Transfers}.
+
+%% @doc Given a ring, `Resizing', that has been resized (and presumably rebalanced)
+%%      schedule a resize transition for `Orig'.
+-spec set_pending_resize(chstate(), chstate()) -> chstate().
+set_pending_resize(Resizing, Orig) ->
+    %% all existing indexes must transfer data when the ring is being resized
+    Next = [{Idx, Owner, '$resize', [], awaiting} ||
+               {Idx, Owner} <- riak_core_ring:all_owners(Orig)],
+    %% Resizing is assumed to have a modified chring, we need to put back
+    %% the original chring to not install the resized on pre-emptively. The
+    %% resized ring is stored in ring metadata for later use
+    FutureCHash = chash(Resizing),
+    ResetRing = set_chash(Resizing, chash(Orig)),
+    update_meta('$resized_ring',
+                FutureCHash,
+                set_pending_changes(ResetRing, Next)).
+
+-spec schedule_resize_transfer(chstate(),
+                               {integer(), term()},
+                               integer() | {integer(), term()}) -> chstate().
+schedule_resize_transfer(State, Source, TargetIdx) when is_integer(TargetIdx) ->
+    TargetNode = index_owner(future_ring(State), TargetIdx),
+    schedule_resize_transfer(State, Source, {TargetIdx, TargetNode});
+schedule_resize_transfer(State, Source, Source) ->
+    State;
+schedule_resize_transfer(State, Source, Target) ->
+    Transfers = resize_transfers(State, Source),
+    case lists:keymember(Target, 1, Transfers) of
+        true -> State;
+        false ->
+            Transfers1 = lists:keystore(Target, 1, Transfers,
+                                        {Target, ordsets:new(), awaiting}),
+            set_resize_transfers(State, Source, Transfers1)
+    end.
+
+%% @doc returns the first awaiting resize_transfer for a {SourceIdx, SourceNode}
+%%      pair. If all transfers for the pair are complete, undefined is returned
+-spec awaiting_resize_transfer(chstate(), {integer(), term()}, atom()) ->
+                                      {integer(), term()} | undefined.
+awaiting_resize_transfer(State, Source, Mod) ->
+    ResizeTransfers = resize_transfers(State, Source),
+    Awaiting = [{Target, Mods, Status} || {Target, Mods, Status} <- ResizeTransfers,
+                                          Status =/= complete,
+                                          not ordsets:is_element(Mod, Mods)],
+    case Awaiting of
+        [] -> undefined;
+        [{Target, _, _} | _] -> Target
+    end.
+
+%% @doc return the status of a resize_transfer for `Source' (a index-node pair). undefined
+%%      is returned if no such transfer is scheduled. complete is returned if the transfer
+%%      is marked as such or `Mod' is contained in the completed modules set. awaiting is
+%%      returned otherwise
+-spec resize_transfer_status(chstate(), {integer(), term()}, {integer(), term()}, atom()) ->
+                                    awaiting | complete | undefined.
+resize_transfer_status(State, Source, Target, Mod) ->
+    ResizeTransfers = resize_transfers(State, Source),
+    %% change to use keyfind
+    StatusMods = [{Status, Mods} || {T, Mods, Status} <- ResizeTransfers,
+                                    T =:= Target],
+    IsComplete = case StatusMods of
+                     [{complete, _}] -> true;
+                     [{awaiting, Mods}] -> ordsets:is_element(Mod, Mods);
+                     _ -> undefined
+                 end,
+    case IsComplete of
+        true -> complete;
+        false -> awaiting;
+        undefined -> undefined
+    end.
+
+%% @doc mark a resize_transfer from `Source' to `Target' for `Mod' complete.
+%%      if all transfers for `Source' are complete, the corresponding entry
+%%      in next is marked complete. This requires any other resize_transfers
+%%      for `Source' that need to be started to be scheduled before calling
+%%      this fuction
+-spec resize_transfer_complete(chstate(),
+                               {integer(),term()},
+                               {integer(),term()},
+                               atom()) -> chstate().
+resize_transfer_complete(State, {SrcIdx, _}=Source, Target, Mod) ->
+    ResizeTransfers = resize_transfers(State, Source),
+    Transfer = lists:keyfind(Target, 1, ResizeTransfers),
+    case Transfer of
+        {Target, Mods, Status} ->
+            VNodeMods =
+                ordsets:from_list([VMod || {_, VMod} <- riak_core:vnode_modules()]),
+            Mods2 = ordsets:add_element(Mod, Mods),
+            Status2 = case {Status, Mods2} of
+                          {complete, _} -> complete;
+                          {awaiting, VNodeMods} -> complete;
+                          _ -> awaiting
+                      end,
+            ResizeTransfers2 = lists:keyreplace(Target, 1, ResizeTransfers,
+                                                {Target, Mods2, Status2}),
+            State1 = set_resize_transfers(State, Source, ResizeTransfers2),
+            AllComplete = lists:all(fun({_, _, complete}) -> true;
+                                       ({_, Ms, awaiting}) -> ordsets:is_element(Mod, Ms)
+                                    end, ResizeTransfers2),
+            case AllComplete of
+                true ->
+                    transfer_complete(State1, SrcIdx, Mod);
+                false -> State1
+            end;
+        _ -> State
+    end.
+
+-spec is_resizing(chstate()) -> boolean().
+is_resizing(State) ->
+    case get_meta('$resized_ring', State) of
+        undefined -> false;
+        {ok, _} -> true
+    end.
+
+-spec is_resize_complete(chstate()) -> boolean().
+is_resize_complete(?CHSTATE{next=Next}) ->
+    not lists:any(fun({_, _, _, _, awaiting}) -> true;
+                     ({_, _, _, _, complete}) -> false
+                  end,
+                  Next).
+
+-spec complete_resize_transfers(chstate(), {integer(),term()}, atom()) -> [{integer(),term()}].
+complete_resize_transfers(State, Source, Mod) ->
+    [Target || {Target, Mods, Status} <- resize_transfers(State, Source),
+               Status =:= complete orelse ordsets:is_element(Mod, Mods)].
+
+resize_transfers(State, Source) ->
+    {ok, Transfers} = get_meta({resize, Source}, [], State),
+    Transfers.
+
+set_resize_transfers(State, Source, Transfers) ->
+    update_meta({resize, Source}, Transfers, State).
+
+clear_resize_transfers(Source, State) ->
+    remove_meta({resize, Source}, State).
+
+-spec vnode_type(chstate(),integer()) -> primary |
+                                         {fallback, term()} |
+                                         new_primary |
+                                         resized_primary.
+vnode_type(State, Idx) ->
+    vnode_type(State, Idx, node()).
+
+vnode_type(State, Idx, Node) ->
+    try index_owner(State, Idx) of
+        Node ->
+            primary;
+        Owner ->
+            case next_owner(State, Idx) of
+                {_, Node, _} ->
+                    future_primary;
+                _ ->
+                    {fallback, Owner}
+            end
+    catch
+        error:badarg ->
+            %% idx doesn't exist so must be an index in a resized ring
+            resized_primary
+    end.
 
 %% @doc Return details for a pending partition ownership change.
 -spec next_owner(State :: chstate(), Idx :: integer()) -> pending_change().
@@ -792,7 +1059,11 @@ ring_changed(Node, State) ->
 
 %% @doc Return the ring that will exist after all pending ownership transfers
 %%      have completed.
+-spec future_ring(chstate()) -> chstate().
 future_ring(State) ->
+    future_ring(State, is_resizing(State)).
+
+future_ring(State, false) ->
     FutureState = change_owners(State, all_next_owners(State)),
     %% Individual nodes will move themselves from leaving to exiting if they
     %% have no ring ownership, this is implemented in riak_core_ring_handler.
@@ -807,7 +1078,12 @@ future_ring(State) ->
                                     StateAcc
                             end
                     end, FutureState, Leaving),
-    FutureState2?CHSTATE{next=[]}.
+    FutureState2?CHSTATE{next=[]};
+future_ring(State0, true) ->
+    {ok, FutureCHash} = get_meta('$resized_ring', State0),
+    State1 = remove_meta('$resized_ring', State0),
+    State2 = lists:foldl(fun clear_resize_transfers/2, State1, all_owners(State1)),
+    State2?CHSTATE{next=[],chring=FutureCHash}.
 
 pretty_print(Ring, Opts) ->
     OptNumeric = lists:member(numeric, Opts),
@@ -1509,5 +1785,77 @@ reconcile_next_test() ->
              {1, nodeA, nodeB, [], awaiting},
              {2, nodeA, nodeB, [riak_kv_vnode, riak_pipe_vnode], complete}],
     ?assertEqual(Next6, reconcile_divergent_next(Next4, Next5)).
+
+resize_test() ->
+    Ring0 = fresh(4, a),
+    Ring1 = resize(Ring0, 8),
+    Ring2 = resize(Ring0, 2),
+    ?assertEqual(8, num_partitions(Ring1)),
+    ?assertEqual(2, num_partitions(Ring2)),
+    valid_resize(Ring0, Ring1),
+    valid_resize(Ring0, Ring1),
+
+    Ring3 = set_pending_resize(Ring2, Ring0),
+    ?assertEqual(num_partitions(Ring0), num_partitions(Ring3)),
+    ?assertEqual(num_partitions(Ring2), future_num_partitions(Ring3)),
+    ?assertEqual(num_partitions(Ring2), num_partitions(future_ring(Ring3))),
+
+    Key = <<0:160/integer>>,
+    OrigIdx = element(1, hd(preflist(Key, Ring0))),
+    %% for non-resize transitions index should be the same
+    ?assertEqual(OrigIdx, future_index(Key, OrigIdx, Ring0)),
+    ?assertEqual(element(1, hd(preflist(Key, Ring2))), future_index(Key, OrigIdx, Ring3)).
+
+resize_xfer_test_() ->
+    {setup,
+     fun() ->
+             meck:new(riak_core, [passthrough]),
+             meck:expect(riak_core, vnode_modules,
+                         fun() -> [{some_app, fake_vnode}, {other_app, other_vnode}] end)
+     end,
+     fun(_) -> meck:unload(riak_core) end,
+     fun test_resize_xfers/0}.
+
+test_resize_xfers() ->
+    Ring0 = riak_core_ring:fresh(4, a),
+    Ring1 = set_pending_resize(resize(Ring0, 8), Ring0),
+    Source1 = {0, a},
+    Target1 = {730750818665451459101842416358141509827966271488, a},
+    TargetIdx2 = 365375409332725729550921208179070754913983135744,
+    Ring2 = schedule_resize_transfer(Ring1, Source1, Target1),
+    ?assertEqual(Target1, awaiting_resize_transfer(Ring2, Source1, fake_vnode)),
+    ?assertEqual(awaiting, resize_transfer_status(Ring2, Source1, Target1, fake_vnode)),
+    %% use Target1 since we haven't used it as a source index
+    ?assertEqual(undefined, awaiting_resize_transfer(Ring2, Target1, fake_vnode)),
+    ?assertEqual(undefined, resize_transfer_status(Ring2, Target1, Source1, fake_vnode)),
+
+    Ring3 = schedule_resize_transfer(Ring2, Source1, TargetIdx2),
+    Ring4 = resize_transfer_complete(Ring3, Source1, Target1, fake_vnode),
+    ?assertEqual({TargetIdx2, a}, awaiting_resize_transfer(Ring4, Source1, fake_vnode)),
+    ?assertEqual(awaiting, resize_transfer_status(Ring4, Source1, {TargetIdx2, a}, fake_vnode)),
+    ?assertEqual(complete, resize_transfer_status(Ring4, Source1, Target1, fake_vnode)),
+
+    Ring5 = resize_transfer_complete(Ring4, Source1, {TargetIdx2, a}, fake_vnode),
+    {_, '$resize', Status1} = next_owner(Ring5, 0, fake_vnode),
+    ?assertEqual(complete, Status1),
+
+    Ring6 = resize_transfer_complete(Ring5, Source1, {TargetIdx2, a}, other_vnode),
+    Ring7 = resize_transfer_complete(Ring6, Source1, Target1, other_vnode),
+    {_, '$resize', Status2} = next_owner(Ring7, 0, fake_vnode),
+    ?assertEqual(complete, Status2),
+    {_, '$resize', Status3} = next_owner(Ring7, 0, other_vnode),
+    ?assertEqual(complete, Status3),
+    {_, '$resize', complete} = next_owner(Ring7, 0).
+
+valid_resize(Ring0, Ring1) ->
+    lists:foreach(fun({Idx, Owner}) ->
+                          case lists:keyfind(Idx, 1, all_owners(Ring0)) of
+                              false ->
+                                  ?assertEqual('$dummyhost@resized', Owner);
+                              {Idx, OrigOwner} ->
+                                  ?assertEqual(OrigOwner, Owner)
+                          end
+                  end,
+                  all_owners(Ring1)).
 
 -endif.

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -816,14 +816,8 @@ future_indices(State, Node) ->
 
 -spec all_next_owners(chstate()) -> [{integer(), term()}].
 all_next_owners(CState) ->
-    case is_resizing(CState) of
-        false ->
-            Next = riak_core_ring:pending_changes(CState),
-            [{Idx, NextOwner} || {Idx, _, NextOwner, _, _} <- Next];
-        true ->
-            {ok, FutureRing} = resized_ring(CState),
-            chash:nodes(FutureRing)
-    end.
+    Next = riak_core_ring:pending_changes(CState),
+    [{Idx, NextOwner} || {Idx, _, NextOwner, _, _} <- Next].
 
 %% @private
 change_owners(CState, Reassign) ->

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -883,7 +883,8 @@ maybe_abort_resize(State0) ->
         true ->
             State1 = State0?CHSTATE{next=[]},
             State2 = clear_all_resize_transfers(State1),
-            {true, remove_meta('$resized_ring', State2)};
+            State3 = remove_meta('$resized_ring_abort', State2),
+            {true, remove_meta('$resized_ring', State3)};
         false ->
             {false, State0}
     end.

--- a/src/riak_core_ring_handler.erl
+++ b/src/riak_core_ring_handler.erl
@@ -193,8 +193,7 @@ maybe_stop_vnode_proxies(Ring) ->
         [] ->
             Idxs = [{I,M} || {I,_} <- riak_core_ring:all_owners(Ring), M <- Mods],
             ProxySpecs = supervisor:which_children(riak_core_vnode_proxy_sup),
-            Running = [{I,M} || {{M,I},Pid,_,_} <- ProxySpecs,
-                            is_pid(Pid) andalso is_process_alive(Pid)],
+            Running = [{I,M} || {{M,I},_,_,_} <- ProxySpecs, lists:member(M, Mods)],
             ToShutdown = Running -- Idxs,
             [riak_core_vnode_proxy_sup:stop_proxy(M,I) || {I, M} <- ToShutdown];
         _ ->

--- a/src/riak_core_ring_handler.erl
+++ b/src/riak_core_ring_handler.erl
@@ -179,7 +179,7 @@ maybe_start_vnode_proxies(Ring) ->
     Larger = Size < FutureSize,
     case Larger of
         true ->
-            FutureIdxs = riak_core_ring:all_next_owners(Ring),
+            FutureIdxs = riak_core_ring:all_owners(riak_core_ring:future_ring(Ring)),
             [riak_core_vnode_proxy_sup:start_proxy(Mod, Idx) || {Idx, _} <- FutureIdxs,
                                                                 Mod <- Mods],
             ok;

--- a/src/riak_core_ring_handler.erl
+++ b/src/riak_core_ring_handler.erl
@@ -36,6 +36,8 @@ init([]) ->
 handle_event({ring_update, Ring}, State) ->
     %% Make sure all vnodes are started...
     ensure_vnodes_started(Ring),
+    maybe_start_vnode_proxies(Ring),
+    maybe_stop_vnode_proxies(Ring),
     riak_core_vnode_manager:ring_changed(Ring),
     riak_core_capability:ring_changed(Ring),
     {ok, State}.
@@ -168,4 +170,33 @@ startable_vnodes(Mod, Ring) ->
                 RO ->
                     [RO | riak_core_ring:my_indices(Ring)]
             end
+    end.
+
+maybe_start_vnode_proxies(Ring) ->
+    Mods = [M || {_,M} <- riak_core:vnode_modules()],
+    Size = riak_core_ring:num_partitions(Ring),
+    FutureSize = riak_core_ring:future_num_partitions(Ring),
+    Larger = Size < FutureSize,
+    case Larger of
+        true ->
+            FutureIdxs = riak_core_ring:all_next_owners(Ring),
+            [riak_core_vnode_proxy_sup:start_proxy(Mod, Idx) || {Idx, _} <- FutureIdxs,
+                                                                Mod <- Mods],
+            ok;
+        false ->
+            ok
+    end.
+
+maybe_stop_vnode_proxies(Ring) ->
+    Mods = [M || {_, M} <- riak_core:vnode_modules()],
+    case riak_core_ring:pending_changes(Ring) of
+        [] ->
+            Idxs = [{I,M} || {I,_} <- riak_core_ring:all_owners(Ring), M <- Mods],
+            ProxySpecs = supervisor:which_children(riak_core_vnode_proxy_sup),
+            Running = [{I,M} || {{M,I},Pid,_,_} <- ProxySpecs,
+                            is_pid(Pid) andalso is_process_alive(Pid)],
+            ToShutdown = Running -- Idxs,
+            [riak_core_vnode_proxy_sup:stop_proxy(M,I) || {I, M} <- ToShutdown];
+        _ ->
+            ok
     end.

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -40,6 +40,7 @@
 -export([get_mod_index/1,
          set_forwarding/2,
          trigger_handoff/2,
+         trigger_handoff/3,
          core_status/1,
          handoff_error/3]).
 
@@ -103,8 +104,9 @@ behaviour_info(_Other) ->
           mod :: module(),
           modstate :: term(),
           forward :: node(),
-          handoff_node=none :: none | node(),
+          handoff_target=none :: none | {integer(), node()},
           handoff_pid :: pid(),
+          handoff_type :: hinted_handoff | ownership_transfer | resize_transfer,
           pool_pid :: pid() | undefined,
           pool_config :: tuple() | undefined,
           manager_event_timer :: reference(),
@@ -209,6 +211,9 @@ get_mod_index(VNode) ->
 set_forwarding(VNode, ForwardTo) ->
     gen_fsm:send_all_state_event(VNode, {set_forwarding, ForwardTo}).
 
+trigger_handoff(VNode, TargetIdx, TargetNode) ->
+    gen_fsm:send_all_state_event(VNode, {trigger_handoff, TargetIdx, TargetNode}).
+
 trigger_handoff(VNode, TargetNode) ->
     gen_fsm:send_all_state_event(VNode, {trigger_handoff, TargetNode}).
 
@@ -224,7 +229,7 @@ continue(State, NewModState) ->
 %% Active vnodes operate in three states: normal, handoff, and forwarding.
 %%
 %% In the normal state, vnode commands are passed to handle_command. When
-%% a handoff is triggered, handoff_node is set to the target node and the vnode
+%% a handoff is triggered, handoff_target is set and the vnode
 %% is said to be in the handoff state.
 %%
 %% In the handoff state, vnode commands are passed to handle_handoff_command.
@@ -241,23 +246,51 @@ continue(State, NewModState) ->
 %% new owner, or simply because the ring has yet to converge on the new owner.
 %% In the forwarding state, all vnode commands and coverage commands are
 %% forwarded to the new owner for processing.
-
-vnode_command(Sender, Request, State=#state{index=Index,
-                                            mod=Mod,
-                                            modstate=ModState,
-                                            forward=Forward,
-                                            pool_pid=Pool}) ->
-    %% Check if we should forward
-    case Forward of
-        undefined ->
-            Action = Mod:handle_command(Request, Sender, ModState);
-        NextOwner ->
-            lager:debug("Forwarding ~p -> ~p: ~p~n", [node(), NextOwner, Index]),
-            riak_core_vnode_master:command({Index, NextOwner}, Request, Sender,
-                                           riak_core_vnode_master:reg_name(Mod)),
-            Action = continue
+%%
+%% The above becomes a bit more complicated when the vnode takes part in resizing
+%% the ring, since several transfers with a single vnode as the source are necessary
+%% to complete the operation. A vnode will remain in the handoff state, for, potentially,
+%% more than one transfer and may be in the handoff state despite there being no active
+%% transfers with this vnode as the source. During this time requests that can be forwarded
+%% to a partition for which the transfer has already completed, are forwarded. All other
+%% requests are passed to handle_handoff_command.
+forward_or_vnode_command(Sender, Request, State=#state{forward=Forward,
+                                                       mod=Mod,
+                                                       handoff_target=HT,
+                                                       index=Index}) ->
+    Resizing = is_list(Forward),
+    case Resizing of
+        true ->
+            RequestHash = Mod:request_hash(Request);
+        false ->
+            RequestHash = undefined
     end,
-    case Action of
+    case {Forward, RequestHash} of
+        %% no forwarding
+        {undefined, _} -> vnode_command(Sender, Request, State);
+        %% implicit forwarding after ownership_transfer/hinted_handoff
+        {F, _} when not is_list(F) -> vnode_forward(HT, Sender, Request, State);
+        %% during resize we can't forward a request w/o request hash
+        {_, undefined} -> vnode_command(Sender, Request, State);
+        %% possible forwarding during ring resizing
+        {_, _} ->
+            %% during ring resizing if we have completed a transfer to the index that will
+            %% handle request in future ring we forward to it. Otherwise we delegate
+            %% to the local vnode like other requests during handoff
+            {ok, R} = riak_core_ring_manager:get_my_ring(),
+            FutureIndex = riak_core_ring:future_index(RequestHash, Index, R),
+            case lists:keyfind(FutureIndex, 1, Forward) of
+                false -> vnode_handoff_command(Sender, Request, RequestHash, State);
+                {FutureIndex, FutureOwner} ->
+                    vnode_forward({FutureIndex, FutureOwner}, Sender,
+                                  {resize_forward,Request}, State)
+            end
+    end.
+
+vnode_command(Sender, Request, State=#state{mod=Mod,
+                                            modstate=ModState,
+                                            pool_pid=Pool}) ->
+    case Mod:handle_command(Request, Sender, ModState) of
         continue ->
             continue(State, ModState);
         {reply, Reply, NewModState} ->
@@ -283,6 +316,9 @@ vnode_coverage(Sender, Request, KeySpaces, State=#state{index=Index,
     case Forward of
         undefined ->
             Action = Mod:handle_coverage(Request, KeySpaces, Sender, ModState);
+        %% handle coverage requests locally during ring resize
+        Forwards when is_list(Forwards) ->
+            Action = Mod:handle_coverage(Request, KeySpaces, Sender, ModState);
         NextOwner ->
             lager:debug("Forwarding coverage ~p -> ~p: ~p~n", [node(), NextOwner, Index]),
             riak_core_vnode_master:coverage(Request, {Index, NextOwner},
@@ -307,11 +343,11 @@ vnode_coverage(Sender, Request, KeySpaces, State=#state{index=Index,
             {stop, Reason, State#state{modstate=NewModState}}
     end.
 
-vnode_handoff_command(Sender, Request, State=#state{index=Index,
-                                                    mod=Mod,
-                                                    modstate=ModState,
-                                                    handoff_node=HN,
-                                                    pool_pid=Pool}) ->
+vnode_handoff_command(Sender, Request, RequestHash, State=#state{mod=Mod,
+                                                                 index=Index,
+                                                                 modstate=ModState,
+                                                                 handoff_target=HOTarget,
+                                                                 pool_pid=Pool}) ->
     case Mod:handle_handoff_command(Request, Sender, ModState) of
         {reply, Reply, NewModState} ->
             reply(Sender, Reply),
@@ -324,14 +360,29 @@ vnode_handoff_command(Sender, Request, State=#state{index=Index,
             riak_core_vnode_worker_pool:handle_work(Pool, Work, From),
             continue(State, NewModState);
         {forward, NewModState} ->
-            riak_core_vnode_master:command({Index, HN}, Request, Sender,
-                                           riak_core_vnode_master:reg_name(Mod)),
+            case RequestHash of
+                undefined ->
+                    vnode_forward(HOTarget, Sender, Request, State);
+                _ ->
+                    {ok, R} = riak_core_ring_manager:get_my_ring(),
+                    FutureIndex = riak_core_ring:future_index(RequestHash, Index, R),
+                    FutureOwner = riak_core_ring:future_owner(R, FutureIndex),
+                    vnode_forward({FutureIndex, FutureOwner}, Sender,
+                                  {resize_forward, Request}, State)
+            end,
             continue(State, NewModState);
         {drop, NewModState} ->
             continue(State, NewModState);
         {stop, Reason, NewModState} ->
             {stop, Reason, State#state{modstate=NewModState}}
     end.
+
+vnode_forward(ForwardTo, Sender, Request, State) ->
+    lager:debug("Forwarding {~p,~p} -> ~p~n",
+                [State#state.index, node(), ForwardTo]),
+    riak_core_vnode_master:command(ForwardTo, Request, Sender,
+                                   riak_core_vnode_master:reg_name(State#state.mod)),
+    continue(State).
 
 active(timeout, State=#state{mod=Mod, index=Idx}) ->
     riak_core_vnode_manager:vnode_event(Mod, Idx, self(), inactive),
@@ -341,14 +392,30 @@ active(?COVERAGE_REQ{keyspaces=KeySpaces,
                      sender=Sender}, State) ->
     %% Coverage request handled in handoff and non-handoff.  Will be forwarded if set.
     vnode_coverage(Sender, Request, KeySpaces, State);
-active(?VNODE_REQ{sender=Sender, request=Request},
-       State=#state{handoff_node=HN}) when HN =:= none ->
+active(?VNODE_REQ{sender=Sender, request={resize_forward, Request}}, State) ->
     vnode_command(Sender, Request, State);
+active(?VNODE_REQ{sender=Sender, request=Request},
+       State=#state{handoff_target=HT}) when HT =:= none ->
+    forward_or_vnode_command(Sender, Request, State);
+active(?VNODE_REQ{sender=Sender, request=Request},
+                  State=#state{handoff_type=resize_transfer,
+                               mod=Mod}) ->
+    vnode_handoff_command(Sender, Request, Mod:request_hash(Request), State);
 active(?VNODE_REQ{sender=Sender, request=Request},State) ->
-    vnode_handoff_command(Sender, Request, State);
+    vnode_handoff_command(Sender, Request, undefined, State);
 active(handoff_complete, State) ->
     State2 = start_manager_event_timer(handoff_complete, State),
     continue(State2);
+active({resize_transfer_complete, SeenIdxs}, State=#state{mod=Mod,
+                                                          modstate=ModState,
+                                                          handoff_target=Target}) ->
+    case Target of
+        none -> continue(State);
+        _ ->
+            %% TODO: refactor similarties w/ finish_handoff handle_event
+            {ok, NewModState} = Mod:handoff_finished(Target, ModState),
+            finish_handoff(SeenIdxs, State#state{modstate=NewModState})
+    end;
 active({handoff_error, _Err, _Reason}, State) ->
     State2 = start_manager_event_timer(handoff_error, State),
     continue(State2);
@@ -356,14 +423,17 @@ active({send_manager_event, Event}, State) ->
     State2 = start_manager_event_timer(Event, State),
     continue(State2);
 active({trigger_handoff, TargetNode}, State) ->
-     maybe_handoff(State, TargetNode);
+    active({trigger_handoff, State#state.index, TargetNode}, State);
+active({trigger_handoff, TargetIdx, TargetNode}, State) ->
+     maybe_handoff(TargetIdx, TargetNode, State);
 active(unregistered, State=#state{mod=Mod, index=Index}) ->
     %% Add exclusion so the ring handler will not try to spin this vnode
     %% up until it receives traffic.
     riak_core_handoff_manager:add_exclusion(Mod, Index),
     lager:debug("~p ~p vnode excluded and unregistered.",
                 [Index, Mod]),
-    {stop, normal, State#state{handoff_node=none,
+    {stop, normal, State#state{handoff_target=none,
+                               handoff_type=undefined,
                                pool_pid=undefined}}.
 
 active(_Event, _From, State) ->
@@ -376,7 +446,37 @@ active(_Event, _From, State) ->
 %% manager. Blocking the manager can impact all vnodes. This code is safe
 %% to execute on multiple parallel vnodes because of the synchronization
 %% afforded by having all ring changes go through the single ring manager.
-mark_handoff_complete(Idx, Prev, New, Mod) ->
+mark_handoff_complete(SrcIdx, Target, SeenIdxs, Mod, resize_transfer) ->
+    Prev = node(),
+    Source = {SrcIdx, Prev},
+    Result = riak_core_ring_manager:ring_trans(
+               fun(Ring, _) ->
+                       Owner = riak_core_ring:index_owner(Ring,SrcIdx),
+                       Status = riak_core_ring:resize_transfer_status(Ring, Source,
+                                                                      Target, Mod),
+                       case {Owner, Status} of
+                           {Prev, awaiting} ->
+                               F = fun(SeenIdx, RingAcc) ->
+                                           riak_core_ring:schedule_resize_transfer(RingAcc,
+                                                                                   Source,
+                                                                                   SeenIdx)
+                                   end,
+                               Ring2 = lists:foldl(F, Ring, SeenIdxs),
+                               Ring3 = riak_core_ring:resize_transfer_complete(Ring2,
+                                                                               Source,
+                                                                               Target,
+                                                                               Mod),
+                               {new_ring, Ring3};
+                           _ ->
+                               ignore
+                       end
+               end, []),
+    case Result of
+        {ok, _NewRing} -> resize;
+        _ -> continue
+    end;
+mark_handoff_complete(Idx, {Idx, New}, [], Mod, _) ->
+    Prev = node(),
     Result = riak_core_ring_manager:ring_trans(
       fun(Ring, _) ->
               Owner = riak_core_ring:index_owner(Ring, Idx),
@@ -422,15 +522,25 @@ mark_handoff_complete(Idx, Prev, New, Mod) ->
             shutdown
     end.
 
-finish_handoff(State=#state{mod=Mod,
-                            modstate=ModState,
-                            index=Idx,
-                            handoff_node=HN,
-                            pool_pid=Pool}) ->
-    case mark_handoff_complete(Idx, node(), HN, Mod) of
+finish_handoff(State) ->
+    finish_handoff([], State).
+
+finish_handoff(SeenIdxs, State=#state{mod=Mod,
+                                      modstate=ModState,
+                                      index=Idx,
+                                      handoff_target=Target,
+                                      handoff_type=HOType}) ->
+    case mark_handoff_complete(Idx, Target, SeenIdxs, Mod, HOType) of
         continue ->
-            continue(State#state{handoff_node=none});
+            continue(State#state{handoff_target=none,handoff_type=undefined});
+        resize ->
+            CurrentForwarding = resize_forwarding(State),
+            NewForwarding = [Target | CurrentForwarding],
+            continue(State#state{handoff_target=none,
+                                 handoff_type=undefined,
+                                 forward=NewForwarding});
         Res when Res == forward; Res == shutdown ->
+            {_, HN} = Target,
             %% Have to issue the delete now.  Once unregistered the
             %% vnode master will spin up a new vnode on demand.
             %% Shutdown the async pool beforehand, don't want callbacks
@@ -449,9 +559,15 @@ finish_handoff(State=#state{mod=Mod,
             lager:debug("vnode hn/fwd :: ~p/~p :: ~p -> ~p~n",
                         [State#state.mod, State#state.index, State#state.forward, HN]),
             continue(State#state{modstate={deleted,NewModState}, % like to fail if used
-                                 handoff_node=none,
+                                 handoff_target=none,
+                                 handoff_type=undefined,
                                  forward=HN})
     end.
+
+resize_forwarding(#state{forward=F}) when is_list(F) ->
+    F;
+resize_forwarding(_) ->
+    [].
 
 handle_event({set_forwarding, undefined}, _StateName,
              State=#state{modstate={deleted, _ModState}}) ->
@@ -465,16 +581,16 @@ handle_event({set_forwarding, ForwardTo}, _StateName, State) ->
 handle_event(finish_handoff, _StateName,
              State=#state{modstate={deleted, _ModState}}) ->
     stop_manager_event_timer(State),
-    continue(State#state{handoff_node=none});
+    continue(State#state{handoff_target=none});
 handle_event(finish_handoff, _StateName, State=#state{mod=Mod,
                                                       modstate=ModState,
-                                                      handoff_node=HN}) ->
+                                                      handoff_target=Target}) ->
     stop_manager_event_timer(State),
-    case HN of
+    case Target of
         none ->
             continue(State);
         _ ->
-            {ok, NewModState} = Mod:handoff_finished(HN, ModState),
+            {ok, NewModState} = Mod:handoff_finished(Target, ModState),
             finish_handoff(State#state{modstate=NewModState})
     end;
 handle_event(cancel_handoff, _StateName, State=#state{mod=Mod,
@@ -482,17 +598,21 @@ handle_event(cancel_handoff, _StateName, State=#state{mod=Mod,
     %% it would be nice to pass {Err, Reason} to the vnode but the
     %% API doesn't currently allow for that.
     stop_manager_event_timer(State),
-    case State#state.handoff_node of
+    case State#state.handoff_target of
         none ->
             continue(State);
         _ ->
             {ok, NewModState} = Mod:handoff_cancelled(ModState),
-            continue(State#state{handoff_node=none, modstate=NewModState})
+            continue(State#state{handoff_target=none,
+                                 handoff_type=undefined,
+                                 modstate=NewModState})
     end;
-handle_event({trigger_handoff, _TargetNode}, _StateName,
+handle_event({trigger_handoff, TargetNode}, StateName, State) ->
+    handle_event({trigger_handoff, State#state.index, TargetNode}, StateName, State);
+handle_event({trigger_handoff, _TargetIdx, _TargetNode}, _StateName,
              State=#state{modstate={deleted, _ModState}}) ->
     continue(State);
-handle_event(R={trigger_handoff, _TargetNode}, _StateName, State) ->
+handle_event(R={trigger_handoff, _TargetIdx, _TargetNode}, _StateName, State) ->
     active(R, State);
 handle_event(R=?VNODE_REQ{}, _StateName, State) ->
     active(R, State);
@@ -523,12 +643,12 @@ handle_sync_event({handoff_data,BinObj}, _From, StateName,
 handle_sync_event(core_status, _From, StateName, State=#state{index=Index,
                                                               mod=Mod,
                                                               modstate=ModState,
-                                                              handoff_node=HN,
+                                                              handoff_target=HT,
                                                               forward=FN}) ->
-    Mode = case {FN, HN} of
+    Mode = case {FN, HT} of
                {undefined, none} ->
                    active;
-               {undefined, HN} ->
+               {undefined, HT} ->
                    handoff;
                {FN, none} ->
                    forward;
@@ -542,11 +662,11 @@ handle_sync_event(core_status, _From, StateName, State=#state{index=Index,
             _ ->
                 [{forward, FN}]
         end++
-        case HN of
+        case HT of
             none ->
                 [];
             _ ->
-                [{handoff_node, HN}]
+                [{handoff_target, HT}]
         end ++
         case ModState of
             {deleted, _} ->
@@ -643,28 +763,30 @@ terminate(Reason, _StateName, #state{mod=Mod, modstate=ModState,
 code_change(_OldVsn, StateName, State, _Extra) ->
     {ok, StateName, State}.
 
-maybe_handoff(State=#state{modstate={deleted, _}}, _TargetNode) ->
+maybe_handoff(_TargetIdx, _TargetNode, State=#state{modstate={deleted, _}}) ->
     %% Modstate has been deleted, waiting for unregistered.  No handoff.
     continue(State);
-maybe_handoff(State=#state{index=Idx, mod=Mod, modstate=ModState,
-                           handoff_node=HN, handoff_pid=HPid}, TargetNode) ->
+maybe_handoff(TargetIdx, TargetNode,
+              State=#state{index=Idx, mod=Mod, modstate=ModState,
+                           handoff_target=CurrentTarget, handoff_pid=HPid}) ->
+    Target = {TargetIdx, TargetNode},
     ExistingHO = is_pid(HPid) andalso is_process_alive(HPid),
-    ValidHN = case HN of
+    ValidHN = case CurrentTarget of
                   none ->
                       true;
-                  TargetNode ->
+                  Target ->
                       not ExistingHO;
                   _ ->
                       lager:info("~s/~b: handoff request to ~p before "
                                  "finishing handoff to ~p",
-                                 [Mod, Idx, TargetNode, HN]),
+                                 [Mod, Idx, Target, CurrentTarget]),
                       not ExistingHO
               end,
     case ValidHN of
         true ->
-            case Mod:handoff_starting(TargetNode, ModState) of
+            case Mod:handoff_starting(Target, ModState) of
                 {true, NewModState} ->
-                    start_handoff(State#state{modstate=NewModState}, TargetNode);
+                    start_handoff(TargetIdx, TargetNode,State#state{modstate=NewModState});
                 {false, NewModState} ->
                     continue(State, NewModState)
             end;
@@ -672,22 +794,37 @@ maybe_handoff(State=#state{index=Idx, mod=Mod, modstate=ModState,
             continue(State)
     end.
 
-start_handoff(State=#state{index=Idx, mod=Mod, modstate=ModState}, TargetNode) ->
+start_handoff(TargetIdx, TargetNode,
+              State=#state{index=Idx, mod=Mod, modstate=ModState}) ->
+    {ok, R} = riak_core_ring_manager:get_my_ring(),
+    Resizing = riak_core_ring:is_resizing(R),
+    Primary = riak_core_ring:is_primary(R, {Idx, node()}),
+    HOType = case {Resizing, Primary} of
+                 {true, _} -> resize_transfer;
+                 {_, true} -> ownership_transfer;
+                 {_, false} -> hinted_handoff
+             end,
     case Mod:is_empty(ModState) of
         {true, NewModState} ->
             finish_handoff(State#state{modstate=NewModState,
-                                       handoff_node=TargetNode});
+                                       handoff_type=HOType,
+                                       handoff_target={TargetIdx, TargetNode}});
         {false, NewModState} ->
-            case riak_core_handoff_manager:add_outbound(Mod,Idx,TargetNode,self()) of
-                {ok, Pid} ->
-                    NewState = State#state{modstate=NewModState,
-                                           handoff_pid=Pid,
-                                           handoff_node=TargetNode},
-                    continue(NewState);
-                {error,_Reason} ->
-                    continue(State#state{modstate=NewModState})
-            end
+            NewState = start_handoff(HOType, TargetIdx, TargetNode, State),
+            continue(NewState#state{modstate=NewModState})
     end.
+
+
+start_handoff(HOType, TargetIdx, TargetNode, State=#state{index=Idx,mod=Mod}) ->
+    case riak_core_handoff_manager:add_outbound(HOType,Mod,Idx,TargetIdx,TargetNode,self()) of
+        {ok, Pid} ->
+            State#state{handoff_pid=Pid,
+                        handoff_type=HOType,
+                        handoff_target={TargetIdx, TargetNode}};
+        {error,_Reason} ->
+            State
+    end.
+
 
 
 %% @doc Send a reply to a vnode request.  If

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -291,6 +291,8 @@ forward_or_vnode_command(Sender, Request, State=#state{forward=Forward,
             end
     end.
 
+vnode_command(_Sender, _Request, State=#state{modstate={deleted,_}}) ->
+    continue(State);
 vnode_command(Sender, Request, State=#state{mod=Mod,
                                             modstate=ModState,
                                             pool_pid=Pool}) ->

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -504,7 +504,7 @@ mark_handoff_complete(SrcIdx, Target, SeenIdxs, Mod, resize_transfer) ->
                                                                                    Source,
                                                                                    SeenIdx)
                                    end,
-                               Ring2 = lists:foldl(F, Ring, SeenIdxs),
+                               Ring2 = lists:foldl(F, Ring, ordsets:to_list(SeenIdxs)),
                                Ring3 = riak_core_ring:resize_transfer_complete(Ring2,
                                                                                Source,
                                                                                Target,

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -480,7 +480,8 @@ mark_handoff_complete(SrcIdx, Target, SeenIdxs, Mod, resize_transfer) ->
                                                                                Source,
                                                                                Target,
                                                                                Mod),
-                               {new_ring, Ring3};
+                               %% local ring optimization (see below)
+                               {set_only, Ring3};
                            _ ->
                                ignore
                        end
@@ -594,10 +595,12 @@ mark_delete_complete(Idx, Mod) ->
                        case {Type, Next, Status} of
                            {resized_primary, '$delete', awaiting} ->
                                Ring3 = riak_core_ring:deletion_complete(Ring, Idx, Mod),
-                               {new_ring, Ring3};
+                               %% Use local ring optimization like mark_handoff_complete
+                               {set_only, Ring3};
                            {{fallback, _}, '$delete', awaiting} ->
                                Ring3 = riak_core_ring:deletion_complete(Ring, Idx, Mod),
-                               {new_ring, Ring3};
+                               %% Use local ring optimization like mark_handoff_complete
+                               {set_only, Ring3};
                            _ ->
                                ignore
                        end

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -592,6 +592,9 @@ mark_delete_complete(Idx, Mod) ->
                        Type = riak_core_ring:vnode_type(Ring, Idx),
                        {_, Next, Status} = riak_core_ring:next_owner(Ring, Idx),
                        case {Type, Next, Status} of
+                           {resized_primary, '$delete', awaiting} ->
+                               Ring3 = riak_core_ring:deletion_complete(Ring, Idx, Mod),
+                               {new_ring, Ring3};
                            {{fallback, _}, '$delete', awaiting} ->
                                Ring3 = riak_core_ring:deletion_complete(Ring, Idx, Mod),
                                {new_ring, Ring3};

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -571,6 +571,8 @@ check_forward(Ring, Mod, Index) ->
         {Node, '$resize', _} ->
             Complete = riak_core_ring:complete_resize_transfers(Ring, {Index, Node}, Mod),
             {{Mod, Index}, Complete};
+        {Node, '$delete', _} ->
+            {{Mod, Index}, undefined};
         {Node, NextOwner, complete} ->
             {{Mod, Index}, NextOwner};
         _ ->
@@ -641,6 +643,11 @@ should_handoff(Ring, Mod, Idx) ->
         %% otherwise, if primary don't handoff
         {primary, _, _} ->
             Target = undefined;
+        %% partitions moved during resize and scheduled for deletion, indexes
+        %% that exist in both the original and resized ring that were moved appear
+        %% as fallbacks.
+        {{fallback, _}, '$delete', _} ->
+            Target = '$delete';
         %% fallback vnode target is primary (For)
         {{fallback, For}, undefined, _} ->
             Target = For;
@@ -651,8 +658,9 @@ should_handoff(Ring, Mod, Idx) ->
     case Target of
         undefined ->
             false;
-        '$resize' ->
-            {true, '$resize'};
+        Action when Action == '$resize' orelse
+                    Action == '$delete' ->
+            {true, Action};
         TargetNode ->
             case app_for_vnode_module(Mod) of
                 undefined -> false;
@@ -690,6 +698,8 @@ maybe_trigger_handoff(Mod, Idx, Pid, _State=#state{handoff=HO}) ->
                 {TargetIdx, TargetNode} ->
                     riak_core_vnode:trigger_handoff(Pid, TargetIdx, TargetNode)
             end;
+        {ok, '$delete'} ->
+            riak_core_vnode:trigger_delete(Pid);
         {ok, TargetNode} ->
             riak_core_vnode:trigger_handoff(Pid, TargetNode),
             ok;

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -648,6 +648,10 @@ should_handoff(Ring, Mod, Idx) ->
         %% as fallbacks.
         {{fallback, _}, '$delete', _} ->
             Target = '$delete';
+        %% partitions that no longer exist after the ring has been resized (shrunk)
+        %% scheduled for deletion
+        {resized_primary, '$delete', _} ->
+            Target = '$delete';
         %% fallback vnode target is primary (For)
         {{fallback, For}, undefined, _} ->
             Target = For;

--- a/test/riak_core_ring_eqc.erl
+++ b/test/riak_core_ring_eqc.erl
@@ -1,0 +1,128 @@
+%% -------------------------------------------------------------------
+%%
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_core_ring_eqc).
+
+-ifdef(EQC).
+-export([prop_future_index/0]).
+
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(TEST_ITERATIONS, 10000).
+-define(QC_OUT(P),
+        eqc:on_output(fun(Str, Args) -> io:format(user, Str, Args) end, P)).
+
+
+eqc_test_() ->
+    {inparallel,
+     [{spawn,
+       [{setup,
+         fun() -> ok end,
+         fun(_) -> ok end,
+         [
+          %% Run the quickcheck tests
+          {timeout, 60000, % timeout is in msec
+           %% Indicate the number of test iterations for each property here
+           ?_assertEqual(true,
+                         quickcheck(numtests(?TEST_ITERATIONS,
+                                             ?QC_OUT(prop_future_index()))))
+          }]}]}]}.
+
+
+
+prop_future_index() ->
+    ?FORALL({CHashKey, OrigIdx, TargetIdx, N, Pos, Ring}=TransferItem, resize_item(),
+            ?WHENFAIL(prop_future_index_failed(TransferItem),
+                      collect(N =/= undefined andalso Pos >= N,
+                              begin
+                                  {Time, Val} = timer:tc(riak_core_ring, future_index,
+                                                         [CHashKey, OrigIdx, N, Ring]),
+                                  measure(future_index_usec, Time, TargetIdx =:= Val)
+                              end))).
+
+resize_item() ->
+    %% RingSize - Starting Ring Size
+    %% GrowthFactor - >1 expanding, <1 shrinking
+    %% IndexStart - first partition in preflist for key
+    %% Pos - position of source partition in preflist
+    %% N - optional known N-value for the key
+    ?LET({RingSize, GrowthF},
+         {current_size(), growth_factor()},
+         ?LET({IndexStart, Pos, N},
+              {index_in_current_ring(RingSize),
+               replica_position(RingSize),
+               check_nval(RingSize, GrowthF)},
+              begin
+                  Ring0 = riak_core_ring:fresh(RingSize, node()),
+                  Ring1 = riak_core_ring:resize(Ring0,trunc(GrowthF * RingSize)),
+                  Ring = riak_core_ring:set_pending_resize(Ring1, Ring0),
+                  CHashKey = <<(IndexStart-1):160/integer>>,
+                  Preflist = riak_core_ring:preflist(CHashKey, Ring0),
+                  FuturePreflist = riak_core_ring:preflist(CHashKey, Ring1),
+                  {SourceIdx, _} = lists:nth(Pos+1, Preflist),
+
+                  %% account for case where position is greater than
+                  %% future ring size or possbly known N-value
+                  %% (shrinking) we shouldn't have a target index in
+                  %% that case since a transfer to it would be invalid
+                  case Pos >= riak_core_ring:num_partitions(Ring1) orelse
+                      (N =/= undefined andalso Pos >= N) of
+                      true -> TargetIdx = undefined;
+                      false -> {TargetIdx, _} = lists:nth(Pos+1, FuturePreflist)
+                  end,
+                  {CHashKey, SourceIdx, TargetIdx, N, Pos, Ring}
+              end)).
+
+index_in_current_ring(RingSize) ->
+    elements([I || {I,_} <- riak_core_ring:all_owners(riak_core_ring:fresh(RingSize, node()))]).
+
+current_size() ->
+    elements([16, 32, 64, 128]).
+
+growth_factor() ->
+    oneof([0.25, 0.5, 2, 4]).
+
+
+replica_position(RingSize) ->
+    %% use a max position that could be invalid for shrinking (greater than future size)
+    %% purposefully to generate negative cases
+    Max = RingSize,
+    choose(0, (Max - 1)).
+
+check_nval(RingSize, GrowthF) ->
+    case GrowthF > 1 of
+        %% while expanding the n-value doesn't matter
+        true -> undefined;
+        %% while shrinking provide a "realistic" n-value of the key
+        false -> choose(1, trunc((RingSize * GrowthF) / 2) - 1)
+    end.
+
+
+prop_future_index_failed({CHashKey, OrigIdx, TargetIdx, NValCheck, _, R}) ->
+    <<CHashInt:160/integer>> = CHashKey,
+    FoundTarget = riak_core_ring:future_index(CHashKey, OrigIdx, NValCheck, R),
+    io:format("key: ~p~nsource: ~p~ncurrsize: ~p~nfuturesize: ~p~nexpected: ~p~nactual: ~p~n",
+              [CHashInt, OrigIdx,
+               riak_core_ring:num_partitions(R), riak_core_ring:future_num_partitions(R),
+               TargetIdx, FoundTarget]).
+
+-endif.


### PR DESCRIPTION
Ring Resizing enables `riak_core` applications to change the number of partitions (running vnodes) during normal operations, under load. Previously, a cluster was limited to always having `ring_creation_size` partitions. In order to change the number of partitions, a seperate cluster would need to be stood up along side the original and the data would be migrated between the two by external means.

The intended purpose of this feature is to support users who create a cluster with either too few or two many partitions and have a need to change this without all the hassle mentioned above. It _is not intended_ as a scaling feature for clusters to add or remove concurrent processing ability. Riak already has support for that via adding/removing nodes. However, since the number of partitions ultimately limits the number of nodes in the cluster,  ring resizing can be used to increase capacity in that regard. In short, the feature is intended for infrequent use in specific scenarios.

This feature is a work-in-progress that will undergo several more iterations. Some details on that work as well as issues with the current implementation are discussed below.

**For a more detailed description of the implemention see [here](https://github.com/basho/riak_core/blob/jrw-dynamic-ring/docs/ring-resizing.md).**
## Goals

Besides the obvious goal that the cluster should safely transition between the old and new rings -- ensuring requests for unmodified keys return the same data and new writes are reflected in bolth rings. The implemention was designed with the following goals in mind:
- During the operation requests for existing keys should not return `not_found`
- The minimum number of transfers to ensure safety should be made
- ~~The implementation should be ignorant of the N values used to store keys in Riak~~ The implementation should be as ignorant as possible of the N values used to store keys in riak
- The operation should be cancelable and support forceful replacement of nodes in the case that SHTF
## The Rest of the Story

There are some caveats and future work that are worth mentioning here.
- **Rehashing**: When the ring expands some existing partitions are not moved to new owners. In this case none of their data is removed. In the future, a "rehashing" operation will be submitted during the cleanup cycle that removes keys no longer owned by these existing partitions. 
- **Repl**: replication does not support clusters of different ring sizes. The only available approach that currently works is to disable realtime until bolth cluster have been resized and then restablish the repl link, at which point a full-sync will probably be necessary.
- **Perf. Improvements**: ~~There is a known optimization for how to determine if keys should be transferred that is not included here because it still has some kinks to work out. Performance improvements are also expected thanks to the many improvements coming to handoff/gossip in general.~~ Different optimization now included see [1] for microbenchmark. 
- **Memory & Storage Considerations**: Like the old method of resizing (using two clusters), to safely transition to the new ring, in the worst possible case, the entire data set is copied (an ugly consequence of not cleaning up data until the new ring is installed). Clusters should have the available disk space (& memory if using bitcask) to account for this.

[1] https://gist.github.com/jrwest/4940f009b2adb928ef59
