### PR TITLE
Add bucket type defaults and reset

### DIFF
--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -64,13 +64,7 @@ start(_StartType, _StartArgs) ->
 
     %% add these defaults now to supplement the set that may have been
     %% configured in app.config
-    riak_core_bucket:append_bucket_defaults(
-      [{n_val,3},
-       {allow_mult,false},
-       {last_write_wins,false},
-       {precommit, []},
-       {postcommit, []},
-       {chash_keyfun, {riak_core_util, chash_std_keyfun}}]),
+    riak_core_bucket:append_bucket_defaults(riak_core_bucket_type:defaults()),
 
     %% Spin up the supervisor; prune ring files as necessary
     case riak_core_sup:start_link() of


### PR DESCRIPTION
Non-default bucket-types are unaffected by changes to app.config and
bucket types can have their properties reset to the hardcoded defaults.

cc @jrwest
