### PR TITLE
Add #riak_core_fold_req_v2 record, part 1 of 2

### DIFF
--- a/include/riak_core_vnode.hrl
+++ b/include/riak_core_vnode.hrl
@@ -23,7 +23,12 @@
 -record(riak_core_fold_req_v1, {
           foldfun :: fun(),
           acc0 :: term()}).
+-record(riak_core_fold_req_v2, {
+          foldfun :: fun(),
+          acc0 :: term(),
+          forwardable :: boolean(),
+          opts = [] :: list()}).
 
 -define(VNODE_REQ, #riak_vnode_req_v1).
 -define(COVERAGE_REQ, #riak_coverage_req_v1).
--define(FOLD_REQ, #riak_core_fold_req_v1).
+-define(FOLD_REQ, #riak_core_fold_req_v2).

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -90,6 +90,9 @@ start(_StartType, _StartArgs) ->
             riak_core_capability:register({riak_core, resizable_ring},
                                           [true, false],
                                           false),
+            riak_core_capability:register({riak_core, fold_req_version},
+                                          [v2, v1],
+                                          v1),
 
             {ok, Pid};
         {error, Reason} ->

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -152,8 +152,9 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
          UnsentAcc0 = get_notsent_acc0(Opts),
          UnsentFun = get_notsent_fun(Opts),
 
-         Req = ?FOLD_REQ{foldfun=fun visit_item/3,
-                         acc0=#ho_acc{
+         Req = riak_core_util:make_fold_req(
+                             fun visit_item/3,
+                             #ho_acc{
                                       ack=0,
                                       error=ok,
                                       filter=Filter,
@@ -176,8 +177,7 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
                                       type=Type,
                                       notsent_acc=UnsentAcc0,
                                       notsent_fun=UnsentFun
-                                     }
-                        },                             
+                                     }),
 
          %% IFF the vnode is using an async worker to perform the fold
          %% then sync_command will return error on vnode crash,

--- a/src/riak_core_util.erl
+++ b/src/riak_core_util.erl
@@ -52,8 +52,12 @@
          is_arch/1,
          format_ip_and_port/2,
          peername/2,
-         sockname/2
+         sockname/2,
+         make_fold_req/2,
+         make_fold_req/4
         ]).
+
+-include("riak_core_vnode.hrl").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -531,6 +535,17 @@ sockname(Socket, Transport) ->
             %% just return a string so JSON doesn't blow up
             lists:flatten(io_lib:format("error:~p", [Reason]))
     end.
+
+make_fold_req(FoldFun, Acc0) ->
+    make_fold_req(FoldFun, Acc0, false, []).
+
+make_fold_req(FoldFun, Acc0, Forwardable, Opts)
+  when is_function(FoldFun, 3)
+       andalso (Forwardable == true orelse Forwardable == true)
+       andalso is_list(Opts) ->
+    %% TODO: Capability negotiation goes here, to figure out which version #
+    %% of the riak_core_fold_req_v* record to use.
+    ?FOLD_REQ{foldfun=FoldFun, acc0=Acc0, forwardable=Forwardable, opts=Opts}.
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_core_util.erl
+++ b/src/riak_core_util.erl
@@ -55,7 +55,8 @@
          sockname/2,
          make_fold_req/1,
          make_fold_req/2,
-         make_fold_req/4
+         make_fold_req/4,
+         make_newest_fold_req/1
         ]).
 
 -include("riak_core_vnode.hrl").
@@ -537,23 +538,44 @@ sockname(Socket, Transport) ->
             lists:flatten(io_lib:format("error:~p", [Reason]))
     end.
 
