### PR TITLE
Support for `plan/2` and `process_results/3` funs for coverage fsm

### DIFF
--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -306,7 +306,4 @@ exports(Function, Exports) ->
     proplists:is_defined(Function, Exports).
 
 exports_arity(Function, Arity, Exports) ->
-    case proplists:get_all_values(Function, Exports) of
-        [] -> false;
-        L -> lists:member(Arity, L)
-    end.
+    lists:member(Arity, proplists:get_all_values(Function, Exports)).


### PR DESCRIPTION
Enables 2i pagination.

See https://github.com/basho/riak_kv/pull/535 for more details
