### PR TITLE
Backport issue 300 to 1.3 branch

### DIFF
--- a/src/riak_core_vnode_worker.erl
+++ b/src/riak_core_vnode_worker.erl
@@ -23,7 +23,7 @@
 -export([behaviour_info/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
         code_change/3]).
--export([start_link/1, handle_work/4, handle_work/5]).
+-export([start_link/1, handle_work/3, handle_work/4]).
 
 -record(state, {
         module :: atom(),
@@ -39,24 +39,26 @@ behaviour_info(_Other) ->
 
 start_link(Args) ->
     WorkerMod = proplists:get_value(worker_callback_mod, Args),
-    [VNodeIndex, WorkerArgs, WorkerProps] = proplists:get_value(worker_args, Args),
-    gen_server:start_link(?MODULE, [WorkerMod, VNodeIndex, WorkerArgs, WorkerProps], []).
+    [VNodeIndex, WorkerArgs, WorkerProps, Caller] = proplists:get_value(worker_args, Args),
+    gen_server:start_link(?MODULE, [WorkerMod, VNodeIndex, WorkerArgs, WorkerProps, Caller], []).
 
-handle_work(Worker, Pool, Work, From) ->
-    handle_work(Worker, Pool, Work, From, self()).
+handle_work(Worker, Work, From) ->
+    handle_work(Worker, Work, From, self()).
 
-handle_work(Worker, Pool, Work, From, Caller) ->
-    gen_server:cast(Worker, {work, Pool, Work, From, Caller}).
+handle_work(Worker, Work, From, Caller) ->
+    gen_server:cast(Worker, {work, Work, From, Caller}).
 
-init([Module, VNodeIndex, WorkerArgs, WorkerProps]) ->
+init([Module, VNodeIndex, WorkerArgs, WorkerProps, Caller]) ->
     {ok, WorkerState} = Module:init_worker(VNodeIndex, WorkerArgs, WorkerProps),
+    %% let the pool queue manager know there might be a worker to checkout
+    gen_fsm:send_all_state_event(Caller, worker_start),
     {ok, #state{module=Module, modstate=WorkerState}}.
 
 handle_call(Event, _From, State) ->
     lager:debug("Vnode worker received synchronous event: ~p.", [Event]),
     {reply, ok, State}.
 
-handle_cast({work, Pool, Work, WorkFrom, Caller},
+handle_cast({work, Work, WorkFrom, Caller},
             #state{module = Mod, modstate = ModState} = State) ->
     NewModState = case Mod:handle_work(Work, WorkFrom, ModState) of
         {reply, Reply, NS} ->
@@ -66,7 +68,6 @@ handle_cast({work, Pool, Work, WorkFrom, Caller},
             NS
     end,
     %% check the worker back into the pool
-    poolboy:checkin(Pool, self()),
     gen_fsm:send_all_state_event(Caller, {checkin, self()}),
     {noreply, State#state{modstate=NewModState}};
 handle_cast(_Event, State) ->

--- a/src/riak_core_vnode_worker_pool.erl
+++ b/src/riak_core_vnode_worker_pool.erl
@@ -16,6 +16,27 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
+
+%% @doc This is a wrapper around a poolboy pool, that implements a
+%% queue. That is, this process maintains a queue of work, and checks
+%% workers out of a poolboy pool to consume it.
+%%
+%% The workers it uses send two messages to this process.
+%%
+%% The first message is at startup, the bare atom
+%% `worker_started'. This is a clue to this process that a worker was
+%% just added to the poolboy pool, so a checkout request has a chance
+%% of succeeding. This is most useful after an old worker has exited -
+%% `worker_started' is a trigger guaranteed to arrive at a time that
+%% will mean an immediate poolboy:checkout will not beat the worker
+%% into the pool.
+%%
+%% The second message is when the worker finishes work it has been
+%% handed, the two-tuple, `{checkin, WorkerPid}'. This message gives
+%% this process the choice of whether to give the worker more work or
+%% check it back into poolboy's pool at this point. Note: the worker
+%% should *never* call poolboy:checkin itself, because that will
+%% confuse (or cause a race) with this module's checkout management.
 -module(riak_core_vnode_worker_pool).
 
 -behaviour(gen_fsm).
@@ -52,7 +73,7 @@ shutdown_pool(Pid, Wait) ->
 
 init([WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps]) ->
     {ok, Pid} = poolboy:start_link([{worker_module, riak_core_vnode_worker},
-            {worker_args, [VNodeIndex, WorkerArgs, WorkerProps]},
+            {worker_args, [VNodeIndex, WorkerArgs, WorkerProps, self()]},
             {worker_callback_mod, WorkerMod},
             {size, PoolSize}, {max_overflow, 0}]),
     {ok, ready, #state{pool=Pid}}.
@@ -66,7 +87,7 @@ ready({work, Work, From} = Msg, #state{pool=Pool, queue=Q, monitors=Monitors} = 
             {next_state, queueing, State#state{queue=queue:in(Msg, Q)}};
         Pid when is_pid(Pid) ->
             NewMonitors = monitor_worker(Pid, From, Work, Monitors),
-            riak_core_vnode_worker:handle_work(Pid, Pool, Work, From),
+            riak_core_vnode_worker:handle_work(Pid, Work, From),
             {next_state, ready, State#state{monitors=NewMonitors}}
     end;
 ready(_Event, State) ->
@@ -90,8 +111,9 @@ shutdown({work, _Work, From}, State) ->
 shutdown(_Event, State) ->
     {next_state, shutdown, State}.
 
-handle_event({checkin, Pid}, shutdown, #state{monitors=Monitors0} = State) ->
+handle_event({checkin, Pid}, shutdown, #state{pool=Pool, monitors=Monitors0} = State) ->
     Monitors = demonitor_worker(Pid, Monitors0),
+    poolboy:checkin(Pool, Pid),
     case Monitors of
         [] -> %% work all done, time to exit!
             {stop, shutdown, State};
@@ -101,19 +123,32 @@ handle_event({checkin, Pid}, shutdown, #state{monitors=Monitors0} = State) ->
 handle_event({checkin, Worker}, _, #state{pool = Pool, queue=Q, monitors=Monitors} = State) ->
     case queue:out(Q) of
         {{value, {work, Work, From}}, Rem} ->
-            case poolboy:checkout(Pool, false) of
-                full ->
-                    {next_state, queueing, State#state{queue=Q,
-                            monitors=Monitors}};
-                Pid when is_pid(Pid) ->
-                    NewMonitors = monitor_worker(Pid, From, Work, Monitors),
-                    riak_core_vnode_worker:handle_work(Pid, Pool, Work, From),
-                    {next_state, queueing, State#state{queue=Rem,
-                            monitors=NewMonitors}}
-            end;
+            %% there is outstanding work to do - instead of checking
+            %% the worker back in, just hand it more work to do
+            NewMonitors = monitor_worker(Worker, From, Work, Monitors),
+            riak_core_vnode_worker:handle_work(Worker, Work, From),
+            {next_state, queueing, State#state{queue=Rem,
+                                               monitors=NewMonitors}};
         {empty, Empty} ->
             NewMonitors = demonitor_worker(Worker, Monitors),
+            poolboy:checkin(Pool, Worker),
             {next_state, ready, State#state{queue=Empty, monitors=NewMonitors}}
+    end;
+handle_event(worker_start, StateName, #state{pool=Pool, queue=Q, monitors=Monitors}=State) ->
+    %% a new worker just started - if we have work pending, try to do it
+    case queue:out(Q) of
+        {{value, {work, Work, From}}, Rem} ->
+            case poolboy:checkout(Pool, false) of
+                full ->
+                    {next_state, queueing, State};
+                Pid when is_pid(Pid) ->
+                    NewMonitors = monitor_worker(Pid, From, Work, Monitors),
+                    riak_core_vnode_worker:handle_work(Pid, Work, From),
+                    {next_state, queueing, State#state{queue=Rem, monitors=NewMonitors}}
+            end;
+        {empty, _} ->
+            %% StateName might be either 'ready' or 'shutdown'
+            {next_state, StateName, State}
     end;
 handle_event(_Event, StateName, State) ->
     {next_state, StateName, State}.
@@ -144,9 +179,9 @@ handle_info({'DOWN', _Ref, _, Pid, Info}, StateName, #state{monitors=Monitors} =
         {Pid, _, From, Work} ->
             riak_core_vnode:reply(From, {error, {worker_crash, Info, Work}}),
             NewMonitors = lists:keydelete(Pid, 1, Monitors),
-            %% pretend a worker just checked in so that any queued work can
-            %% sent to the new worker just started to replace this dead one
-            gen_fsm:send_all_state_event(self(), {checkin, undefined}),
+            %% trigger to do more work will be 'worker_start' message
+            %% when poolboy replaces this worker (if not a 'checkin'
+            %% or 'handle_work')
             {next_state, StateName, State#state{monitors=NewMonitors}};
         false ->
             {next_state, StateName, State}


### PR DESCRIPTION
It was desired to have the riak_core_vnode_worker_pool race from #300 backported to the 1.3 branch. The parent commit containing the regression tests for this race has been elided, since it requires changes to poolboy that are not otherwise required to fix the issue (so there is no need to roll a new poolboy version).

To run the worker pool test against this branch, also cherry-pick commit 7a60b6e onto this branch. Then follow the instructions in #300 (poolboy master now has PULSE annotations).
