### PR TITLE
Coverage plan nif

### DIFF
--- a/c_src/riak_core_coverage_plan.c
+++ b/c_src/riak_core_coverage_plan.c
@@ -1,0 +1,225 @@
+#define __STDC_FORMAT_MACROS
+#include <erl_nif.h>
+#include <string.h>
+#include <stdio.h>
+#include <inttypes.h>
+
+#define OK 1
+#define ERR 0
+#define BASE 64
+#define EMPTY_SET 0
+
+struct state {
+  unsigned int offset;
+  unsigned int nval;
+};
+
+typedef unsigned char vnode_t;
+typedef struct state state_t;
+
+static int load(ErlNifEnv* env, void** priv, ERL_NIF_TERM load_info)
+{
+    return 0;
+}
+
+/* Bitmask arithmetics */
+static uint64_t intersect(const uint64_t bm1, const uint64_t bm2)
+{
+    return bm1 & bm2;
+}
+
+static uint64_t subtract(const uint64_t bm1, const uint64_t bm2)
+{
+    return (bm1 ^ bm2) & bm1;
+}
+
+static uint64_t singleton(vnode_t vnode)
+{
+    return (uint64_t) 1 << vnode;
+}
+
+static vnode_t vnode_by_tie_breaker(unsigned int tie_breaker, state_t *state)
+{
+    return (tie_breaker - state->offset) & (BASE - 1);
+}
+
+static unsigned int covers(uint64_t key_spaces,
+			   vnode_t vnode,
+			   state_t *state)
+{
+    int nval = state->nval;
+    int pos;
+    uint64_t flag;
+    unsigned int cover_num = 0;
+
+    while (nval > 0) {
+	pos = vnode - nval;
+	if (pos > 0)
+	    flag = (uint64_t) 1 << pos;
+	else
+	    flag = (uint64_t) 1 << (BASE + pos);
+
+	if (intersect(flag, key_spaces) != EMPTY_SET)
+	    cover_num++;
+
+	nval--;
+    }
+
+    return cover_num;
+}
+
+static void next_node(uint64_t key_spaces,
+		      uint64_t vnodes,
+		      state_t *state,
+		      vnode_t *max_vnode,
+		      unsigned int *max_cover_num)
+{
+    vnode_t vnode;
+    unsigned int cover_num;
+    unsigned int tie_breaker = 0;
+    *max_vnode = 0;
+    *max_cover_num = 0;
+
+    while (tie_breaker < BASE) {
+	vnode = vnode_by_tie_breaker(tie_breaker, state);
+	if (intersect(vnodes, singleton(vnode)) != EMPTY_SET) {
+	    cover_num = covers(key_spaces, vnode, state);
+	    if (cover_num == state->nval) {
+		*max_vnode = vnode;
+		*max_cover_num = cover_num;
+		break;
+	    } else if (cover_num > *max_cover_num) {
+		*max_vnode = vnode;
+		*max_cover_num = cover_num;
+	    }
+	};
+	tie_breaker++;
+    }
+}
+
+static uint64_t n_keyspaces(vnode_t vnode, state_t *state)
+{
+    int shift = vnode - state->nval;
+    uint64_t bm = ((uint64_t) 1 << state->nval) - 1;
+    if (shift > 0)
+	return (bm << shift) | (bm >> (BASE - shift));
+    else
+	return (bm << (BASE+shift)) | (bm >> -shift);
+}
+
+static ERL_NIF_TERM bitmask_to_list(ErlNifEnv* env, uint64_t bm)
+{
+    ERL_NIF_TERM tail = enif_make_list(env, 0);
+    int i;
+
+    for (i=BASE-1; i>=0; i--) {
+	if (bm & ((uint64_t) 1 << i)) {
+	    tail = enif_make_list_cell(env, enif_make_uint(env, i), tail);
+	}
+    }
+    
+    return tail;
+}
+
+static ERL_NIF_TERM coverage_to_list(ErlNifEnv* env, uint64_t coverage[BASE])
+{
+    ERL_NIF_TERM tail = enif_make_list(env, 0);
+    ERL_NIF_TERM tuple;
+    
+    int i;
+    
+    for (i = BASE-1; i >= 0; i--) {
+	if (coverage[i] != 0) {
+	    tuple = enif_make_tuple2(env, enif_make_uint(env, i),
+				     bitmask_to_list(env, coverage[i]));
+	    tail = enif_make_list_cell(env, tuple, tail);
+	}
+    }
+
+    return tail;
+}
+
+static ERL_NIF_TERM find_coverage_vnodes(ErlNifEnv* env,
+					 uint64_t key_spaces,
+					 uint64_t available_key_spaces,
+					 state_t *state,
+					 uint64_t coverage[BASE])
+{
+    vnode_t vnode;
+    unsigned int cover_num;
+    uint64_t covers;
+
+    while (1) {
+	if (key_spaces == EMPTY_SET) {
+	    return enif_make_tuple2(env, enif_make_atom(env, "ok"),
+				    coverage_to_list(env, coverage));
+	} else if (available_key_spaces == EMPTY_SET) {
+	    return enif_make_tuple3(env,
+				    enif_make_atom(env, "insufficient_vnodes_available"),
+				    bitmask_to_list(env, key_spaces),
+				    coverage_to_list(env, coverage));
+	} else {
+	    next_node(key_spaces, available_key_spaces, state, &vnode, &cover_num);
+	    if (cover_num == 0) {
+		/* out of vnodes */
+		available_key_spaces = EMPTY_SET;
+	    } else {
+		covers = n_keyspaces(vnode, state);
+		available_key_spaces = subtract(available_key_spaces, singleton(vnode));
+		coverage[vnode] = intersect(key_spaces, covers);
+		key_spaces = subtract(key_spaces, covers);
+	    }
+	}
+    }
+}
+
+static int list_to_bitmask(ErlNifEnv* env, ERL_NIF_TERM list, uint64_t *bm)
+{
+    ERL_NIF_TERM head, tail;
+    unsigned int vnode;
+    *bm = 0;
+
+    while (enif_get_list_cell(env, list, &head, &tail)) {
+	if (enif_get_uint(env, head, &vnode))
+	    *bm = *bm | ((uint64_t) 1 << vnode);
+	else
+	    return ERR;
+	list = tail;
+    }
+
+    return OK;
+}
+
+static ERL_NIF_TERM find_coverage(ErlNifEnv* env, int argc,
+				  const ERL_NIF_TERM argv[])
+{
+    uint64_t unavailable_key_spaces;
+    uint64_t all_key_spaces;
+    uint64_t vnodes;
+    uint64_t coverage[BASE] = {0};
+    state_t state;
+
+    if (argc == 3) {
+	if (enif_get_uint(env, argv[0], &state.offset) &&
+	    enif_get_uint(env, argv[1], &state.nval) &&
+	    enif_is_list(env, argv[2]) &&
+	    list_to_bitmask(env, argv[2], &unavailable_key_spaces))
+	    {
+		all_key_spaces = UINT64_MAX;
+		vnodes = subtract(all_key_spaces, unavailable_key_spaces);
+		return find_coverage_vnodes(env, all_key_spaces,
+					    vnodes, &state, coverage);
+	    } else {
+	    return enif_make_badarg(env);
+	}
+    }
+
+    return enif_make_badarg(env);
+}
+
+static ErlNifFunc nif_funcs[] =
+    {
+	{"find_coverage_fast", 3, find_coverage}
+    };
+
+ERL_NIF_INIT(riak_core_coverage_plan, nif_funcs, load, NULL, NULL, NULL)

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_first_files, ["src/gen_nb_server.erl", "src/riak_core_gen_server.erl"]}.
 {cover_enabled, true}.
