### PR TITLE
gen_server:call() timeout fixes

### DIFF
--- a/src/riak_core_connection_mgr.erl
+++ b/src/riak_core_connection_mgr.erl
@@ -152,7 +152,7 @@ pause() ->
 %% @doc Return paused state
 -spec is_paused() -> boolean().
 is_paused() ->
-    gen_server:call(?SERVER, is_paused).
+    gen_server:call(?SERVER, is_paused, infinity).
 
 %% @doc Reset all backoff delays to zero.
 -spec reset_backoff() -> 'ok'.
@@ -189,13 +189,13 @@ apply_locator(Name, Strategy) ->
 %%
 -spec connect(Target :: string(), ClientSpec :: clientspec(), Strategy :: client_scheduler_strategy()) -> {'ok', reference()}.
 connect(Target, ClientSpec, Strategy) ->
-    gen_server:call(?SERVER, {connect, Target, ClientSpec, Strategy}).
+    gen_server:call(?SERVER, {connect, Target, ClientSpec, Strategy}, infinity).
 
 %% @doc same as connect(Target, ClientSpec, default).
 %% @see connect/3
 -spec connect(Target :: string(), ClientSpec :: clientspec()) -> {'ok', reference()}.
 connect(Target, ClientSpec) ->
-    gen_server:call(?SERVER, {connect, Target, ClientSpec, default}).
+    gen_server:call(?SERVER, {connect, Target, ClientSpec, default}, infinity).
 
 %% @doc Disconnect from the remote side.
 -spec disconnect(Target :: string()) -> 'ok'.
@@ -205,7 +205,7 @@ disconnect(Target) ->
 %% doc Stop the server and sever all connections.
 -spec stop() -> 'ok'.
 stop() ->
-    gen_server:call(?SERVER, stop).
+    gen_server:call(?SERVER, stop, infinity).
 
 %%%===================================================================
 %%% gen_server callbacks
@@ -502,11 +502,11 @@ connection_helper(Ref, _Protocol, _Strategy, []) ->
 connection_helper(Ref, Protocol, Strategy, [Addr|Addrs]) ->
     {{ProtocolId, _Foo},_Bar} = Protocol,
     %% delay by the backoff_delay for this endpoint.
-    {ok, BackoffDelay} = gen_server:call(?SERVER, {get_endpoint_backoff, Addr}),
+    {ok, BackoffDelay} = gen_server:call(?SERVER, {get_endpoint_backoff, Addr}, infinity),
     lager:debug("Holding off ~p seconds before trying ~p at ~p",
                [(BackoffDelay/1000), ProtocolId, string_of_ipport(Addr)]),
     timer:sleep(BackoffDelay),
-    case gen_server:call(?SERVER, {should_try_endpoint, Ref, Addr}) of
+    case gen_server:call(?SERVER, {should_try_endpoint, Ref, Addr}, infinity) of
         true ->
             lager:debug("Trying connection to: ~p at ~p", [ProtocolId, string_of_ipport(Addr)]),
             ?TRACE(?debugMsg("Attempting riak_core_connection:sync_connect/2")),

--- a/src/riak_core_service_mgr.erl
+++ b/src/riak_core_service_mgr.erl
@@ -131,7 +131,7 @@ unregister_service(ProtocolId) ->
 %% @doc True if the given protocal id is registered.
 -spec(is_registered(proto_id()) -> boolean()).
 is_registered(ProtocolId) ->
-    gen_server:call(?SERVER, {is_registered, service, ProtocolId}).
+    gen_server:call(?SERVER, {is_registered, service, ProtocolId}, infinity).
 
 %% @doc Register a callback function that will get called periodically or
 %% when the connection status of services changes. The function will
@@ -148,12 +148,12 @@ register_stats_fun(Fun) ->
 %% @doc Number of open connections for each protocol id.
 -spec get_stats() -> [{proto_id(), non_neg_integer()}].
 get_stats() ->
-    gen_server:call(?SERVER, get_stats).
+    gen_server:call(?SERVER, get_stats, infinity).
 
 %% @doc Stop the ranch listener, and then exit the server normally.
 -spec stop() -> 'ok'.
 stop() ->
-    gen_server:call(?SERVER, stop).
+    gen_server:call(?SERVER, stop, infinity).
 
 %%%===================================================================
 %%% gen_server callbacks
