### PR TITLE
only silently drop DOWN-normal messages in deleted modstate

### DIFF
--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -784,7 +784,12 @@ handle_info({'EXIT', Pid, Reason},
             continue(State#state{pool_pid=NewPoolPid})
         end;
 
-handle_info({'DOWN',_Ref,process,_Pid,normal}, _StateName, State) ->
+handle_info({'DOWN',_Ref,process,_Pid,normal}, _StateName,
+            State=#state{modstate={deleted, _}}) ->
+    %% these messages are produced by riak_kv_vnode's aae tree
+    %% monitors; they are harmless, so don't yell about them. also
+    %% only dustbin them in the deleted modstate, because pipe vnodes
+    %% need them in other states
     continue(State);
 handle_info(Info, _StateName,
             State=#state{mod=Mod,modstate={deleted, _},index=Index}) ->


### PR DESCRIPTION
This is a restriction of the modification made in PR #334.

Dropping all `{'DOWN',_,process,_,normal}` messages on the floor instead of passing them to vnode `handle_info` functions causes `riak_pipe` vnodes to missing messages that it uses to cleanup workers for pipes that shutdown unexpectedly.

This commit restricts the DOWN-normal message dropping to the case that the vnode's modstate is `{deleted, _}`. PR #334 suggests the original modification was made only to quiet the log spam generated by the following clause, which also only operates in modstate-deleted.

Before this commit, the `riak_test` `pipe_verify_exceptions` would fail during its `verify_middle_fitting_normal` test, because workers would be left running after the fitting exited `normal`. After this commit, workers are once again terminated correctly, so the test passes again.

This PR resolves basho/riak_test#316.
