### PR TITLE
Implement vnode overload protection

### DIFF
--- a/src/riak_core_stat.erl
+++ b/src/riak_core_stat.erl
@@ -106,6 +106,9 @@ update1(gossip_received) ->
 update1(rings_reconciled) ->
     folsom_metrics:notify_existing_metric({?APP, rings_reconciled}, 1, spiral);
 
+update1(dropped_vnode_requests) ->
+    folsom_metrics:notify_existing_metric({?APP, dropped_vnode_requests_total}, {inc, 1}, counter);
+
 update1(converge_timer_begin) ->
     folsom_metrics:notify_existing_metric({?APP, converge_delay}, timer_start, duration);
 update1(converge_timer_end) ->
@@ -123,6 +126,7 @@ stats() ->
      {gossip_received, spiral},
      {rejected_handoffs, counter},
      {handoff_timeouts, counter},
+     {dropped_vnode_requests_total, counter},
      {converge_delay, duration},
      {rebalance_delay, duration}].
 

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -514,6 +514,9 @@ handle_sync_event(core_status, _From, StateName, State=#state{index=Index,
         end,
     {reply, {Mode, Status}, StateName, State, State#state.inactivity_timeout}.
 
+handle_info({'$vnode_proxy_ping', From, Msgs}, StateName, State) ->
+    riak_core_vnode_proxy:cast(From, {vnode_proxy_pong, self(), Msgs}),
+    {next_state, StateName, State, State#state.inactivity_timeout};
 
 handle_info({'EXIT', Pid, Reason},
             _StateName,

--- a/src/riak_core_vnode_proxy.erl
+++ b/src/riak_core_vnode_proxy.erl
@@ -21,14 +21,26 @@
          unregister_vnode/3, command_return_vnode/2]).
 -export([system_continue/3, system_terminate/4, system_code_change/4]).
 
--record(state, {mod, index, vnode_pid, vnode_mref, check_interval,
-                check_threshold, check_counter=0, check_mailbox=0}).
-
 -include("riak_core_vnode.hrl").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
+
+-record(state, {mod                    :: atom(),
+                index                  :: partition(),
+                vnode_pid              :: pid(),
+                vnode_mref             :: reference(),
+                check_mailbox          :: non_neg_integer(),
+                check_threshold        :: pos_integer() | undefined,
+                check_counter          :: non_neg_integer(),
+                check_interval         :: pos_integer(),
+                check_request_interval :: non_neg_integer(),
+                check_request          :: undefined | sent | ignore
+               }).
+
+-define(DEFAULT_CHECK_INTERVAL, 5000).
+-define(DEFAULT_OVERLOAD_THRESHOLD, 10000).
 
 reg_name(Mod, Index) ->
     ModBin = atom_to_binary(Mod, latin1),
@@ -46,8 +58,43 @@ start_link(Mod, Index) ->
 init([Parent, RegName, Mod, Index]) ->
     erlang:register(RegName, self()),
     proc_lib:init_ack(Parent, {ok, self()}),
-    State = #state{mod=Mod, index=Index, check_interval=5000,
-                   check_threshold=10000},
+
+    Interval = app_helper:get_env(riak_core,
+                                  vnode_check_interval,
+                                  ?DEFAULT_CHECK_INTERVAL),
+    RequestInterval = app_helper:get_env(riak_core,
+                                         vnode_check_request_interval,
+                                         Interval div 2),
+    Threshold = app_helper:get_env(riak_core,
+                                   vnode_overload_threshold,
+                                   ?DEFAULT_OVERLOAD_THRESHOLD),
+
+    SafeInterval =
+        case (Threshold == undefined) orelse (Interval < Threshold) of
+            true ->
+                Interval;
+            false ->
+                lager:warning("Setting riak_core/vnode_check_interval to ~b",
+                              [Threshold div 2]),
+                Threshold div 2
+        end,
+    SafeRequestInterval =
+        case RequestInterval < SafeInterval of
+            true ->
+                RequestInterval;
+            false ->
+                lager:warning("Setting riak_core/vnode_check_request_interval "
+                              "to ~b", [SafeInterval div 2]),
+                SafeInterval div 2
+        end,
+
+    State = #state{mod=Mod,
+                   index=Index,
+                   check_mailbox=0,
+                   check_counter=0,
+                   check_threshold=Threshold,
+                   check_interval=SafeInterval,
+                   check_request_interval=SafeRequestInterval},
     loop(Parent, State).
 
 unregister_vnode(Mod, Index, Pid) ->
@@ -94,14 +141,12 @@ loop(Parent, State) ->
             {noreply, NewState} = handle_cast(Msg, State),
             loop(Parent, NewState);
         {'DOWN', _Mref, process, _Pid, _} ->
