### PR TITLE
format _stat_ts in connection manager

### DIFF
--- a/src/riak_core_connection_mgr_stats.erl
+++ b/src/riak_core_connection_mgr_stats.erl
@@ -126,7 +126,18 @@ format_stat({{?APP, StatName, Addr, ProtocolId, total},N}) when is_atom(Protocol
 format_stat({{?APP, StatName, Addr, ProtocolId},[{count,N},{one,_W}]}) when is_atom(ProtocolId) ->
     {string_of_ipaddr(Addr)
      ++ "_" ++ atom_to_list(ProtocolId) 
-     ++ "_" ++ atom_to_list(StatName), N}.
+     ++ "_" ++ atom_to_list(StatName), N};
+format_stat({riak_conn_mgr_stats_stat_ts, S}) ->
+    UnivTime = riak_core_format:epoch_to_datetime(S),
+    {{Year, Month, Day}, {Hour, Min, Sec}} = calendar:universal_time_to_local_time(UnivTime),
+    Fmt = riak_core_format:fmt("~4..0B-~2..0B-~2..0B ~2..0B:~2..0B:~2..0B",
+                         [Year, Month, Day, Hour, Min, Sec]),
+    {"riak_conn_mgr_stats_stat_ts", Fmt};
+format_stat({StateName, N}) ->
+    {atom_to_list(StateName), N};
+format_stat(_) ->
+    [].
+
 
 string_of_ipaddr({IP, Port}) when is_list(IP) ->
     lists:flatten(io_lib:format("~s:~p", [IP, Port]));

--- a/src/riak_core_format.erl
+++ b/src/riak_core_format.erl
@@ -23,7 +23,8 @@
 -module(riak_core_format).
 -export([fmt/2,
          human_size_fmt/2,
-         human_time_fmt/2]).
+         human_time_fmt/2,
+         epoch_to_datetime/1]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -51,6 +52,13 @@ human_time_fmt(Fmt, Micros) ->
     Fmt2 = Fmt ++ " ~s",
     {Value, Units} = human_time(Micros),
     fmt(Fmt2, [Value, Units]).
+
+%% @doc Convert a folsom_utils:now_epoch() to a universal datetime
+-spec epoch_to_datetime(non_neg_integer()) -> calendar:datetime().
+epoch_to_datetime(S) ->
+    Epoch = {{1970,1,1},{0,0,0}},
+    Seconds = calendar:datetime_to_gregorian_seconds(Epoch) + S,
+    calendar:gregorian_seconds_to_datetime(Seconds).
 
 %%%===================================================================
 %%% Private


### PR DESCRIPTION
see https://github.com/basho/riak_core/issues/309

You can see the output with `riak-repl clusterstats` from a devrel without any additional repl configuration.

I considered changing the _stat_ts value to a moment(), however I decided on leaving the value as a folsom_utils:now_epoch() as it was already available in 1.3.