-{erl_opts, [{parse_transform, lager_transform}, debug_info, export_all]}.
+{erl_opts, [{parse_transform, lager_transform}, debug_info]}.
 {edoc_opts, [{preprocess, true}]}.
 
 {port_env, [{"CFLAGS", "$CFLAGS -g -O2 -Wall"}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,11 @@
 {erl_first_files, ["src/gen_nb_server.erl", "src/riak_core_gen_server.erl"]}.
 {cover_enabled, true}.
-{erl_opts, [{parse_transform, lager_transform}, debug_info]}.
+{erl_opts, [{parse_transform, lager_transform}, debug_info, export_all]}.
 {edoc_opts, [{preprocess, true}]}.
+
+{port_env, [{"CFLAGS", "$CFLAGS -g -O2 -Wall"}]}.
+{port_specs, [{"priv/lib/riak_core_coverage_plan.so",
+	     ["c_src/riak_core_coverage_plan.c"]}]}.
 
 {deps, [
   {lager, "2.0.0", {git, "git://github.com/basho/lager", {tag, "2.0.0"}}},
@@ -12,7 +16,7 @@
   {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon", {branch, "master"}}},
   {webmachine, ".*", {git, "git://github.com/basho/webmachine",
                                 {tag, "64176ef9b"}}},
-  {folsom, ".*", {git, "git://github.com/basho/folsom.git", {tag, "0.7.4p1"}}},
+  {folsom, ".*", {git, "git://github.com/boundary/folsom.git", {branch, "master"}}},
   {ranch, "0.4.0-p1", {git, "git://github.com/basho/ranch.git", {tag, "0.4.0-p1"}}}
 
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
   {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon", {branch, "master"}}},
   {webmachine, ".*", {git, "git://github.com/basho/webmachine",
                                 {tag, "64176ef9b"}}},
-  {folsom, ".*", {git, "git://github.com/boundary/folsom.git", {branch, "master"}}},
+  {folsom, ".*", {git, "git://github.com/basho/folsom.git", {tag, "0.7.4p1"}}},
   {ranch, "0.4.0-p1", {git, "git://github.com/basho/ranch.git", {tag, "0.4.0-p1"}}}
 
        ]}.

--- a/src/riak_core_coverage_plan.erl
+++ b/src/riak_core_coverage_plan.erl
@@ -138,22 +138,22 @@ load_nif() ->
 %% ====================================================================
 %% @private
 find_coverage(Offset, NVal, PartitionCount, UnavailableKeySpaces, PVC) ->
-    case {lists:min([PVC, NVal]), PartitionCount} of
-        {1, 64} ->
-            find_coverage_fast(Offset, NVal, UnavailableKeySpaces);
-        {Min, _} ->
+    case PartitionCount of
+        64 ->
+            find_coverage_fast(Offset, NVal, UnavailableKeySpaces, PVC);
+        _ ->
             AllKeySpaces = lists:seq(0, PartitionCount - 1),
             find_coverage(AllKeySpaces,
                           Offset,
                           NVal,
                           PartitionCount,
                           UnavailableKeySpaces,
-                          Min,
+                          PVC,
                           [])
     end.
 
 %% @private
-find_coverage_fast(_Offset, _NVal, _UnavailableKeySpaces) ->
+find_coverage_fast(_Offset, _NVal, _UnavailableKeySpaces, _PVC) ->
     erlang:error(nit_not_loaded).
 
 %% @private

--- a/src/riak_core_coverage_plan.erl
+++ b/src/riak_core_coverage_plan.erl
@@ -117,7 +117,7 @@ create_plan(VNodeSelector, NVal, PVC, ReqId, Service) ->
             end
     end.
 
-%% private
+%% @private
 load_nif() ->
     SOPath = case code:priv_dir(riak_core) of
                  {error, _} ->
@@ -154,7 +154,7 @@ find_coverage(Offset, NVal, PartitionCount, UnavailableKeySpaces, PVC) ->
 
 %% @private
 find_coverage_fast(_Offset, _NVal, _UnavailableKeySpaces, _PVC) ->
-    erlang:error(nit_not_loaded).
+    erlang:nif_error(nif_not_loaded).
 
 %% @private
 find_coverage(AllKeySpaces, Offset, NVal, PartitionCount, UnavailableKeySpaces, PVC, []) ->

--- a/src/riak_core_coverage_plan.erl
+++ b/src/riak_core_coverage_plan.erl
@@ -27,7 +27,8 @@
 -module(riak_core_coverage_plan).
 
 %% API
--export([create_plan/5]).
+-export([create_plan/5, load_nif/0]).
+-on_load(load_nif/0).
 
 -type index() :: non_neg_integer().
 -type req_id() :: non_neg_integer().
@@ -68,7 +69,6 @@ create_plan(VNodeSelector, NVal, PVC, ReqId, Service) ->
     Offset = ReqId rem NVal,
 
     RingIndexInc = chash:ring_increment(PartitionCount),
-    AllKeySpaces = lists:seq(0, PartitionCount - 1),
     UnavailableKeySpaces = [(DownVNode div RingIndexInc) || DownVNode <- DownVNodes],
     %% Create function to map coverage keyspaces to
     %% actual VNode indexes and determine which VNode
@@ -96,13 +96,11 @@ create_plan(VNodeSelector, NVal, PVC, ReqId, Service) ->
     %% The offset value serves as a tiebreaker in the
     %% compare_next_vnode function and is used to distribute
     %% work to different sets of VNodes.
-    CoverageResult = find_coverage(AllKeySpaces,
-                                   Offset,
+    CoverageResult = find_coverage(Offset,
                                    NVal,
                                    PartitionCount,
                                    UnavailableKeySpaces,
-                                   lists:min([PVC, NVal]),
-                                   []),
+                                   lists:min([PVC, NVal])),
     case CoverageResult of
         {ok, CoveragePlan} ->
             %% Assemble the data structures required for
@@ -119,9 +117,44 @@ create_plan(VNodeSelector, NVal, PVC, ReqId, Service) ->
             end
     end.
 
+%% private
+load_nif() ->
+    SOPath = case code:priv_dir(riak_core) of
+                 {error, _} ->
+                     filename:join(["priv", "lib"]);
+                 Path ->
+                     filename:join([Path, "lib"])
+             end,
+    case catch erlang:load_nif(
+                 filename:join([SOPath, atom_to_list(?MODULE)]), 0) of
+        ok ->
+            ok;
+        Err ->
+            lager:error("Failed to load NIF ~p: ~p", [?MODULE, Err])
+    end.
+
 %% ====================================================================
 %% Internal functions
 %% ====================================================================
+%% @private
+find_coverage(Offset, NVal, PartitionCount, UnavailableKeySpaces, PVC) ->
+    case {lists:min([PVC, NVal]), PartitionCount} of
+        {1, 64} ->
+            find_coverage_fast(Offset, NVal, UnavailableKeySpaces);
+        {Min, _} ->
+            AllKeySpaces = lists:seq(0, PartitionCount - 1),
+            find_coverage(AllKeySpaces,
+                          Offset,
+                          NVal,
+                          PartitionCount,
+                          UnavailableKeySpaces,
+                          Min,
+                          [])
+    end.
+
+%% @private
+find_coverage_fast(_Offset, _NVal, _UnavailableKeySpaces) ->
+    erlang:error(nit_not_loaded).
 
 %% @private
 find_coverage(AllKeySpaces, Offset, NVal, PartitionCount, UnavailableKeySpaces, PVC, []) ->


### PR DESCRIPTION
I have partially rewritten find_coverage in C using bitarrays (bitmasks), as the original version is slow as hell and consumes 50% of time according to fprof. It is now not a bottle-neck anymore and a node can handle significantly more workload.

NOTE: the code is improved for ring_creation_size = 64 only.