-            NewState = State#state{vnode_pid=undefined, vnode_mref=undefined},
+            NewState = forget_vnode(State),
             loop(Parent, NewState);
         {system, From, Msg} ->
             sys:handle_system_msg(Msg, From, Parent, ?MODULE, [], State);
         Msg ->
-            {noreply, NewState} = handle_proxy(Msg,
-                                               State#state{check_counter=State#state.check_counter+1,
-                                                           check_mailbox=State#state.check_mailbox+1}),
+            {noreply, NewState} = handle_proxy(Msg, State),
             loop(Parent, NewState)
     end.
 
@@ -120,40 +165,128 @@ handle_cast({unregister_vnode, Pid}, State) ->
     %% unregister event anyway -- the vnode manager requires it.
     gen_fsm:send_event(Pid, unregistered),
     catch demonitor(State#state.vnode_mref, [flush]),
-    NewState = State#state{vnode_pid=undefined, vnode_mref=undefined},
+    NewState = forget_vnode(State),
     {noreply, NewState};
+handle_cast({vnode_proxy_pong, Pid, Msgs}, State=#state{vnode_pid=VNodePid,
+                                                        check_request=RequestState,
+                                                        check_mailbox=Mailbox}) ->
+    ValidReply = (Pid =:= VNodePid) and (RequestState =:= sent),
+    NewState = case ValidReply of
+                   true ->
+                       State#state{check_mailbox=Mailbox - Msgs,
+                                   check_request=undefined,
+                                   check_counter=0};
+                   _ ->
+                       State#state{check_request=undefined}
+               end,
+    {noreply, NewState};
+
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
 %% @private
-handle_proxy(Msg, State) ->
-    #state{check_counter=Counter, check_interval=Interval,
-           check_threshold=Threshold, check_mailbox=Mailbox0, mod=Mod} = State,
+handle_proxy(Msg, State=#state{check_threshold=undefined}) ->
     {Pid, NewState} = get_vnode_pid(State),
-    {Mailbox, NewCounter} = case Counter >= Interval andalso (Counter rem Interval) == 0 of
-                                true ->
-                                    %% time to check the mailbox size
-                                    {message_queue_len, L} =
-                                        erlang:process_info(Pid, message_queue_len),
-                                    lager:debug("reset mailbox to ~p", [L]),
-                                    {L, 0};
-                                false ->
-                                    {Mailbox0, Counter}
-                            end,
+    Pid ! Msg,
+    {noreply, NewState};
+handle_proxy(Msg, State=#state{check_counter=Counter,
+                               check_mailbox=Mailbox,
+                               check_interval=Interval,
+                               check_request_interval=RequestInterval,
+                               check_request=RequestState,
+                               check_threshold=Threshold}) ->
+    %%
+    %% NOTE: This function is intentionally written as it is for performance
+    %%       reasons -- the vnode proxy is on the critical path of Riak and
+    %%       must be fast enough to shed already queued work even under
+    %%       extreme overload conditions. Things that are intentional: the
+    %%       use of a monolithic function rather than separate smaller
+    %%       functions; exporting values from case statements rather than
+    %%       generating + pattern matching on intermediary tuples; and
+    %%       updating State once at the very end of the function to ensure
+    %%       that State is only copied once rather than multiple times.
+    %%
+    %%       When changing this function, please run:
+    %%         erts_debug:df(riak_core_vnode_proxy)
+    %%       and look over the generated riak_core_vnode_proxy.dis file to
+    %%       ensure unnecessary work is not being performed needlessly.
+    %%
+    case State#state.vnode_pid of
+        undefined ->
+            {Pid, State2} = get_vnode_pid(State);
+        KnownPid ->
+            Pid = KnownPid,
+            State2 = State
+    end,
 
-    case Mailbox < Threshold of
+    Counter2 = Counter + 1,
+    case Counter2 of
+        RequestInterval ->
+            %% Ping the vnode in hopes that we get a pong back before hitting
+            %% the hard query interval and triggering an expensive process_info
+            %% call. A successful pong from the vnode means that all messages
+            %% sent before the ping have already been handled and therefore
+            %% we can adjust our mailbox estimate accordingly.
+            case RequestState of
+                undefined ->
+                    Pid ! {'$vnode_proxy_ping', self(), Mailbox + 1},
+                    RequestState2 = sent,
+                    Mailbox2 = Mailbox + 2;
+                _ ->
+                    Mailbox2 = Mailbox + 1,
+                    RequestState2 = RequestState
+            end,
+            Counter3 = Counter2;
+        Interval ->
+            %% Time to directly check the mailbox size. This operation may
+            %% be extremely expensive. If the vnode is currently active,
+            %% the proxy will be descheduled until the vnode finishes
+            %% execution and becomes descheduled itself.
+            {_, L} =
+                erlang:process_info(Pid, message_queue_len),
+            Counter3 = 0,
+            Mailbox2 = L,
+            RequestState2 = case RequestState of
+                                sent ->
+                                    %% Ignore pending ping response as it is
+                                    %% no longer valid nor useful.
+                                    ignore;
+                                _ ->
+                                    RequestState
+                            end;
+        _ ->
+            Counter3 = Counter2,
+            Mailbox2 = Mailbox + 1,
+            RequestState2 = RequestState
+    end,
+
+    case Mailbox2 =< Threshold of
         true ->
             Pid ! Msg;
         false ->
