### PR TITLE
Permanently disable legacy gossip

### DIFF
--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -81,7 +81,7 @@ join(false, _, Node, Rejoin, Auto) ->
         pang ->
             {error, not_reachable};
         pong ->
-            case rpc:call(Node, riak_core_gossip, legacy_gossip, []) of
+            case false of
                 true ->
                     legacy_join(Node);
                 _ ->


### PR DESCRIPTION
This commit hardcodes all checks for legacy gossip to return false. This is the first step towards removing legacy gossip from riak_core entirely. A future commit will completely remove all relevant code as well as adjust the callsites that currently still call into these now hardcoded functions.
