### PR TITLE
Enhance transfer display + wrapping nodenames.

### DIFF
--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -316,7 +316,9 @@ print_size({Bytes, bytes}) ->
 
 -define(ARROW, "=======> ").
 
-print_arrowbox(Src0, Target0, Objs, Bytes, Progress) ->
+print_arrowbox(SrcAtom, TargetAtom, Objs, Bytes, Progress) ->
+    Src0 = atom_to_list(SrcAtom),
+    Target0 = atom_to_list(TargetAtom),
     {SCont1, SCont2} = wrap(Src0),
     {TCont1, TCont2} = wrap(Target0),
 


### PR DESCRIPTION
pretty up transfer boxes a little, make nodenames wrap up to 75 characters.

Example output:

```
                           unknown                            
  riak@255.255.255.255     =======>    riak@244.244.244.244   
        |                                           |   0%    
                           unknown                            

                           unknown                            
riak1234567890@255.255.25  =======>    riak@244.244.244.244   
5.255                                                         
        |============                               |  30%    
                           unknown                            

                           unknown                            
  riak@255.255.255.255     =======>  riak@1234567890244.244.24
                                     4.244                    
        |=====================                      |  50%    
                           unknown                            

                            unknown                            
riak123456789012345678901  =======>    riak@244.244.244.244   
234567890@255.255.255.255                                     
        |================================           |  75%    
                           unknown                            

                           unknown                            
riak123456789012345678901  =======>  riak123456789012345678901
234567890123456789012345@            234567890123456789012345@
255.255.255.255                      244.244.244.244          
        |===========================================| 100%    
                           unknown                            

```