-            case Msg of
-                {'$gen_event', ?VNODE_REQ{sender=Sender, request=Request}} ->
-                    catch(Mod:handle_overload_command(Request, Sender,
-                                                      State#state.index));
-                _ ->
-                    ok
-            end
+            handle_overload(Msg, State)
     end,
-    {noreply, NewState#state{check_mailbox=Mailbox, check_counter=NewCounter}}.
+
+    {noreply, State2#state{check_counter=Counter3,
+                           check_mailbox=Mailbox2,
+                           check_request=RequestState2}}.
+
+handle_overload(Msg, #state{mod=Mod, index=Index}) ->
+    riak_core_stat:update(dropped_vnode_requests),
+    case Msg of
+        {'$gen_event', ?VNODE_REQ{sender=Sender, request=Request}} ->
+            catch(Mod:handle_overload_command(Request, Sender, Index));
+        _ ->
+            ok
+    end.
+
+%% @private
+forget_vnode(State) ->
+    State#state{vnode_pid=undefined,
+                vnode_mref=undefined,
+                check_mailbox=0,
+                check_counter=0,
+                check_request=undefined}.
 
 %% @private
 get_vnode_pid(State=#state{mod=Mod, index=Index, vnode_pid=undefined}) ->
@@ -231,7 +364,8 @@ overload_test_() ->
                        VnodePid ! {get_count, self()},
                        receive
                            {count, Count} ->
-                               ?assertEqual(50000, Count)
+                               %% 50000 messages + 1 unanswered vnode_proxy_ping
+                               ?assertEqual(50001, Count)
                        end
                end
               }
@@ -248,7 +382,8 @@ overload_test_() ->
                        VnodePid ! {get_count, self()},
                        receive
                            {count, Count} ->
-                               ?assertEqual(10000, Count)
+                               %% Threshold + 1 unanswered vnode_proxy_ping
+                               ?assertEqual(?DEFAULT_OVERLOAD_THRESHOLD + 1, Count)
                        end
                end
               }
@@ -265,7 +400,8 @@ overload_test_() ->
                        %% reasonable
                        {message_queue_len, L} =
                            erlang:process_info(VnodePid, message_queue_len),
-                       ?assert(L =< 10000)
+                       %% Threshold + 1 unanswered vnode_proxy_ping
+                       ?assert(L =< (?DEFAULT_OVERLOAD_THRESHOLD + 1))
                end
               }
       end


### PR DESCRIPTION
This pull-request provides overload protection for vnodes, limiting the size of a given vnode's mailbox and dropping message if the limit is reached. The overload logic is implemented by the vnode proxy, which decides to either forward the message to the relevant vnode or drop the message -- potentially informing a waiting `riak_client` about the overload condition.

Every time the proxy process sends a message to the vnode, it increments a counter that estimates the size of the vnode's mailbox. If the counter hits the limit, messages are dropped. This limit is configured via `riak_core/vnode_overload_threshold` setting. This estimated mailbox size is periodically adjusted to make it match the actual mailbox size.

After sending a configurable number of messages (determined by `riak_core/vnode_check_request_interval`), the proxy will send a ping message to the vnode. Whenever a pong arrives, the proxy knows all messages sent before the ping have been handled and can adjust the estimate accordingly. In the common case, this ping/pong approach keeps the mailbox estimate up-to-date without ever falling back to the more expensive approach described below.

After sending even more messages (determined by `riak_core/vnode_check_interval`), the proxy will directly query the size of the vnode's mailbox using `process_info`. This call is potentially expensive. If the vnode is currently running, the proxy will be suspended until the vnode is descheduled.

This pull-request also provides the `dropped_vnode_requests_total` stat, which is incremented anytime a request is dropped.

I will edit this pull-request with a link to the relevant riak_test for this work, which also tests the the related FSM overload protection feature. As well as add benchmark results.

This pull-request requires related basho/riak_kv#547
