### PR TITLE
Add Erlang R16B to travis-ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ notifications:
   webhooks: http://basho-engbot.herokuapp.com/travis?key=72ce513a4a26166521f60f72511bfb905329db87
   email: eng@basho.com
 otp_release:
-  - R16B
+  - R16B02
   - R15B01
   - R15B
   - R14B04

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ notifications:
   webhooks: http://basho-engbot.herokuapp.com/travis?key=72ce513a4a26166521f60f72511bfb905329db87
   email: eng@basho.com
 otp_release:
+  - R16B
   - R15B01
   - R15B
   - R14B04
   - R14B03
-


### PR DESCRIPTION
You seem to be supporting R16B in your riak_core release,
so it would be nice to test against it on travis-ci as well,
to catch issues that are not compatible with R16B.

Thanks
