### PR TITLE
Fix repair handoff crash, missing not sent fun

### DIFF
--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -334,14 +334,16 @@ visit_item(K, V, Acc) ->
             end;
 
         false ->
-            NewNotSentAcc = case NotSentFun of
-                undefined -> undefined;
-                _ -> NotSentFun(K, NotSentAcc)
-            end,
+            NewNotSentAcc = handle_not_sent_item(NotSentFun, NotSentAcc, K),
             Acc#ho_acc{error=ok,
                        total_objects=TotalObjects+1,
                        notsent_acc=NewNotSentAcc}
     end.
+
+handle_not_sent_item(undefined, _, _) ->
+    undefined;
+handle_not_sent_item(NotSentFun, Acc, Key) when is_function(NotSentFun) ->
+    NotSentFun(Key, Acc).
 
 send_objects([], Acc) ->
     Acc;

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -334,9 +334,13 @@ visit_item(K, V, Acc) ->
             end;
 
         false ->
+            NewNotSentAcc = case NotSentFun of
+                undefined -> undefined;
+                _ -> NotSentFun(K, NotSentAcc)
+            end,
             Acc#ho_acc{error=ok,
                        total_objects=TotalObjects+1,
-                       notsent_acc=NotSentFun(K, NotSentAcc)}
+                       notsent_acc=NewNotSentAcc}
     end.
 
 send_objects([], Acc) ->


### PR DESCRIPTION
/cc @jrwest @javajolt 
Partition repair was crashing on an undefined 'not sent function' in the handoff accumulator record. Jordan should know the details of the recent change that introduced him. Jordan: please review, feel free to replace with cleaner version of the fix.

Without this fix, the partition_repair riak_test fails every time. It passes with the fix.