@@ -293,7 +293,7 @@ dispatch_service(Listener, Socket, Transport, _Args) ->
                 {NewTransport, NewSocket} ->
                     %% get latest set of registered services from gen_server
                     %% and do negotiation
-                    Services = gen_server:call(?SERVER, get_services),
+                    Services = gen_server:call(?SERVER, get_services, infinity),
                     SubProtocols = [Protocol ||
                         {_Key,{Protocol,_Strategy}} <- Services],
                     lager:debug("started dispatch_service with protocols: ~p",

--- a/src/riak_core_stat_cache.erl
+++ b/src/riak_core_stat_cache.erl
@@ -64,7 +64,7 @@ register_app(App, {M, F, A}) ->
     register_app(App, {M, F, A}, RefreshRate).
 
 register_app(App, {M, F, A}, RefreshRateSecs) ->
-    gen_server:call(?SERVER, {register, App, {{M, F, A}, ?REFRSH_MILLIS(RefreshRateSecs)}}).
+    gen_server:call(?SERVER, {register, App, {{M, F, A}, ?REFRSH_MILLIS(RefreshRateSecs)}}, infinity).
 
 get_stats(App) ->
     gen_server:call(?SERVER, {get_stats, App}, infinity).
@@ -73,7 +73,7 @@ clear_cache(App) ->
     gen_server:call(?SERVER, {clear, App}, infinity).
 
 stop() ->
-    gen_server:cast(?SERVER, stop).
+    gen_server:cast(?SERVER, stop, infinity).
 
 %%% gen server
 

--- a/src/riak_core_tcp_mon.erl
+++ b/src/riak_core_tcp_mon.erl
@@ -76,16 +76,16 @@ start_link(Props) ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, Props, []).
 
 monitor(Socket, Tag, Transport) ->
-    gen_server:call(?MODULE, {monitor, Socket, Tag, Transport}).
+    gen_server:call(?MODULE, {monitor, Socket, Tag, Transport}, infinity).
 
 status() ->
-    gen_server:call(?MODULE, status).
+    gen_server:call(?MODULE, status, infinity).
 
 status(Timeout) ->
     gen_server:call(?MODULE, status, Timeout).
 
 socket_status(Socket) ->
-  gen_server:call(?MODULE, {socket_status, Socket}).
+  gen_server:call(?MODULE, {socket_status, Socket}, infinity).
 
 format() ->
     Status = status(),

--- a/src/riak_core_tracer.erl
+++ b/src/riak_core_tracer.erl
@@ -54,15 +54,15 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 stop() ->
-    gen_server:call(?SERVER, stop).
+    gen_server:call(?SERVER, stop, infinity).
 
 reset() ->
-    gen_server:call(?SERVER, reset).
+    gen_server:call(?SERVER, reset, infinity).
 
 %% Set up a filter on trace messages to the list of [{M, F}]s.  The
 %% tracer function should return a list of events to log
 filter(MFs, Filter) ->
-    gen_server:call(?SERVER, {filter, MFs, Filter}).
+    gen_server:call(?SERVER, {filter, MFs, Filter}, infinity).
 
 %% Collect traces
 collect() ->
@@ -72,15 +72,15 @@ collect(Duration) ->
     collect(Duration, nodes()).
 
 collect(Duration, Nodes) ->
-    gen_server:call(?SERVER, {collect, Duration,  Nodes}).
+    gen_server:call(?SERVER, {collect, Duration,  Nodes}, infinity).
 
 %% Stop collection
 stop_collect() ->
-    gen_server:call(?SERVER, stop_collect).
+    gen_server:call(?SERVER, stop_collect, infinity).
 
 %% Return the trace
 results() ->
-    gen_server:call(?SERVER, results).
+    gen_server:call(?SERVER, results, infinity).
 
 all_events({trace, Pid, call, {M,F,A}}) ->
     [{node(Pid), {M,F,A}}].
@@ -128,7 +128,7 @@ handle_call({collect, Duration, Nodes}, _From, State) ->
                                          {Mega, Secs, Micro} = os:timestamp(),
                                          Ts = 1000000 * (1000000 * Mega + Secs) + Micro,
                                          TsEntries = [{Ts, E} || E <- Entries],
-                                         gen_server:call(Pid,  {traces, TsEntries})
+                                         gen_server:call(Pid,  {traces, TsEntries}, infinity)
                                  end,
                                  Pid
                          end, self()}),


### PR DESCRIPTION
Use 'infinity' (or at least a longer timeout) when we know that the server pid is on the local node.