+%% @doc Convert a #riak_core_fold_req_v? record to the cluster's maximum
+%%      supported record version.
+
 make_fold_req(#riak_core_fold_req_v1{foldfun=FoldFun, acc0=Acc0}) ->
-    make_fold_req(FoldFun, Acc0).
+    make_fold_req2(FoldFun, Acc0, false, []);
+make_fold_req(?FOLD_REQ{foldfun=FoldFun, acc0=Acc0,
+                       forwardable=Forwardable, opts=Opts}) ->
+    make_fold_req2(FoldFun, Acc0, Forwardable, Opts).
 
 make_fold_req(FoldFun, Acc0) ->
-    make_fold_req(FoldFun, Acc0, false, []).
+    make_fold_req2(FoldFun, Acc0, false, []).
 
-make_fold_req(FoldFun, Acc0, Forwardable, Opts)
+make_fold_req(FoldFun, Acc0, Forwardable, Opts) ->
+    make_fold_req2(FoldFun, Acc0, Forwardable, Opts).
+
+%% @doc Force a #riak_core_fold_req_v? record to the cluster's maximum
+%%      supported record version.
+
+make_newest_fold_req(#riak_core_fold_req_v1{foldfun=FoldFun, acc0=Acc0}) ->
+    make_fold_req3(v2, FoldFun, Acc0, false, []);
+make_newest_fold_req(?FOLD_REQ{} = F) ->
+    F.
+
+%% @private
+make_fold_req2(FoldFun, Acc0, Forwardable, Opts) ->
+    make_fold_req3(riak_core_capability:get({riak_core, fold_req_version}, v1),
+                   FoldFun, Acc0, Forwardable, Opts).
+
+%% @private
+make_fold_req3(v1, FoldFun, Acc0, _Forwardable, _Opts)
+  when is_function(FoldFun, 3) ->
+    #riak_core_fold_req_v1{foldfun=FoldFun, acc0=Acc0};
+make_fold_req3(v2, FoldFun, Acc0, Forwardable, Opts)
   when is_function(FoldFun, 3)
        andalso (Forwardable == true orelse Forwardable == false)
        andalso is_list(Opts) ->
-    case riak_core_capability:get({riak_core, fold_req_version}, v1) of
-        v2 ->
-            ?FOLD_REQ{foldfun=FoldFun, acc0=Acc0,
-                      forwardable=Forwardable, opts=Opts};
-        v1 ->
-            #riak_core_fold_req_v1{foldfun=FoldFun, acc0=Acc0}
-    end.
+    ?FOLD_REQ{foldfun=FoldFun, acc0=Acc0,
+              forwardable=Forwardable, opts=Opts}.
 
 %% ===================================================================
 %% EUnit tests
@@ -679,6 +701,49 @@ bounded_pmap_test_() ->
       end,
       Tests
      }.
+
+make_fold_req_test_() ->
+    {setup,
+     fun() ->
+             meck:new(riak_core_capability, [passthrough])
+     end,
+     fun(_) ->
+             meck:unload(riak_core_capability)
+     end,
+     [
+      fun() ->
+              FoldFun = fun(_, _, _) -> ok end,
+              Acc0 = acc0,
+              Forw = true,
+              Opts = [opts],
+              F_1 = #riak_core_fold_req_v1{foldfun=FoldFun, acc0=Acc0},
+              F_2 = #riak_core_fold_req_v2{foldfun=FoldFun, acc0=Acc0,
+                                           forwardable=Forw, opts=Opts},
+              F_2_default = #riak_core_fold_req_v2{foldfun=FoldFun, acc0=Acc0,
+                                                   forwardable=false, opts=[]},
+              Newest = fun() -> F_2_default = make_newest_fold_req(F_1),
+                                F_2         = make_newest_fold_req(F_2),
+                                ok
+                       end,
+
+              meck:expect(riak_core_capability, get,
+                          fun(_, _) -> v1 end),
+              F_1         = make_fold_req(F_1),
+              F_1         = make_fold_req(F_2),
+              F_1         = make_fold_req(FoldFun, Acc0),
+              F_1         = make_fold_req(FoldFun, Acc0, Forw, Opts),
+              ok = Newest(),
+
+              meck:expect(riak_core_capability, get,
+                          fun(_, _) -> v2 end),
+              F_2_default = make_fold_req(F_1),
+              F_2         = make_fold_req(F_2),
+              F_2_default = make_fold_req(FoldFun, Acc0),
+              F_2         = make_fold_req(FoldFun, Acc0, Forw, Opts),
+              ok = Newest()
+      end
+     ]
+    }.
 
 -endif.
 

--- a/src/riak_core_util.erl
+++ b/src/riak_core_util.erl
@@ -53,6 +53,7 @@
          format_ip_and_port/2,
          peername/2,
          sockname/2,
+         make_fold_req/1,
          make_fold_req/2,
          make_fold_req/4
         ]).
@@ -536,16 +537,23 @@ sockname(Socket, Transport) ->
             lists:flatten(io_lib:format("error:~p", [Reason]))
     end.
 
