### PR TITLE
Fix two major vnode manager bugs

### DIFF
--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -552,7 +552,7 @@ idx2vnode(Idx, Mod, _State=#state{idxtab=T}) ->
 delmon(MonRef, _State=#state{idxtab=T}) ->
     case ets:lookup(T, MonRef) of
         [#monrec{key=Key}] ->
-            ets:delete(T, Key),
+            ets:match_delete(T, {idxrec, Key, '_', '_', '_', MonRef}),
             ets:delete(T, MonRef);
         [] ->
             ets:match_delete(T, {idxrec, '_', '_', '_', '_', MonRef})
@@ -597,7 +597,10 @@ get_vnode(IdxList, Mod, State) ->
          IdxRec = #idxrec{key={Idx,Mod},idx=Idx,mod=Mod,pid=Pid,
                           monref=MonRef},
          MonRec = #monrec{monref=MonRef, key={Idx,Mod}},
-         add_vnode_rec([IdxRec, MonRec], State),
+         add_vnode_rec([IdxRec, MonRec], State)
+     end || Idx <- NotStarted],
+    [begin
+         Pid = dict:fetch(Idx, PairsDict),
          Pid
      end || Idx <- IdxList].
 


### PR DESCRIPTION
First, fix a bug that enabled a race condition wherein the vnode
manager could start the same vnode multiple times. This would result
in both vnode instances trying to acquire the same backend, which
would fail and force the Riak node to shutdown.

The cause of this bug was a change introduced during the large
ring optimization work for Riak 1.4. In this work, an unbounded
`ets:match_delete` that resulted in a table scan was changed to
a straightforward `ets:delete`. Unfortunately, the `ets:delete`
could delete data associated with a newer instance of a given vnode
in cases where a monitor for a prior instance fired after the new
instance was created.  This bug was fixed by switching to a bounded
`ets:match_delete` that avoids the table scan while also avoiding
unintended deletes.

Second, fix a bug introduced during the parallel vnode initialization
work from Riak 1.3.1 that caused the vnode manager to newly monitor a
given vnode each time get_vnode_pid was called. This bug could result
in an unbounded number of monitors being created in certain scenarios,
causing a node to become slower over time until it was restarted.
