### PR TITLE
update bad value protection for timer value

### DIFF
--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -199,8 +199,6 @@ maybe_start_timeout_timer(infinity) ->
     ok;
 maybe_start_timeout_timer(Bad) when not is_integer(Bad) ->
     maybe_start_timeout_timer(?DEFAULT_TIMEOUT);
-maybe_start_timeout_timer(undefined) ->
-    maybe_start_timeout_timer(?DEFAULT_TIMEOUT);
 maybe_start_timeout_timer(Timeout) ->
     gen_fsm:start_timer(Timeout, {timer_expired, Timeout}).
 

--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -97,6 +97,8 @@ behaviour_info(callbacks) ->
 behaviour_info(_) ->
     undefined.
 
+-define(DEFAULT_TIMEOUT, 60000*8).
+
 -type req_id() :: non_neg_integer().
 -type from() :: {atom(), req_id(), pid()}.
 
@@ -195,6 +197,10 @@ init({test, Args, StateProps}) ->
 %% @private
 maybe_start_timeout_timer(infinity) ->
     ok;
+maybe_start_timeout_timer(Bad) when not is_integer(Bad) ->
+    maybe_start_timeout_timer(?DEFAULT_TIMEOUT);
+maybe_start_timeout_timer(undefined) ->
+    maybe_start_timeout_timer(?DEFAULT_TIMEOUT);
 maybe_start_timeout_timer(Timeout) ->
     gen_fsm:start_timer(Timeout, {timer_expired, Timeout}).
 


### PR DESCRIPTION
Since there are many paths to spawn a coverage FSM, it would be a lot of code duplication to validate the timeout at each of those entry points.  Instead, expand may_start_timeout_timer to guard against more categories of bad input.

Fixes https://github.com/basho/riak_kv/issues/571 

cc @jrwest @seancribbs 