+make_fold_req(#riak_core_fold_req_v1{foldfun=FoldFun, acc0=Acc0}) ->
+    make_fold_req(FoldFun, Acc0).
+
 make_fold_req(FoldFun, Acc0) ->
     make_fold_req(FoldFun, Acc0, false, []).
 
 make_fold_req(FoldFun, Acc0, Forwardable, Opts)
   when is_function(FoldFun, 3)
-       andalso (Forwardable == true orelse Forwardable == true)
+       andalso (Forwardable == true orelse Forwardable == false)
        andalso is_list(Opts) ->
-    %% TODO: Capability negotiation goes here, to figure out which version #
-    %% of the riak_core_fold_req_v* record to use.
-    ?FOLD_REQ{foldfun=FoldFun, acc0=Acc0, forwardable=Forwardable, opts=Opts}.
+    case riak_core_capability:get({riak_core, fold_req_version}, v1) of
+        v2 ->
+            ?FOLD_REQ{foldfun=FoldFun, acc0=Acc0,
+                      forwardable=Forwardable, opts=Opts};
+        v1 ->
+            #riak_core_fold_req_v1{foldfun=FoldFun, acc0=Acc0}
+    end.
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_core_util.erl
+++ b/src/riak_core_util.erl
@@ -542,35 +542,31 @@ sockname(Socket, Transport) ->
 %%      supported record version.
 
 make_fold_req(#riak_core_fold_req_v1{foldfun=FoldFun, acc0=Acc0}) ->
-    make_fold_req2(FoldFun, Acc0, false, []);
+    make_fold_req(FoldFun, Acc0, false, []);
 make_fold_req(?FOLD_REQ{foldfun=FoldFun, acc0=Acc0,
                        forwardable=Forwardable, opts=Opts}) ->
-    make_fold_req2(FoldFun, Acc0, Forwardable, Opts).
+    make_fold_req(FoldFun, Acc0, Forwardable, Opts).
 
 make_fold_req(FoldFun, Acc0) ->
-    make_fold_req2(FoldFun, Acc0, false, []).
+    make_fold_req(FoldFun, Acc0, false, []).
 
 make_fold_req(FoldFun, Acc0, Forwardable, Opts) ->
-    make_fold_req2(FoldFun, Acc0, Forwardable, Opts).
+    make_fold_reqv(riak_core_capability:get({riak_core, fold_req_version}, v1),
+                   FoldFun, Acc0, Forwardable, Opts).
 
-%% @doc Force a #riak_core_fold_req_v? record to the cluster's maximum
-%%      supported record version.
+%% @doc Force a #riak_core_fold_req_v? record to the latest version,
+%%      regardless of cluster support
 
 make_newest_fold_req(#riak_core_fold_req_v1{foldfun=FoldFun, acc0=Acc0}) ->
-    make_fold_req3(v2, FoldFun, Acc0, false, []);
+    make_fold_reqv(v2, FoldFun, Acc0, false, []);
 make_newest_fold_req(?FOLD_REQ{} = F) ->
     F.
 
 %% @private
-make_fold_req2(FoldFun, Acc0, Forwardable, Opts) ->
-    make_fold_req3(riak_core_capability:get({riak_core, fold_req_version}, v1),
-                   FoldFun, Acc0, Forwardable, Opts).
-
-%% @private
-make_fold_req3(v1, FoldFun, Acc0, _Forwardable, _Opts)
+make_fold_reqv(v1, FoldFun, Acc0, _Forwardable, _Opts)
   when is_function(FoldFun, 3) ->
     #riak_core_fold_req_v1{foldfun=FoldFun, acc0=Acc0};
-make_fold_req3(v2, FoldFun, Acc0, Forwardable, Opts)
+make_fold_reqv(v2, FoldFun, Acc0, Forwardable, Opts)
   when is_function(FoldFun, 3)
        andalso (Forwardable == true orelse Forwardable == false)
        andalso is_list(Opts) ->

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -276,16 +276,19 @@ forward_or_vnode_command(Sender, Request, State=#state{forward=Forward,
         false ->
             RequestHash = undefined
     end,
-    case {Forward, RequestHash} of
+    Forwardable = is_request_forwardable(Request),
+    case {Forwardable, Forward, RequestHash} of
+        %% Not a forwardable command, handle request locally
+        {false, _, _} -> vnode_command(Sender, Request, State);
         %% typical vnode operation, no forwarding set, handle request locally
-        {undefined, _} -> vnode_command(Sender, Request, State);
+        {_, undefined, _} -> vnode_command(Sender, Request, State);
         %% implicit forwarding after ownership_transfer/hinted_handoff
-        {F, _} when not is_list(F) ->
+        {_, F, _} when not is_list(F) ->
             vnode_forward(implicit, {Index, Forward}, Sender, Request, State);
         %% during resize we can't forward a request w/o request hash, always handle locally
-        {_, undefined} -> vnode_command(Sender, Request, State);
+        {_, _, undefined} -> vnode_command(Sender, Request, State);
         %% possible forwarding during ring resizing
-        {_, _} ->
+        {_, _, _} ->
             {ok, R} = riak_core_ring_manager:get_my_ring(),
             FutureIndex = riak_core_ring:future_index(RequestHash, Index, R),
             vnode_resize_command(Sender, Request, FutureIndex, State)
@@ -971,6 +974,16 @@ stop_manager_event_timer(#state{manager_event_timer=undefined}) ->
     ok;
 stop_manager_event_timer(#state{manager_event_timer=T}) ->
     gen_fsm:cancel_timer(T).
+
+is_request_forwardable(#riak_core_fold_req_v2{forwardable=false}) ->
+    false;
+is_request_forwardable(_) ->
+    %% Assume that all other vnode ops are forwardable.
+    %%
+    %% WARNING: The coding style used in this function means that special
+    %%          care must be taken when adding #riak_core_fold_req_v3 and
+    %%          v4 and v27 as well as any other vnode request type.
+    true.
 
 %% ===================================================================
 %% Test API


### PR DESCRIPTION
Move definition of ?FOLD_REQ to v2.

Add functions to riak_core_util.erl to create v2 versions of the
record: arity 1 (upgrade #riak_core_fold_req_v1 record to the v2
record), arity 2 (args = the two record elements of the v1 record)
and arity 4 (args = the four record elements of the v2 record).

Disable request forwarding in riak_core_vnode:forward_or_vnode_command()
if the request explicitly contains not-forwardable annotation.
