### PR TITLE
Reporting 'normal' events is spammy, don't do it

### DIFF
--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -784,6 +784,8 @@ handle_info({'EXIT', Pid, Reason},
             continue(State#state{pool_pid=NewPoolPid})
         end;
 
+handle_info({'DOWN',_Ref,process,_Pid,normal}, _StateName, State) ->
+    continue(State);
 handle_info(Info, _StateName,
             State=#state{mod=Mod,modstate={deleted, _},index=Index}) ->
     lager:info("~p ~p ignored handle_info ~p - vnode unregistering\n",


### PR DESCRIPTION
Avoid log spamminess like this:

```
14:42:43.877 [info] 1141798154164767904846628775559596109106197299200 riak_kv_vnode ignored handle_info {'DOWN',#Ref<0.0.1.47104>,process,<0.9841.1>,normal} - vnode unregistering
14:42:47.720 [info] 1324485858831130769622089379649131486563188867072 riak_kv_vnode ignored handle_info {'DOWN',#Ref<0.0.1.42852>,process,<0.9416.1>,normal} - vnode unregistering
14:42:48.050 [info] 502391187832497878132516661246222288006726811648 riak_kv_vnode ignored handle_info {'DOWN',#Ref<0.0.1.49271>,process,<0.10111.1>,normal} - vnode unregistering
14:43:14.399 [info] 936274486415109681974235595958868809467081785344 riak_kv_vnode ignored handle_info {'DOWN',#Ref<0.0.1.52833>,process,<0.10501.1>,normal} - vnode unregistering
14:43:27.347 [info] 685078892498860742907977265335757665463718379520 riak_kv_vnode ignored handle_info {'DOWN',#Ref<0.0.1.49219>,process,<0.10092.1>,normal} - vnode unregistering
14:43:57.701 [info] 1027618338748291114361965898003636498195577569280 riak_kv_vnode ignored handle_info {'DOWN',#Ref<0.0.1.52781>,process,<0.10482.1>,normal} - vnode unregistering
```
