### PR TITLE
Cluster Metadata (Part 1/2)

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -86,7 +86,13 @@
              riak_core_tcp_mon,
              riak_core_ssl_util,
              supervisor_pre_r14b04,
-             vclock
+             vclock,
+             dvvset,
+             riak_core_metadata,
+             riak_core_metadata_object,
+             riak_core_metadata_manager,
+             riak_core_broadcast,
+             riak_core_broadcast_handler
             ]},
   {registered, []},
   {included_applications, [folsom]},

--- a/include/riak_core_metadata.hrl
+++ b/include/riak_core_metadata.hrl
@@ -1,4 +1,4 @@
--type metadata_prefix()     :: {any(), any()}.
+-type metadata_prefix()     :: {binary(), binary()}.
 -type metadata_key()        :: any().
 -type metadata_pkey()       :: {metadata_prefix(), metadata_key()}.
 -type metadata_value()      :: any().

--- a/include/riak_core_metadata.hrl
+++ b/include/riak_core_metadata.hrl
@@ -3,6 +3,7 @@
 -type metadata_pkey()       :: {metadata_prefix(), metadata_key()}.
 -type metadata_value()      :: any().
 -type metadata_resolver()   :: fun((metadata_value(), metadata_value()) -> metadata_value()).
+-type metadata_modifier()   :: fun(([metadata_value()] | undefined) -> metadata_value()).
 -type metadata_object()     :: {metadata, dvvset:clock()}.
 -type metadata_context()    :: dvvset:vector().
 

--- a/include/riak_core_metadata.hrl
+++ b/include/riak_core_metadata.hrl
@@ -2,8 +2,11 @@
 -type metadata_key()        :: any().
 -type metadata_pkey()       :: {metadata_prefix(), metadata_key()}.
 -type metadata_value()      :: any().
--type metadata_resolver()   :: fun((metadata_value(), metadata_value()) -> metadata_value()).
--type metadata_modifier()   :: fun(([metadata_value()] | undefined) -> metadata_value()).
+-type metadata_tombstone()  :: '$deleted'.
+-type metadata_resolver()   :: fun((metadata_value() | metadata_tombstone(),
+                                    metadata_value() | metadata_tombstone()) -> metadata_value()).
+-type metadata_modifier()   :: fun(([metadata_value() | metadata_tombstone()] | undefined) ->
+                                          metadata_value()).
 -type metadata_object()     :: {metadata, dvvset:clock()}.
 -type metadata_context()    :: dvvset:vector().
 

--- a/include/riak_core_metadata.hrl
+++ b/include/riak_core_metadata.hrl
@@ -1,0 +1,13 @@
+-type metadata_prefix()     :: {any(), any()}.
+-type metadata_key()        :: any().
+-type metadata_pkey()       :: {metadata_prefix(), metadata_key()}.
+-type metadata_value()      :: any().
+-type metadata_resolver()   :: fun((metadata_value(), metadata_value()) -> metadata_value()).
+-type metadata_object()     :: {metadata, dvvset:clock()}.
+-type metadata_context()    :: dvvset:vector().
+
+-record(metadata_broadcast, {
+          pkey  :: metadata_pkey(),
+          obj   :: metadata_object()
+         }).
+-type metadata_broadcast()  ::  #metadata_broadcast{}.

--- a/include/riak_core_metadata.hrl
+++ b/include/riak_core_metadata.hrl
@@ -1,4 +1,4 @@
--type metadata_prefix()     :: {binary(), binary()}.
+-type metadata_prefix()     :: {binary() | atom(), binary() | atom()}.
 -type metadata_key()        :: any().
 -type metadata_pkey()       :: {metadata_prefix(), metadata_key()}.
 -type metadata_value()      :: any().

--- a/src/dvvset.erl
+++ b/src/dvvset.erl
@@ -1,0 +1,461 @@
+%%-------------------------------------------------------------------
+%%
+%% File:      dvvset.erl
+%%
+%% @title Dotted Version Vector Set
+%% @author    Ricardo Tomé Gonçalves <tome.wave@gmail.com>
+%% @author    Paulo Sérgio Almeida <pssalmeida@gmail.com>
+%
+%% @copyright The MIT License (MIT)
+%% Copyright (C) 2013
+%%
+%% Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+%% associated documentation files (the "Software"), to deal in the Software without restriction,
+%% including without limitation the rights to use, copy, modify, merge, publish, distribute,
+%% sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+%% furnished to do so, subject to the following conditions:
+%%
+%% The above copyright notice and this permission notice shall be included in all copies or
+%% substantial portions of the Software.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+%% BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+%% NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+%% DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+%% OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+%%
+%% @doc  
+%% An Erlang implementation of *compact* Dotted Version Vectors, which
+%% provides a container for a set of concurrent values (siblings) with causal
+%% order information.
+%%
+%% For further reading, visit the
+%% <a href="https://github.com/ricardobcl/Dotted-Version-Vectors/tree/ompact">github page</a>.
+%% @end  
+%%
+%% @reference
+%% <a href="http://arxiv.org/abs/1011.5808">
+%% Dotted Version Vectors: Logical Clocks for Optimistic Replication
+%% </a>
+%% @end
+%%
+%%-------------------------------------------------------------------
+-module(dvvset).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-export([new/1,
+         new/2,
+         sync/1,
+         join/1,
+         update/2,
+         update/3,
+         size/1,
+         ids/1,
+         values/1,
+         equal/2,
+         less/2,
+         map/2,
+         last/2,
+         lww/2,
+         reconcile/2
+        ]).
+
+-export_type([clock/0, vector/0, id/0, value/0]).
+
+% % @doc
+%% STRUCTURE details:
+%%      * entries() are sorted by id()
+%%      * each counter() also includes the number of values in that id()
+%%      * the values in each triple of entries() are causally ordered and each new value goes to the head of the list
+
+-type clock() :: {entries(), values()}.
+-type vector() :: [{id(), counter()}].
+-type entries() :: [{id(), counter(), values()}].
+-type id() :: any().
+-type values() :: [value()].
+-type value() :: any().
+-type counter() :: non_neg_integer().
+
+
+%% @doc Constructs a new clock set without causal history,
+%% and receives a list of values that gos to the anonymous list.
+-spec new([value()]) -> clock().
+new(Vs) when is_list(Vs) -> {[], Vs};
+new(V) -> {[], [V]}.
+
+%% @doc Constructs a new clock set with the causal history
+%% of the given version vector / vector clock,
+%% and receives a list of values that gos to the anonymous list.
+%% The version vector SHOULD BE a direct result of join/1.
+-spec new(vector(), [value()]) -> clock().
+new(VV, Vs) when is_list(Vs) ->
+    VVS = lists:sort(VV), % defense against non-order preserving serialization
+    {[{I, N, []} || {I, N} <- VVS], Vs};
+new(VV, V) -> new(VV, [V]).
+
+%% @doc Synchronizes a list of clocks using sync/2.
+%% It discards (causally) outdated values, 
+%% while merging all causal histories.
+-spec sync([clock()]) -> clock().
+sync(L) -> lists:foldl(fun sync/2, {}, L).
+
+%% Private function
+-spec sync(clock(), clock()) -> clock().
+sync({}, C) -> C;
+sync(C ,{}) -> C;
+sync(C1={E1,V1},C2={E2,V2}) ->
+    V = case less(C1,C2) of
+        true  -> V2; % C1 < C2 => return V2
+        false -> case less(C2,C1) of
+                    true  -> V1; % C2 < C1 => return V1
+                    false -> % keep all unique anonymous values and sync entries()
+                        sets:to_list(sets:from_list(V1++V2))
+                 end
+    end,
+    {sync2(E1,E2),V}.
+
+%% Private function
+-spec sync2(entries(), entries()) -> entries().
+sync2([], C) -> C;
+sync2(C, []) -> C;
+sync2([{I1, N1, L1}=H1 | T1]=C1, [{I2, N2, L2}=H2 | T2]=C2) ->
+    if
+      I1 < I2 -> [H1 | sync2(T1, C2)];
+      I1 > I2 -> [H2 | sync2(T2, C1)];
+      true    -> [merge(I1, N1, L1, N2, L2) | sync2(T1, T2)]
+    end.
+
+%% Private function
+-spec merge(id(), counter(), values(), counter(), values()) -> {id(), counter(), values()}.
+merge(I, N1, L1, N2, L2) ->
+    LL1 = length(L1),
+    LL2 = length(L2),
+    case N1 >= N2 of
+        true ->
+          case N1 - LL1 >=  N2 - LL2 of 
+            true  -> {I, N1, L1};
+            false -> {I, N1, lists:sublist(L1, N1 - N2 + LL2)}
+          end;
+        false ->
+          case N2 - LL2 >=  N1 - LL1 of 
+            true  -> {I, N2, L2};
+            false -> {I, N2, lists:sublist(L2, N2 - N1 + LL1)}
+          end
+    end.
+
+
+%% @doc Return a version vector that represents the causal history.
+-spec join(clock()) -> vector().
+join({C,_}) -> [{I, N} || {I, N, _} <- C].
+
+%% @doc Advances the causal history with the given id.
+%% The new value is the *anonymous dot* of the clock.
+%% The client clock SHOULD BE a direct result of new/2.
+-spec update(clock(), id()) -> clock().
+update({C,[V]}, I) -> {event(C, I, V), []}.
+
+%% @doc Advances the causal history of the
+%% first clock with the given id, while synchronizing
+%% with the second clock, thus the new clock is
+%% causally newer than both clocks in the argument.
+%% The new value is the *anonymous dot* of the clock.
+%% The first clock SHOULD BE a direct result of new/2,
+%% which is intended to be the client clock with
+%% the new value in the *anonymous dot* while
+%% the second clock is from the local server.
+-spec update(clock(), clock(), id()) -> clock().
+update({Cc,[V]}, Cr, I) -> 
+    %% Sync both clocks without the new value
+    {C,Vs} = sync({Cc,[]}, Cr),
+    %% We create a new event on the synced causal history,
+    %% with the id I and the new value.
+    %% The anonymous values that were synced still remain.
+    {event(C, I, V), Vs}.
+
+%% Private function
+-spec event(vector(), id(), value()) -> vector().
+event([], I, V) -> [{I, 1, [V]}];
+event([{I, N, L} | T], I, V) -> [{I, N+1, [V | L]} | T];
+event([{I1, _, _} | _]=C, I, V) when I1 > I -> [{I, 1, [V]} | C];
+event([H | T], I, V) -> [H | event(T, I, V)].
+
+%% @doc Returns the total number of values in this clock set.
+-spec size(clock()) -> non_neg_integer().
+size({C,Vs}) -> lists:sum([length(L) || {_,_,L} <- C]) + length(Vs).
+
+%% @doc Returns all the ids used in this clock set.
+-spec ids(clock()) -> [id()].
+ids({C,_}) -> ([I || {I,_,_} <- C]).
+
+%% @doc Returns all the values used in this clock set,
+%% including the anonymous values.
+-spec values(clock()) -> [value()].
+values({C,Vs}) -> Vs ++ lists:append([L || {_,_,L} <- C]).
+
+%% @doc Compares the equality of both clocks, regarding
+%% only the causal histories, thus ignoring the values.
+-spec equal(clock() | vector(), clock() | vector()) -> boolean().
+equal({C1,_},{C2,_}) -> equal2(C1,C2); % DVVSet
+equal(C1,C2) when is_list(C1) and is_list(C2) -> equal2(C1,C2). %vector clocks
+
+%% Private function
+-spec equal2(vector(), vector()) -> boolean().
+equal2([], []) -> true;
+equal2([{I, C, L1} | T1], [{I, C, L2} | T2]) 
+    when length(L1) =:= length(L2) -> 
+    equal2(T1, T2);
+equal2(_, _) -> false.
+
+%% @doc Returns True if the first clock is causally older than
+%% the second clock, thus values on the first clock are outdated.
+%% Returns False otherwise.
+-spec less(clock(), clock()) -> boolean().
+less({C1,_}, {C2,_}) -> greater(C2, C1, false).
+
+%% Private function
+-spec greater(vector(), vector(), boolean()) -> boolean().
+greater([], [], Strict) -> Strict;
+greater([_|_], [], _) -> true;
+greater([], [_|_], _) -> false;
+greater([{I, N1, _} | T1], [{I, N2, _} | T2], Strict) ->
+   if
+     N1 == N2 -> greater(T1, T2, Strict);
+     N1 >  N2 -> greater(T1, T2, true);
+     N1 <  N2 -> false
+   end;
+greater([{I1, _, _} | T1], [{I2, _, _} | _]=C2, _) when I1 < I2 -> greater(T1, C2, true);
+greater(_, _, _) -> false.
+
+%% @doc Maps (applies) a function on all values in this clock set,
+%% returning the same clock set with the updated values.
+-spec map(fun((value()) -> value()), clock()) -> clock().
+map(F, {C,Vs}) -> 
+    {[ {I, N, lists:map(F, V)} || {I, N, V} <- C], lists:map(F, Vs)}.
+
+
+%% @doc Return a clock with the same causal history, but with only one
+%% value in the anonymous placeholder. This value is the result of
+%% the function F, which takes all values and returns a single new value.
+-spec reconcile(Winner::fun(([value()]) -> value()), clock()) -> clock().
+reconcile(F, C) ->
+    V = F(values(C)),
+    new(join(C),[V]).
+
+%% @doc Returns the latest value in the clock set,
+%% according to function F(A,B), which returns *true* if 
+%% A compares less than or equal to B, false otherwise.
+-spec last(LessOrEqual::fun((value(),value()) -> boolean()), clock()) -> value().
+last(F, C) ->
+   {_ ,_ , V2} = find_entry(F, C),
+   V2.
+
+%% @doc Return a clock with the same causal history, but with only one
+%% value in its original position. This value is the newest value
+%% in the given clock, according to function F(A,B), which returns *true*
+%% if A compares less than or equal to B, false otherwise.
+-spec lww(LessOrEqual::fun((value(),value()) -> boolean()), clock()) -> clock().
+lww(F, C={E,_}) ->
+    case find_entry(F, C) of
+        {id, I, V}      -> {join_and_replace(I, V, E),[]};
+        {anonym, _, V}  -> new(join(C),[V])
+    end.
+
+%% find_entry/2 - Private function
+find_entry(F, {[], [V|T]}) -> find_entry(F, null, V, {[],T}, anonym);
+find_entry(F, {[{_, _, []} | T], Vs}) -> find_entry(F, {T,Vs});
+find_entry(F, {[{I, _, [V|_]} | T], Vs}) -> find_entry(F, I, V, {T,Vs}, id).
+
+%% find_entry/5 - Private function
+find_entry(F, I, V, C, Flag) ->
+    Fun = fun (A,B) ->
+        case F(A,B) of
+            false -> {left,A}; % A is newer than B
+            true  -> {right,B} % A is older than B
+        end
+    end,
+    find_entry2(Fun, I, V, C, Flag).
+
+%% find_entry2/5 - Private function
+find_entry2(_, I, V, {[], []}, anonym) -> {anonym, I , V};
+find_entry2(_, I, V, {[], []}, id) -> {id, I, V};
+find_entry2(F, I, V, {[], [V1 | T]}, Flag) ->
+    case F(V, V1) of
+        {left,V2}  -> find_entry2(F, I, V2, {[],T}, Flag);
+        {right,V2} -> find_entry2(F, I, V2, {[],T}, anonym)
+    end;
+find_entry2(F, I, V, {[{_, _, []} | T], Vs}, Flag) -> find_entry2(F, I, V, {T, Vs}, Flag);
+find_entry2(F, I, V, {[{I1, _, [V1|_]} | T], Vs}, Flag) -> 
+    case F(V, V1) of
+        {left,V2}  -> find_entry2(F, I, V2, {T, Vs}, Flag);
+        {right,V2} -> find_entry2(F, I1, V2, {T, Vs}, Flag)
+    end.
+
+%% Private function
+join_and_replace(Ir, V, C) -> 
+    [if
+       I == Ir -> {I, N, [V]};
+       true    -> {I, N, []}
+     end
+     || {I, N, _} <- C].
+
+
+%% ===================================================================
+%% EUnit tests
+%% ===================================================================
+-ifdef(TEST).
+
+
+join_test() ->
+    A  = new([v1]),
+    A1 = update(A,a),
+    B  = new(join(A1),[v2]),
+    B1 = update(B, A1, b),
+    ?assertEqual( join(A)  , []             ),
+    ?assertEqual( join(A1) , [{a,1}]        ),
+    ?assertEqual( join(B1) , [{a,1},{b,1}]  ),
+    ok.
+
+update_test() ->
+    A0 = update(new([v1]),a),
+    A1 = update(new(join(A0),[v2]), A0, a),
+    A2 = update(new(join(A1),[v3]), A1, b),
+    A3 = update(new(join(A0),[v4]), A1, b),
+    A4 = update(new(join(A0),[v5]), A1, a),
+    ?assertEqual( A0 , {[{a,1,[v1]}],[]}                ),
+    ?assertEqual( A1 , {[{a,2,[v2]}],[]}                ),
+    ?assertEqual( A2 , {[{a,2,[]}, {b,1,[v3]}],[]}      ),
+    ?assertEqual( A3 , {[{a,2,[v2]}, {b,1,[v4]}],[]}    ),
+    ?assertEqual( A4 , {[{a,3,[v5,v2]}],[]}             ),
+    ok.
+
+sync_test() ->
+    X   = {[{x,1,[]}],[]},
+    A   = update(new([v1]),a),
+    Y   = update(new([v2]),b),
+    A1  = update(new(join(A),[v2]), a),
+    A3  = update(new(join(A1),[v3]), b),
+    A4  = update(new(join(A1),[v3]), c),
+    F   = fun (L,R) -> L>R end,
+    W   = {[{a,1,[]}],[]},
+    Z   = {[{a,2,[v2,v1]}],[]},
+    ?assertEqual( sync([W,Z])     , {[{a,2,[v2]}],[]}                         ),
+    ?assertEqual( sync([W,Z])     , sync([Z,W])                                 ),
+    ?assertEqual( sync([A,A1])    , sync([A1,A])                                ),
+    ?assertEqual( sync([A4,A3])   , sync([A3,A4])                             ),
+    ?assertEqual( sync([A4,A3])   , {[{a,2,[]}, {b,1,[v3]}, {c,1,[v3]}],[]}   ),
+    ?assertEqual( sync([X,A])     , {[{a,1,[v1]},{x,1,[]}],[]}                ),
+    ?assertEqual( sync([X,A])     , sync([A,X])                                 ),
+    ?assertEqual( sync([X,A])     , sync([A,X])                               ),
+    ?assertEqual( sync([A,Y])     , {[{a,1,[v1]},{b,1,[v2]}],[]}              ),
+    ?assertEqual( sync([Y,A])     , sync([A,Y])                                 ),
+    ?assertEqual( sync([Y,A])     , sync([A,Y])                               ),
+    ?assertEqual( sync([A,X])     , sync([X,A])                               ),
+    ?assertEqual( lww(F,A4)     , sync([A4,lww(F,A4)])                        ),
+    ok.
+
+syn_update_test() ->
+    A0  = update(new([v1]), a),              % Mary writes v1 w/o VV
+    VV1 = join(A0),                        % Peter reads v1 with version vector (VV)
+    A1  = update(new([v2]), A0, a),          % Mary writes v2 w/o VV
+    A2  = update(new(VV1,[v3]), A1, a),      % Peter writes v3 with VV from v1
+    ?assertEqual( VV1 , [{a,1}]                          ),
+    ?assertEqual( A0  , {[{a,1,[v1]}],[]}                ),
+    ?assertEqual( A1  , {[{a,2,[v2,v1]}],[]}             ),
+    %% now A2 should only have v2 and v3, since v3 was causally newer than v1
+    ?assertEqual( A2  , {[{a,3,[v3,v2]}],[]}             ),
+    ok.
+
+event_test() ->
+    {A,_} = update(new([v1]),a),
+    ?assertEqual( event(A,a,v2) , [{a,2,[v2,v1]}]           ),
+    ?assertEqual( event(A,b,v2) , [{a,1,[v1]}, {b,1,[v2]}]  ),
+    ok.
+
+lww_last_test() ->
+    F  = fun (A,B) -> A =< B end,
+    F2 = fun ({_,TS1}, {_,TS2}) -> TS1 =< TS2 end,
+    X  = {[{a,4,[5,2]},{b,1,[]},{c,1,[3]}],[]},
+    Y  = {[{a,4,[5,2]},{b,1,[]},{c,1,[3]}],[10,0]},
+    Z  = {[{a,4,[5,2]}, {b,1,[1]}], [3]},
+    A  = {[{a,4,[{5, 1002345}, {7, 1002340}]}, {b,1,[{4, 1001340}]}], [{2, 1001140}]},
+    ?assertEqual( last(F,X) , 5                                         ),
+    ?assertEqual( last(F,Y) , 10                                        ),
+    ?assertEqual( lww(F,X)  , {[{a,4,[5]},{b,1,[]},{c,1,[]}],[]}        ),
+    ?assertEqual( lww(F,Y)  , {[{a,4,[]},{b,1,[]},{c,1,[]}],[10]}       ),
+    ?assertEqual( lww(F,Z)  , {[{a,4,[5]},{b,1,[]}],[]}                 ),
+    ?assertEqual( lww(F2,A) , {[{a,4,[{5, 1002345}]}, {b,1,[]}], []}    ),
+    ok.
+
+reconcile_test() ->
+    F1 = fun (L) -> lists:sum(L) end,
+    F2 = fun (L) -> hd(lists:sort(L)) end,
+    X  = {[{a,4,[5,2]},{b,1,[]},{c,1,[3]}],[]},
+    Y  = {[{a,4,[5,2]},{b,1,[]},{c,1,[3]}],[10,0]},
+    ?assertEqual( reconcile(F1,X) , {[{a,4,[]},{b,1,[]},{c,1,[]}],[10]} ),
+    ?assertEqual( reconcile(F1,Y) , {[{a,4,[]},{b,1,[]},{c,1,[]}],[20]} ),
+    ?assertEqual( reconcile(F2,X) , {[{a,4,[]},{b,1,[]},{c,1,[]}],[2]}  ),
+    ?assertEqual( reconcile(F2,Y) , {[{a,4,[]},{b,1,[]},{c,1,[]}],[0]}  ),
+    ok.
+
+less_test() ->
+    A  = update(new(v1),[a]),
+    B  = update(new(join(A),[v2]), a),
+    B2 = update(new(join(A),[v2]), b),
+    B3 = update(new(join(A),[v2]), z),
+    C  = update(new(join(B),[v3]), A, c),
+    D  = update(new(join(C),[v4]), B2, d),
+    ?assert(    less(A,B)  ),
+    ?assert(    less(A,C)  ),
+    ?assert(    less(B,C)  ),
+    ?assert(    less(B,D)  ),
+    ?assert(    less(B2,D) ),
+    ?assert(    less(A,D)  ),
+    ?assertNot( less(B2,C) ),
+    ?assertNot( less(B,B2) ),
+    ?assertNot( less(B2,B) ),
+    ?assertNot( less(A,A)  ),
+    ?assertNot( less(C,C)  ),
+    ?assertNot( less(D,B2) ),
+    ?assertNot( less(B3,D) ),
+    ok.
+
+equal_test() ->
+    A = {[{a,4,[v5,v0]},{b,0,[]},{c,1,[v3]}], [v0]},
+    B = {[{a,4,[v555,v0]}, {b,0,[]}, {c,1,[v3]}], []},
+    C = {[{a,4,[v5,v0]},{b,0,[]}], [v6,v1]},
+    % compare only the causal history
+    ?assert(    equal(A,B) ),
+    ?assert(    equal(B,A) ),
+    ?assertNot( equal(A,C) ),
+    ?assertNot( equal(B,C) ),
+    ok.
+
+size_test() ->
+    ?assertEqual( 1 , ?MODULE:size(new([v1]))                                         ),
+    ?assertEqual( 5 , ?MODULE:size({[{a,4,[v5,v0]},{b,0,[]},{c,1,[v3]}],[v4,v1]})   ),
+    ok.
+
+ids_values_test() ->
+    A = {[{a,4,[v0,v5]},{b,0,[]},{c,1,[v3]}], [v1]},
+    B = {[{a,4,[v0,v555]}, {b,0,[]}, {c,1,[v3]}], []},
+    C = {[{a,4,[]},{b,0,[]}], [v1,v6]},
+    ?assertEqual( ids(A)                , [a,b,c]       ),
+    ?assertEqual( ids(B)                , [a,b,c]       ),
+    ?assertEqual( ids(C)                , [a,b]         ),
+    ?assertEqual( lists:sort(values(A)) , [v0,v1,v3,v5] ),
+    ?assertEqual( lists:sort(values(B)) , [v0,v3,v555]  ),
+    ?assertEqual( lists:sort(values(C)) , [v1,v6]       ),
+    ok.
+
+map_test() ->
+    A = {[{a,4,[]},{b,0,[]},{c,1,[]}],[10]},
+    B = {[{a,4,[5,0]},{b,0,[]},{c,1,[2]}],[20,10]},
+    F = fun (X) -> X*2 end,
+    ?assertEqual( map(F,A) , {[{a,4,[]},{b,0,[]},{c,1,[]}],[20]}            ),
+    ?assertEqual( map(F,B) , {[{a,4,[10,0]},{b,0,[]},{c,1,[4]}],[40,20]}    ),
+    ok.
+
+-endif.

--- a/src/riak_core_broadcast.erl
+++ b/src/riak_core_broadcast.erl
@@ -1,0 +1,473 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_broadcast).
+
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0,
+         start_link/3,
+         broadcast/2,
+         ring_update/1,
+         broadcast_members/0,
+         set_peers/3,
+         neighbors_down/1]).
+
+%% Debug API
+-export([debug_get_peers/2,
+         debug_get_tree/2]).
+
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-define(SERVER, ?MODULE).
+
+-type nodename()        :: any().
+-type message_id()      :: any().
+-type message_round()   :: non_neg_integer().
+-type outstanding()     :: {message_id(), module(), message_round(), nodename()}.
+
+-record(state, {
+          %% Initially trees rooted at each node are the same.
+          %% Portions of that tree belonging to this node are
+          %% shared in this set.
+          common_eagers :: ordset:ordset(nodename()),
+
+          %% Initially trees rooted at each node share the same lazy links.
+          %% Typically this set will contain a single element. However, it may
+          %% contain more in large clusters and may be empty for clusters with
+          %% less than three nodes.
+          common_lazys  :: ordset:ordset(nodename()),
+
+          %% A mapping of sender node (root of each broadcast tree)
+          %% to this node's portion of the tree. Elements are
+          %% added to this structure as messages rooted at a node
+          %% propogate to this node. Nodes that are never the
+          %% root of a message will never have a key added to
+          %% `eager_sets'
+          eager_sets    :: [{nodename(), ordset:ordset(nodename())}],
+
+          %% A Mapping of sender node (root of each spanning tree)
+          %% to this node's set of lazy peers. Elements are added
+          %% to this structure as messages rooted at a node
+          %% propogate to this node. Nodes that are never the root
+          %% of a message will never have a key added to `lazy_sets'
+          lazy_sets     :: [{nodename(), ordset:ordset(nodename())}],
+
+          %% Lazy messages that have not been acked. Messages are added to
+          %% this set when a node is sent a lazy message (or when it should be
+          %% sent one sometime in the future). Messages are removed when the lazy
+          %% pushes are acknowleged via graft or ignores. Entries are keyed by their
+          %% destination
+          outstanding   :: [{nodename(), outstanding()}],
+
+          %% Set of modules that handle messages that have been broadcast
+          handling_mods :: ordset:ordset(module()),
+
+          %% Set of all known members. Used to determine
+          %% which members have joined and left during a membership update
+          all_members   :: ordset:ordset(nodename())
+         }).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%% @doc Starts the broadcast server on this node. The initial membership list is
+%% fetched from the ring. If the node is a singleton then the initial eager and lazy
+%% sets are empty. If there are two nodes, each will be in the others eager set and the
+%% lazy sets will be empty. When number of members is less than 5, each node will initially
+%% have one other node in its eager set and lazy set. If there are more than five nodes
+%% each node will have at most two other nodes in its eager set and one in its lazy set, initally.
+%% In addition, after the broadcast server is started, a callback is registered with ring_events
+%% to generate membership updates as the ring changes.
+-spec start_link() -> {ok, pid()} | ignore | {error, term()}.
+start_link() ->
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    Members = all_broadcast_members(Ring),
+    {InitEagers, InitLazys} = init_peers(Members),
+    Res = start_link(Members, InitEagers, InitLazys),
+    riak_core_ring_events:add_sup_callback(fun ?MODULE:ring_update/1),
+    Res.
+
+%% @doc Starts the broadcast server on this node. `InitMembers' must be a list
+%% of all members known to this node when starting the broadcast server.
+%% `InitEagers' are the initial peers of this node for all broadcast trees.
+%% `InitLazys' is a list of random peers not in `InitEagers' that will be used
+%% as the initial lazy peer shared by all trees for this node. If the number
+%% of nodes in the cluster is less than 3, `InitLazys' should be an empty list.
+%% `InitEagers' and `InitLazys' must also be subsets of `InitMembers'.
+%%
+%% NOTE: When starting the server using start_link/2 no automatic membership update from
+%% ring_events is registered. Use start_link/0.
+-spec start_link([nodename()], [nodename()], [nodename()]) -> {ok, pid()} | ignore | {error, term}.
+start_link(InitMembers, InitEagers, InitLazys) ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [InitMembers, InitEagers, InitLazys], []).
+
+%% @doc Broadcasts a message originating from this node. The message will be delivered to
+%% each node at least once. The `Mod' passed is responsible for handling the message on remote
+%% nodes as well as providing some other information both locally and and on other nodes.
+%% `Mod' must be loaded on all members of the clusters and implement the
+%% `riak_core_broadcast_handler' behaviour.
+-spec broadcast(any(), module()) -> ok.
+broadcast(Broadcast, Mod) ->
+    {MessageId, Payload} = Mod:broadcast_data(Broadcast),
+    gen_server:cast(?SERVER, {broadcast, MessageId, Payload, Mod}).
+
+
+%% @doc Notifies broadcast server of membership update given a new ring
+-spec ring_update(riak_core_ring:riak_core_ring()) -> ok.
+ring_update(Ring) ->
+    CurrentMembers = ordsets:from_list(all_broadcast_members(Ring)),
+    BroadcastMembers = ?MODULE:broadcast_members(),
+    New = ordsets:subtract(CurrentMembers, BroadcastMembers),
+    Removed = ordsets:subtract(BroadcastMembers, CurrentMembers),
+    case ordsets:size(New) > 0 of
+        false -> ok;
+        true ->
+            {EagerPeers, LazyPeers} = init_peers(CurrentMembers),
+            ?MODULE:set_peers(CurrentMembers, EagerPeers, LazyPeers)
+    end,
+    ?MODULE:neighbors_down(Removed).
+
+%% @doc Returns the broadcast servers view of full cluster membership.
+-spec broadcast_members() -> ordset:ordset(nodename()).
+broadcast_members() ->
+    gen_server:call(?SERVER, broadcast_members).
+
+%% @doc Sets the broadcast server's peers for all trees (effectively resetting the
+%% sender based trees). `AllMembers' must be a superset of both `EagerPeers' and
+%% `LazyPeers' which, in addition, must be disjoint
+-spec set_peers([nodename()], [nodename()], [nodename()]) -> ok.
+set_peers(AllMembers, EagerPeers, LazyPeers) ->
+    gen_server:cast(?SERVER, {set_peers, AllMembers, EagerPeers, LazyPeers}).
+
+%% @doc Notifies the broadcast server that some nodes have left the cluster
+-spec neighbors_down([nodename()]) -> ok.
+neighbors_down(Nodes) ->
+    gen_server:cast(?SERVER, {neighbors_down, Nodes}).
+
+%%%===================================================================
+%%% Debug API
+%%%===================================================================
+
+%% @doc return the peers for `Node' for the tree rooted at `Root'
+-spec debug_get_peers(node(), node()) -> {ordset:ordset(node()), ordset:ordset(node())}.
+debug_get_peers(Node, Root) ->
+    gen_server:call({?SERVER, Node}, {get_peers, Root}).
+
+%% @doc return peers for all `Nodes' for tree rooted at `Root'
+-spec debug_get_tree(node(), [node()]) ->
+                            [{node(), {ordset:ordset(node()), ordset:ordset(node())}}].
+debug_get_tree(Root, Nodes) ->
+    [begin
+         Peers = try debug_get_peers(Node, Root)
+                 catch _:_ -> down
+                 end,
+         {Node, Peers}
+     end || Node <- Nodes].
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%% @private
+-spec init([[nodename()]]) -> {ok, #state{}} |
+                                  {ok, #state{}, non_neg_integer() | infinity} |
+                                  ignore |
+                                  {stop, term()}.
+init([AllMembers, InitEagers, InitLazys]) ->
+    schedule_lazy_tick(),
+    State1 =  #state{
+       outstanding   = orddict:new(),
+       handling_mods = ordsets:new()
+     },
+    State2 = reset_peers(AllMembers, InitEagers, InitLazys, State1),
+    {ok, State2}.
+
+%% @private
+-spec handle_call(term(), {pid(), term()}, #state{}) ->
+                         {reply, term(), #state{}} |
+                         {reply, term(), #state{}, non_neg_integer()} |
+                         {noreply, #state{}} |
+                         {noreply, #state{}, non_neg_integer()} |
+                         {stop, term(), term(), #state{}} |
+                         {stop, term(), #state{}}.
+handle_call({get_peers, Root}, _From, State) ->
+    EagerPeers = all_peers(Root, State#state.eager_sets, State#state.common_eagers),
+    LazyPeers = all_peers(Root, State#state.lazy_sets, State#state.common_lazys),
+    {reply, {EagerPeers, LazyPeers}, State};
+handle_call(broadcast_members, _From, State=#state{all_members=AllMembers}) ->
+    {reply, AllMembers, State}.
+
+%% @private
+-spec handle_cast(term(), #state{}) -> {noreply, #state{}} |
+                                       {noreply, #state{}, non_neg_integer()} |
+                                       {stop, term(), #state{}}.
+handle_cast({broadcast, MessageId, Message, Mod}, State) ->
+    State1 = eager_push(MessageId, Message, Mod, State),
+    State2 = schedule_lazy_push(MessageId, Mod, State1),
+    {noreply, State2};
+handle_cast({broadcast, MessageId, Message, Mod, Round, Root, From}, State) ->
+    Valid = Mod:merge(MessageId, Message),
+    State1 = handle_broadcast(Valid, MessageId, Message, Mod, Round, Root, From, State),
+    {noreply, State1};
+handle_cast({prune, Root, From}, State) ->
+    State1 = add_lazy(From, Root, State),
+    {noreply, State1};
+handle_cast({i_have, MessageId, Mod, Round, Root, From}, State) ->
+    Stale = Mod:is_stale(MessageId),
+    State1 = handle_ihave(Stale, MessageId, Mod, Round, Root, From, State),
+    {noreply, State1};
+handle_cast({ignored_i_have, MessageId, Mod, Round, Root, From}, State) ->
+    State1 = ack_outstanding(MessageId, Mod, Round, Root, From, State),
+    {noreply, State1};
+handle_cast({graft, MessageId, Mod, Round, Root, From}, State) ->
+    Result = Mod:graft(MessageId),
+    State1 = handle_graft(Result, MessageId, Mod, Round, Root, From, State),
+    {noreply, State1};
+handle_cast({set_peers, AllMembers, EagerPeers, LazyPeers}, State) ->
+    State1 = reset_peers(AllMembers, EagerPeers, LazyPeers, State),
+    {noreply, State1};
+handle_cast({neighbors_down, Removed}, State) ->
+    State1 = neighbors_down(ordsets:from_list(Removed), State),
+    {noreply, State1}.
+
+%% @private
+-spec handle_info(term(), #state{}) -> {noreply, #state{}} |
+                                       {noreply, #state{}, non_neg_integer()} |
+                                       {stop, term(), #state{}}.
+handle_info(lazy_tick, State) ->
+    schedule_lazy_tick(),
+    send_lazy(State),
+    {noreply, State}.
+
+%% @private
+-spec terminate(term(), #state{}) -> term().
+terminate(_Reason, _State) ->
+    ok.
+
+%% @private
+-spec code_change(term() | {down, term()}, #state{}, term()) -> {ok, #state{}}.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+handle_broadcast(false, _MessageId, _Message, _Mod, _Round, Root, From, State) -> %% stale msg
+    State1 = add_lazy(From, Root, State),
+    send({prune, Root, node()}, From),
+    State1;
+handle_broadcast(true, MessageId, Message, Mod, Round, Root, From, State) -> %% valid msg
+    State1 = add_eager(From, Root, State),
+    State2 = eager_push(MessageId, Message, Mod, Round+1, Root, From, State1),
+    schedule_lazy_push(MessageId, Mod, Round+1, Root, From, State2).
+
+handle_ihave(true, MessageId, Mod, Round, Root, From, State) -> %% stale i_have
+    send({ignored_i_have, MessageId, Mod, Round, Root, node()}, From),
+    State;
+handle_ihave(false, MessageId, Mod, Round, Root, From, State) -> %% valid i_have
+    %% TODO: don't graft immediately
+    send({graft, MessageId, Mod, Round, Root, node()}, From),
+    add_eager(From, Root, State).
+
+handle_graft(stale, MessageId, Mod, Round, Root, From, State) ->
+    %% There has been a subsequent broadcast that is causally newer than this message
+    %% according to Mod. We ack the outstanding message since the outstanding entry
+    %% for the newer message exists
+    ack_outstanding(MessageId, Mod, Round, Root, From, State);
+handle_graft({ok, Message}, MessageId, Mod, Round, Root, From, State) ->
+    %% we don't ack outstanding here because the broadcast may fail to be delivered
+    %% instead we will allow the i_have to be sent once more and let the subsequent
+    %% ignore serve as the ack.
+    State1 = add_eager(From, Root, State),
+    send({broadcast, MessageId, Message, Mod, Round, Root, node()}, From),
+    State1;
+handle_graft({error, Reason}, _MessageId, Mod, _Round, _Root, _From, State) ->
+    lager:error("unable to graft message from ~p. reason: ~p", [Mod, Reason]),
+    State.
+
+neighbors_down(Removed, State=#state{common_eagers=CommonEagers,eager_sets=EagerSets,
+                                     common_lazys=CommonLazys,lazy_sets=LazySets,
+                                     outstanding=Outstanding}) ->
+    NewCommonEagers = ordsets:subtract(CommonEagers, Removed),
+    NewCommonLazys  = ordsets:subtract(CommonLazys, Removed),
+    %% TODO: once we have delayed grafting need to remove timers
+    NewEagerSets = ordsets:from_list([{Root, ordsets:subtract(Existing, Removed)} ||
+                                         {Root, Existing} <- ordsets:to_list(EagerSets)]),
+    NewLazySets  = ordsets:from_list([{Root, ordsets:subtract(Existing, Removed)} ||
+                                         {Root, Existing} <- ordsets:to_list(LazySets)]),
+    %% delete outstanding messages to removed peers
+    NewOutstanding = ordsets:fold(fun(RPeer, OutstandingAcc) ->
+                                          orddict:erase(RPeer, OutstandingAcc)
+                                  end,
+                                  Outstanding, Removed),
+    State#state{common_eagers=NewCommonEagers,
+                common_lazys=NewCommonLazys,
+                eager_sets=NewEagerSets,
+                lazy_sets=NewLazySets,
+                outstanding=NewOutstanding}.
+
+eager_push(MessageId, Message, Mod, State) ->
+    eager_push(MessageId, Message, Mod, 0, node(), node(), State).
+
+eager_push(MessageId, Message, Mod, Round, Root, From, State) ->
+    Peers = eager_peers(Root, From, State),
+    send({broadcast, MessageId, Message, Mod, Round, Root, node()}, Peers),
+    State.
+
+schedule_lazy_push(MessageId, Mod, State) ->
+    schedule_lazy_push(MessageId, Mod, 0, node(), node(), State).
+
+schedule_lazy_push(MessageId, Mod, Round, Root, From, State) ->
+    Peers = lazy_peers(Root, From, State),
+    add_all_outstanding(MessageId, Mod, Round, Root, Peers, State).
+
+send_lazy(#state{outstanding=Outstanding}) ->
+    [send_lazy(Peer, Messages) || {Peer, Messages} <- orddict:to_list(Outstanding)].
+
+send_lazy(Peer, Messages) ->
+    [send_lazy(MessageId, Mod, Round, Root, Peer) ||
+        {MessageId, Mod, Round, Root} <- ordsets:to_list(Messages)].
+
+send_lazy(MessageId, Mod, Round, Root, Peer) ->
+    send({i_have, MessageId, Mod, Round, Root, node()}, Peer).
+
+
+ack_outstanding(MessageId, Mod, Round, Root, From, State=#state{outstanding=All}) ->
+    Existing = existing_outstanding(From, All),
+    Updated = set_outstanding(From,
+                              ordsets:del_element({MessageId, Mod, Round, Root}, Existing),
+                              All),
+    State#state{outstanding=Updated}.
+
+add_all_outstanding(MessageId, Mod, Round, Root, Peers, State) ->
+    lists:foldl(fun(Peer, SAcc) -> add_outstanding(MessageId, Mod, Round, Root, Peer, SAcc) end,
+                State,
+                ordsets:to_list(Peers)).
+
+add_outstanding(MessageId, Mod, Round, Root, Peer, State=#state{outstanding=All}) ->
+    Existing = existing_outstanding(Peer, All),
+    Updated = set_outstanding(Peer,
+                              ordsets:add_element({MessageId, Mod, Round, Root}, Existing),
+                              All),
+    State#state{outstanding=Updated}.
+
+set_outstanding(Peer, Outstanding, All) ->
+    case ordsets:size(Outstanding) of
+        0 -> orddict:erase(Peer, All);
+        _ -> orddict:store(Peer, Outstanding, All)
+    end.
+
+existing_outstanding(Peer, All) ->
+    case orddict:find(Peer, All) of
+        error -> ordsets:new();
+        {ok, Outstanding} -> Outstanding
+    end.
+
+add_eager(From, Root, State) ->
+    update_peers(From, Root, fun ordsets:add_element/2, fun ordsets:del_element/2, State).
+
+add_lazy(From, Root, State) ->
+    update_peers(From, Root, fun ordsets:del_element/2, fun ordsets:add_element/2, State).
+
+update_peers(From, Root, EagerUpdate, LazyUpdate, State) ->
+    CurrentEagers = all_eager_peers(Root, State),
+    CurrentLazys = all_lazy_peers(Root, State),
+    NewEagers = EagerUpdate(From, CurrentEagers),
+    NewLazys  = LazyUpdate(From, CurrentLazys),
+    set_peers(Root, NewEagers, NewLazys, State).
+
+set_peers(Root, Eagers, Lazys, State=#state{eager_sets=EagerSets,lazy_sets=LazySets}) ->
+    NewEagers = orddict:store(Root, Eagers, EagerSets),
+    NewLazys = orddict:store(Root, Lazys, LazySets),
+    State#state{eager_sets=NewEagers, lazy_sets=NewLazys}.
+
+all_eager_peers(Root, State) ->
+    all_peers(Root, State#state.eager_sets, State#state.common_eagers).
+
+all_lazy_peers(Root, State) ->
+    all_peers(Root, State#state.lazy_sets, State#state.common_lazys).
+
+eager_peers(Root, From, #state{eager_sets=EagerSets, common_eagers=CommonEagers}) ->
+    all_filtered_peers(Root, From, EagerSets, CommonEagers).
+
+lazy_peers(Root, From, #state{lazy_sets=LazySets, common_lazys=CommonLazys}) ->
+    all_filtered_peers(Root, From, LazySets, CommonLazys).
+
+all_filtered_peers(Root, From, Sets, Common) ->
+    All = all_peers(Root, Sets, Common),
+    ordsets:del_element(From, All).
+
+all_peers(Root, Sets, Default) ->
+    case orddict:find(Root, Sets) of
+        error -> Default;
+        {ok, Peers} -> Peers
+    end.
+
+send(Msg, Peers) when is_list(Peers) ->
+    [send(Msg, P) || P <- Peers];
+send(Msg, P) ->
+    %% TODO: add debug logging
+    gen_server:cast({?SERVER, P}, Msg).
+
+schedule_lazy_tick() ->
+    TickMs = app_helper:get_env(riak_core, broadcast_lazy_timer, 1000),
+    erlang:send_after(TickMs, ?MODULE, lazy_tick).
+
+reset_peers(AllMembers, EagerPeers, LazyPeers, State) ->
+    State#state{
+      common_eagers = ordsets:del_element(node(), ordsets:from_list(EagerPeers)),
+      common_lazys  = ordsets:del_element(node(), ordsets:from_list(LazyPeers)),
+      eager_sets    = orddict:new(),
+      lazy_sets     = orddict:new(),
+      all_members   = ordsets:from_list(AllMembers)
+     }.
+
+all_broadcast_members(Ring) ->
+    riak_core_ring:members(Ring, [joining, valid, leaving, exiting, down]).
+
+init_peers(Members) ->
+    case length(Members) of
+        1 ->
+            %% Single member, must be ourselves
+            InitEagers = [],
+            InitLazys  = [];
+        2 ->
+            %% Two members, just eager push to the other
+            InitEagers = Members -- [node()],
+            InitLazys  = [];
+        N when N < 5 ->
+            %% 2 to 4 members, start with a fully connected tree
+            %% with cycles. it will be adjusted as needed
+            Tree = riak_core_util:build_tree(1, Members, [cycles]),
+            InitEagers = orddict:fetch(node(), Tree),
+            InitLazys  = [lists:nth(random:uniform(N - 2), Members -- [node() | InitEagers])];
+        N ->
+            %% 5 or more members, start with gossip tree used by
+            %% riak_core_gossip. it will be adjusted as needed
+            Tree = riak_core_util:build_tree(2, Members, [cycles]),
+            InitEagers = orddict:fetch(node(), Tree),
+            InitLazys  = [lists:nth(random:uniform(N - 3), Members -- [node() | InitEagers])]
+    end,
+    {InitEagers, InitLazys}.

--- a/src/riak_core_broadcast.erl
+++ b/src/riak_core_broadcast.erl
@@ -26,10 +26,12 @@
          start_link/3,
          broadcast/2,
          ring_update/1,
-         broadcast_members/0]).
+         broadcast_members/0,
+         broadcast_members/1]).
 
 %% Debug API
 -export([debug_get_peers/2,
+         debug_get_peers/3,
          debug_get_tree/2]).
 
 
@@ -138,20 +140,36 @@ ring_update(Ring) ->
     gen_server:cast(?SERVER, {ring_update, Ring}).
 
 %% @doc Returns the broadcast servers view of full cluster membership.
+%% Wait indefinitely for a response is returned from the process
 -spec broadcast_members() -> ordset:ordset(nodename()).
 broadcast_members() ->
-    gen_server:call(?SERVER, broadcast_members).
+    broadcast_members(infinity).
+
+%% @doc Returns the broadcast servers view of full cluster membership.
+%% Waits `Timeout' ms for a response from the server
+-spec broadcast_members(infinity | pos_integer()) -> ordset:ordset(nodename()).
+broadcast_members(Timeout) ->
+    gen_server:call(?SERVER, broadcast_members, Timeout).
 
 %%%===================================================================
 %%% Debug API
 %%%===================================================================
 
-%% @doc return the peers for `Node' for the tree rooted at `Root'
+%% @doc return the peers for `Node' for the tree rooted at `Root'. 
+%% Wait indefinitely for a response is returned from the process
 -spec debug_get_peers(node(), node()) -> {ordset:ordset(node()), ordset:ordset(node())}.
 debug_get_peers(Node, Root) ->
-    gen_server:call({?SERVER, Node}, {get_peers, Root}).
+    debug_get_peers(Node, Root, infinity).
+
+%% @doc return the peers for `Node' for the tree rooted at `Root'. 
+%% Waits `Timeout' ms for a response from the server
+-spec debug_get_peers(node(), node(), infinity | pos_integer()) ->
+                             {ordset:ordset(node()), ordset:ordset(node())}.
+debug_get_peers(Node, Root, Timeout) ->
+    gen_server:call({?SERVER, Node}, {get_peers, Root}, Timeout).
 
 %% @doc return peers for all `Nodes' for tree rooted at `Root'
+%% Wait indefinitely for a response is returned from the process
 -spec debug_get_tree(node(), [node()]) ->
                             [{node(), {ordset:ordset(node()), ordset:ordset(node())}}].
 debug_get_tree(Root, Nodes) ->

--- a/src/riak_core_broadcast_handler.erl
+++ b/src/riak_core_broadcast_handler.erl
@@ -1,0 +1,36 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_broadcast_handler).
+
+%% @doc return a two-tuple of message id and payload from a given broadcast
+-callback broadcast_data(any()) -> {any(), any()}.
+
+%% @doc given the message id and payload, merge the message in the local state.
+%% If the message has already been received return `false', otherwise return `true'
+-callback merge(any(), any()) -> boolean().
+
+%% @doc return true if the message (given the message id) has already been received.
+%% `false' otherwise
+-callback is_stale(any()) -> boolean().
+
+%% @doc return the message associated with the given message id. In some cases a message
+%% has already been sent with information that subsumes the message associated with the given
+%% message id. In this case, `stale' is returned.
+-callback graft(any()) -> stale | {ok, any()}.

--- a/src/riak_core_broadcast_handler.erl
+++ b/src/riak_core_broadcast_handler.erl
@@ -33,4 +33,4 @@
 %% @doc return the message associated with the given message id. In some cases a message
 %% has already been sent with information that subsumes the message associated with the given
 %% message id. In this case, `stale' is returned.
--callback graft(any()) -> stale | {ok, any()}.
+-callback graft(any()) -> stale | {ok, any()} | {error, any()}.

--- a/src/riak_core_metadata.erl
+++ b/src/riak_core_metadata.erl
@@ -1,0 +1,116 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_metadata).
+
+-export([get/2,
+         get/3,
+         put/3,
+         put/4]).
+
+-include("riak_core_metadata.hrl").
+
+%% Get Option Types
+-type get_opt_default_val() :: {default, metadata_value()}.
+-type get_opt_resolver()    :: {resolver, metadata_resolver()}.
+-type get_opt()             :: get_opt_default_val() | get_opt_resolver().
+-type get_opts()            :: [get_opt()].
+
+%% Put Option Types
+-type put_opts()            :: [].
+
+
+%% @doc same as get(Prefix, Key, [])
+-spec get(metadata_prefix(), metadata_key()) -> metadata_value() | undefined.
+get(Prefix, Key) ->
+    get(Prefix, Key, []).
+
+%% @doc Retrieves the local value stored at the given prefix and key.
+%%
+%% get/3 can take the following options:
+%%  * default: value to return if no value is found, `undefined' if not given.
+%%  * resolver:  A function that resolves conflicts if they are encountered. If not given
+%%               last-write-wins is used to resolve the conflicts
+%%
+%% NOTE: an update will be broadcast if conflicts are resolved. any further conflicts generated
+%% by concurrenct writes during resolution are not resolved
+-spec get(metadata_prefix(), metadata_key(), get_opts()) -> metadata_value().
+get(Prefix, Key, Opts) ->
+    PKey = prefixed_key(Prefix, Key),
+    Default = get_option(default, Opts, undefined),
+    ResolveMethod = get_option(resolver, Opts, lww),
+    case riak_core_metadata_manager:get(PKey) of
+        undefined -> Default;
+        Existing -> maybe_resolve(PKey, Existing, ResolveMethod)
+    end.
+
+%% @doc same as put(Prefix, Key, Value, [])
+-spec put(metadata_prefix(), metadata_key(), metadata_value()) -> ok.
+put(Prefix, Key, Value) ->
+    put(Prefix, Key, Value, []).
+
+%% @doc Stores the value at the given prefix and key locally and then triggers a
+%% broadcast to notify other nodes in the cluster. Currently, there are no put
+%% options
+-spec put(metadata_prefix(), metadata_key(), metadata_value(), put_opts()) -> ok.
+put(Prefix, Key, Value, _Opts) ->
+    PKey = prefixed_key(Prefix, Key),
+    CurrentContext = current_context(PKey),
+    Updated = riak_core_metadata_manager:put(PKey, CurrentContext, Value),
+    broadcast(PKey, Updated).
+
+current_context(PKey) ->
+    case riak_core_metadata_manager:get(PKey) of
+        undefined -> riak_core_metadata_object:empty_context();
+        CurrentMeta -> riak_core_metadata_object:context(CurrentMeta)
+    end.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+%% @private
+maybe_resolve(PKey, Existing, Method) ->
+    SibCount = riak_core_metadata_object:value_count(Existing),
+    maybe_resolve(PKey, Existing, SibCount, Method).
+
+%% @private
+maybe_resolve(_PKey, Existing, 1, _Method) ->
+    riak_core_metadata_object:value(Existing);
+maybe_resolve(PKey, Existing, _, Method) ->
+    Reconciled = riak_core_metadata_object:resolve(Existing, Method),
+    RContext = riak_core_metadata_object:context(Reconciled),
+    RValue = riak_core_metadata_object:value(Reconciled),
+    Stored = riak_core_metadata_manager:put(PKey, RContext, RValue),
+    broadcast(PKey, Stored),
+    RValue.
+
+%% @private
+broadcast(PKey, Obj) ->
+    Broadcast = #metadata_broadcast{pkey = PKey,
+                                    obj  = Obj},
+    riak_core_broadcast:broadcast(Broadcast, riak_core_metadata_manager).
+
+%% @private
+-spec prefixed_key(metadata_prefix(), metadata_key()) -> metadata_pkey().
+prefixed_key(Prefix, Key) ->
+    {Prefix, Key}.
+
+get_option(Key, Opts, Default) ->
+    proplists:get_value(Key, Opts, Default).

--- a/src/riak_core_metadata.erl
+++ b/src/riak_core_metadata.erl
@@ -22,6 +22,7 @@
 -export([get/2,
          get/3,
          fold/3,
+         fold/4,
          iterator/1,
          iterator/2,
          itr_next/1,
@@ -47,6 +48,7 @@
 -type it_opt_resolver()     :: {resolver, metadata_resolver() | lww}.
 -type it_opt()              :: it_opt_resolver().
 -type it_opts()             :: [it_opt()].
+-type fold_opts()           :: it_opts().
 -opaque iterator()          :: {riak_core_metadata_manager:metadata_iterator(), it_opts()}.
 
 %% Put Option Types
@@ -83,11 +85,21 @@ get({Prefix, SubPrefix}=FullPrefix, Key, Opts)
         Existing -> maybe_resolve(PKey, Existing, ResolveMethod)
     end.
 
-%% @spec Fold over all keys and values stored under a given prefix/subprefix
--spec fold(fun(({metadata_key(), [metadata_value()]}) -> any()), any(), metadata_prefix()) ->
-                  any().
+%% @spec same as fold(Fun, Acc0, FullPrefix, []).
+-spec fold(fun(({metadata_key(), [metadata_value()] | metadata_value()}, any()) -> any()),
+           any(),
+           metadata_prefix()) -> any().
 fold(Fun, Acc0, FullPrefix) ->
-    It = iterator(FullPrefix),
+    fold(Fun, Acc0, FullPrefix, []).
+
+%% @spec Fold over all keys and values stored under a given prefix/subprefix. Available
+%% options are the same as those provided to iterator/2.
+-spec fold(fun(({metadata_key(), [metadata_value()] | metadata_value()}, any()) -> any()),
+           any(),
+           metadata_prefix(),
+           fold_opts()) -> any().
+fold(Fun, Acc0, FullPrefix, Opts) ->
+    It = iterator(FullPrefix, Opts),
     fold_it(Fun, Acc0, It).
 
 fold_it(Fun, Acc, It) ->

--- a/src/riak_core_metadata.erl
+++ b/src/riak_core_metadata.erl
@@ -58,8 +58,9 @@ get(FullPrefix, Key) ->
 %% NOTE: an update will be broadcast if conflicts are resolved. any further conflicts generated
 %% by concurrenct writes during resolution are not resolved
 -spec get(metadata_prefix(), metadata_key(), get_opts()) -> metadata_value().
-get({Prefix, SubPrefix}=FullPrefix, Key, Opts) when is_binary(Prefix) andalso
-                                                    is_binary(SubPrefix) ->
+get({Prefix, SubPrefix}=FullPrefix, Key, Opts)
+  when (is_binary(Prefix) orelse is_atom(Prefix)) andalso
+       (is_binary(SubPrefix) orelse is_atom(SubPrefix)) ->
     PKey = prefixed_key(FullPrefix, Key),
     Default = get_option(default, Opts, undefined),
     ResolveMethod = get_option(resolver, Opts, lww),
@@ -85,8 +86,8 @@ fold_it(Fun, Acc, It) ->
 
 %% @doc Return an iterator pointing to the first key stored under a prefix
 -spec iterator(metadata_prefix()) -> riak_core_metadata_manager:iterator().
-iterator({Prefix, SubPrefix}=FullPrefix) when is_binary(Prefix) andalso
-                                              is_binary(SubPrefix) ->
+iterator({Prefix, SubPrefix}=FullPrefix) when (is_binary(Prefix) orelse is_atom(Prefix)) andalso
+                                              (is_binary(SubPrefix) orelse is_atom(SubPrefix)) ->
     riak_core_metadata_manager:iterator(FullPrefix).
 
 %% @doc Advances the iterator
@@ -129,8 +130,9 @@ put(FullPrefix, Key, Value) ->
 %% broadcast to notify other nodes in the cluster. Currently, there are no put
 %% options
 -spec put(metadata_prefix(), metadata_key(), metadata_value(), put_opts()) -> ok.
-put({Prefix, SubPrefix}=FullPrefix, Key, Value, _Opts) when is_binary(Prefix) andalso
-                                                            is_binary(SubPrefix) ->
+put({Prefix, SubPrefix}=FullPrefix, Key, Value, _Opts)
+  when (is_binary(Prefix) orelse is_atom(Prefix)) andalso
+       (is_binary(SubPrefix) orelse is_atom(SubPrefix)) ->
     PKey = prefixed_key(FullPrefix, Key),
     CurrentContext = current_context(PKey),
     Updated = riak_core_metadata_manager:put(PKey, CurrentContext, Value),

--- a/src/riak_core_metadata.erl
+++ b/src/riak_core_metadata.erl
@@ -51,7 +51,8 @@
 -type it_opt_resolver()     :: {resolver, metadata_resolver() | lww}.
 -type it_opt_default_fun()  :: fun((metadata_key()) -> metadata_value()).
 -type it_opt_default()      :: {default, metadata_value() | it_opt_default_fun()}.
--type it_opt()              :: it_opt_resolver() | it_opt_default().
+-type it_opt_keymatch()     :: {match, term()}.
+-type it_opt()              :: it_opt_resolver() | it_opt_default() | it_opt_keymatch().
 -type it_opts()             :: [it_opt()].
 -type fold_opts()           :: it_opts().
 -opaque iterator()          :: {riak_core_metadata_manager:metadata_iterator(), it_opts()}.
@@ -139,11 +140,14 @@ iterator(FullPrefix) ->
 %%              of the tombstone. If default is a value, the value is returned in place of
 %%              the tombstone. This applies when using functions such as itr_values/1 and
 %%              itr_key_values/1.
+%%   * match: A tuple containing erlang terms and '_'s. Match can be used to iterate
+%%            over a subset of keys -- assuming the keys stored are tuples
 -spec iterator(metadata_prefix(), it_opts()) -> iterator().
 iterator({Prefix, SubPrefix}=FullPrefix, Opts)
   when (is_binary(Prefix) orelse is_atom(Prefix)) andalso
        (is_binary(SubPrefix) orelse is_atom(SubPrefix)) ->
-    It = riak_core_metadata_manager:iterator(FullPrefix),
+    KeyMatch = proplists:get_value(match, Opts),
+    It = riak_core_metadata_manager:iterator(FullPrefix, KeyMatch),
     {It, Opts}.
 
 %% @doc Advances the iterator

--- a/src/riak_core_metadata_manager.erl
+++ b/src/riak_core_metadata_manager.erl
@@ -454,7 +454,7 @@ dets_filename({Prefix, SubPrefix}=FullPrefix) ->
 dets_filename_part(Part) when is_atom(Part) ->
     dets_filename_part(list_to_binary(atom_to_list(Part)));
 dets_filename_part(Part) when is_binary(Part) ->
-    <<MD5Int:128/integer>> = crypto:md5(Part),
+    <<MD5Int:128/integer>> = riak_core_util:md5(Part),
     riak_core_util:integer_to_list(MD5Int, 16).
 
 dets_filename_trailer(FullPrefix) ->

--- a/src/riak_core_metadata_manager.erl
+++ b/src/riak_core_metadata_manager.erl
@@ -1,0 +1,269 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_metadata_manager).
+
+-behaviour(gen_server).
+-behaviour(riak_core_broadcast_handler).
+
+%% API
+-export([start_link/0,
+         start_link/1,
+         get/1,
+         put/3]).
+
+%% riak_core_broadcast_handler callbacks
+-export([broadcast_data/1,
+         merge/2,
+         is_stale/1,
+         graft/1]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-include("riak_core_metadata.hrl").
+
+-define(SERVER, ?MODULE).
+-define(MM_DETS, mm_dets).
+-define(MM_ETS, mm_ets).
+
+-record(state, {serverid :: term()}).
+
+-type mm_path_opt()     :: {data_dir, file:name_all()}.
+-type mm_nodename_opt() :: {nodename, term()}.
+-type mm_opt()          :: mm_path_opt() | mm_nodename_opt().
+-type mm_opts()         :: [mm_opt()].
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%% @doc Same as start_link([]).
+-spec start_link() -> {ok, pid()} | ignore | {error, term()}.
+start_link() ->
+    start_link([]).
+
+%% @doc Start riak_core_metadadata_manager and link to calling process.
+%%
+%% The following options can be provided:
+%%    * data_dir: the root directory to place cluster metadata files.
+%%                if not provided this defaults to the `cluster_meta' directory in
+%%                riak_core's `platform_data_dir'.
+%%    * nodename: the node identifier (for use in logical clocks). defaults to node()
+-spec start_link(mm_opts()) -> {ok, pid()} | ignore | {error, term()}.
+start_link(Opts) ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [Opts], []).
+
+%% @doc Reads the value for a prefixed key. If the value does not exist `undefined' is
+%% returned. otherwise a Dotted Version Vector Set is returned. When reading the value
+%% for a subsequent call to put/3 the context can be obtained using
+%% riak_core_metadata_object:context/1. Values can obtained w/ riak_core_metadata_object:values/1.
+-spec get(metadata_pkey()) -> metadata_object() | undefined.
+get(PKey) ->
+    gen_server:call(?SERVER, {get, PKey}).
+
+%% @doc Sets the value of a prefixed key. The most recently read context (see get/1)
+%% should be passed as the second argument to prevent unneccessary siblings.
+-spec put(metadata_pkey(), metadata_context() | undefined, metadata_value()) -> metadata_object().
+put(PKey, undefined, Value) ->
+    %% nil is an empty version vector for dvvset
+    put(PKey, [], Value);
+put(PKey, Context, Value) ->
+    gen_server:call(?SERVER, {put, PKey, Context, Value}).
+
+%%%===================================================================
+%%% riak_core_broadcast_handler callbacks
+%%%===================================================================
+
+%% @doc Deconstructs are broadcast that is sent using `riak_core_metadata_manager' as the
+%% handling module returning the message id and payload.
+-spec broadcast_data(metadata_broadcast()) -> {{metadata_pkey(), metadata_context()},
+                                               metadata_object()}.
+broadcast_data(#metadata_broadcast{pkey=Key, obj=Obj}) ->
+    Context = riak_core_metadata_object:context(Obj),
+    {{Key, Context}, Obj}.
+
+%% @doc Merges a remote copy of a metadata record sent via broadcast w/ the local view
+%% for the key contained in the message id. If the remote copy is causally older than
+%% the current data stored then `false' is returned and no updates are merged. Otherwise,
+%% the remote copy is merged (possibly generating siblings) and `true' is returned.
+-spec merge({metadata_pkey(), metadata_context()}, metadata_object()) -> boolean().
+merge({PKey, _Context}, Obj) ->
+    gen_server:call(?SERVER, {merge, PKey, Obj}).
+
+%% @doc Returns false if the update (or a causally newer update) has already been
+%% received (stored locally).
+-spec is_stale({metadata_pkey(), metadata_context()}) -> boolean().
+is_stale({PKey, Context}) ->
+    gen_server:call(?SERVER, {is_stale, PKey, Context}).
+
+%% @doc returns the object associated with the given key and context (message id) if
+%% the currently stored version has an equal context. otherwise stale is returned.
+%% because it assumed that a grafted context can only be causally older than the local view
+%% a stale response means there is another message that subsumes the grafted one
+-spec graft({metadata_pkey(), metadata_context()}) ->
+                   stale | {ok, metadata_object()} | {error, term()}.
+graft({PKey, Context}) ->
+    case ?MODULE:get(PKey) of
+        undefined ->
+            %% There would have to be a serious error in implementation to hit this case.
+            %% Catch if here b/c it would be much harder to detect
+            lager:error("object not found during graft for key: ~p", [PKey]),
+            {error, {not_found, PKey}};
+         Obj ->
+            graft(Context, Obj)
+    end.
+
+graft(Context, Obj) ->
+    case riak_core_metadata_object:equal_context(Context, Obj) of
+        false ->
+            %% when grafting the context will never be causally newer
+            %% than what we have locally. Since its not equal, it must be
+            %% an ancestor. Thus we've sent another, newer update that contains
+            %% this context's information in addition to its own.  This graft
+            %% is deemed stale
+            stale;
+        true ->
+            {ok, Obj}
+    end.
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%% @private
+-spec init([mm_opts()]) -> {ok, #state{}} |
+                           {ok, #state{}, non_neg_integer() | infinity} |
+                           ignore |
+                           {stop, term()}.
+init([Opts]) ->
+    case data_root(Opts) of
+        undefined ->
+            {stop, no_data_dir};
+        DataRoot ->
+            Nodename = proplists:get_value(nodename, Opts, node()),
+            State = #state{serverid=Nodename},
+            State2 = init_disk_storage(DataRoot, State),
+            State3 = init_mem_storage(State2),
+            {ok, State3}
+    end.
+
+%% @private
+-spec handle_call(term(), {pid(), term()}, #state{}) ->
+                         {reply, term(), #state{}} |
+                         {reply, term(), #state{}, non_neg_integer()} |
+                         {noreply, #state{}} |
+                         {noreply, #state{}, non_neg_integer()} |
+                         {stop, term(), term(), #state{}} |
+                         {stop, term(), #state{}}.
+handle_call({put, PKey, Context, Value}, _From, State) ->
+    {Result, NewState} = read_modify_write(PKey, Context, Value, State),
+    {reply, Result, NewState};
+handle_call({merge, PKey, Obj}, _From, State) ->
+    {Result, NewState} = read_merge_write(PKey, Obj, State),
+    {reply, Result, NewState};
+handle_call({get, PKey}, _From, State) ->
+    Result = read(PKey, State),
+    {reply, Result, State};
+handle_call({is_stale, PKey, Context}, _From, State) ->
+    Existing = read(PKey, State),
+    IsStale = riak_core_metadata_object:is_stale(Context, Existing),
+    {reply, IsStale, State}.
+
+%% @private
+-spec handle_cast(term(), #state{}) -> {noreply, #state{}} |
+                                       {noreply, #state{}, non_neg_integer()} |
+                                       {stop, term(), #state{}}.
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%% @private
+%% @doc Handling all non call/cast messages
+-spec handle_info(term(), #state{}) -> {noreply, #state{}} |
+                                       {noreply, #state{}, non_neg_integer()} |
+                                       {stop, term(), #state{}}.
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%% @private
+-spec terminate(term(), #state{}) -> term().
+terminate(_Reason, _State) ->
+    ok = dets:close(?MM_DETS).
+
+
+%% @private
+-spec code_change(term() | {down, term()}, #state{}, term()) -> {ok, #state{}}.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+read_modify_write(PKey, Context, Value, State=#state{serverid=ServerId}) ->
+    Existing = read(PKey, State),
+    Modified = riak_core_metadata_object:modify(Existing, Context, Value, ServerId),
+    store(PKey, Modified, State).
+
+read_merge_write(PKey, Obj, State) ->
+    Existing = read(PKey, State),
+    case riak_core_metadata_object:reconcile(Obj, Existing) of
+        false -> {false, State};
+        {true, Reconciled} ->
+            {_, NewState} = store(PKey, Reconciled, State),
+            {true, NewState}
+    end.
+
+%% TODO: ets storage
+store(PKey, Metadata, State) ->
+    dets:insert(?MM_DETS, [{PKey, Metadata}]),
+    {Metadata, State}.
+
+%% TODO: add in ets lookup
+read(Key, _State) ->
+    case dets:lookup(?MM_DETS, Key) of
+        [] -> undefined;
+        [{Key, MetaRec}] -> MetaRec
+    end.
+
+init_disk_storage(DataRoot, State) ->
+    DetsFile = dets_file(DataRoot),
+    ok = filelib:ensure_dir(DetsFile),
+    {ok, ?MM_DETS} = dets:open_file(?MM_DETS, [{file, DetsFile}]),
+    State.
+
+init_mem_storage(State) ->
+    ?MM_ETS = ets:new(?MM_ETS, [named_table]),
+%    dets:to_ets(?MM_DETS, ?MM_ETS),
+    State.
+
+dets_file(DataRoot) ->
+    filename:join(DataRoot, "metadata").
+
+data_root(Opts) ->
+    case proplists:get_value(data_dir, Opts) of
+        undefined -> default_data_root();
+        Root -> Root
+    end.
+
+default_data_root() ->
+    case application:get_env(riak_core, platform_data_dir) of
+        {ok, PRoot} -> filename:join(PRoot, "cluster_meta");
+        undefined -> undefined
+    end.

--- a/src/riak_core_metadata_manager.erl
+++ b/src/riak_core_metadata_manager.erl
@@ -28,6 +28,7 @@
          get/1,
          iterator/1,
          iterate/1,
+         iterator_prefix/1,
          iterator_value/1,
          iterator_done/1,
          put/3]).
@@ -117,6 +118,10 @@ iterator({Prefix, SubPrefix}=FullPrefix) when (is_binary(Prefix) orelse is_atom(
 -spec iterate(metadata_iterator()) -> metadata_iterator().
 iterate(Iterator) ->
     gen_server:call(?SERVER, {iterate, Iterator}).
+
+%% @doc return the full prefix being iterated by this iterator
+-spec iterator_prefix(metadata_iterator()) -> metadata_prefix().
+iterator_prefix(#metadata_iterator{prefix=Prefix}) -> Prefix.
 
 %% @doc return the key and object pointed to by the iterator
 -spec iterator_value(metadata_iterator()) -> {metadata_key(), metadata_object()}.

--- a/src/riak_core_metadata_manager.erl
+++ b/src/riak_core_metadata_manager.erl
@@ -106,7 +106,7 @@ start_link(Opts) ->
 -spec get(metadata_pkey()) -> metadata_object() | undefined.
 get({{Prefix, SubPrefix}, _Key}=PKey) when (is_binary(Prefix) orelse is_atom(Prefix)) andalso
                                            (is_binary(SubPrefix) orelse is_atom(SubPrefix)) ->
-    gen_server:call(?SERVER, {get, PKey}).
+    gen_server:call(?SERVER, {get, PKey}, infinity).
 
 %% @doc Return an iterator for keys stored under a prefix. If KeyMatch is undefined then
 %% all keys will may be visted by the iterator. Otherwise only keys matching KeyMatch will be
@@ -121,13 +121,13 @@ get({{Prefix, SubPrefix}, _Key}=PKey) when (is_binary(Prefix) orelse is_atom(Pre
 iterator({Prefix, SubPrefix}=FullPrefix, KeyMatch)
   when (is_binary(Prefix) orelse is_atom(Prefix)) andalso
        (is_binary(SubPrefix) orelse is_atom(SubPrefix)) ->
-    gen_server:call(?SERVER, {iterator, FullPrefix, KeyMatch}).
+    gen_server:call(?SERVER, {iterator, FullPrefix, KeyMatch}, infinity).
 
 
 %% @doc advance the iterator by one key
 -spec iterate(metadata_iterator()) -> metadata_iterator().
 iterate(Iterator) ->
-    gen_server:call(?SERVER, {iterate, Iterator}).
+    gen_server:call(?SERVER, {iterate, Iterator}, infinity).
 
 %% @doc return the full prefix being iterated by this iterator
 -spec iterator_prefix(metadata_iterator()) -> metadata_prefix().
@@ -152,7 +152,7 @@ put(PKey, undefined, ValueOrFun) ->
 put({{Prefix, SubPrefix}, _Key}=PKey, Context, ValueOrFun)
   when (is_binary(Prefix) orelse is_atom(Prefix)) andalso
        (is_binary(SubPrefix) orelse is_atom(SubPrefix)) ->
-    gen_server:call(?SERVER, {put, PKey, Context, ValueOrFun}).
+    gen_server:call(?SERVER, {put, PKey, Context, ValueOrFun}, infinity).
 
 %%%===================================================================
 %%% riak_core_broadcast_handler callbacks
@@ -172,13 +172,13 @@ broadcast_data(#metadata_broadcast{pkey=Key, obj=Obj}) ->
 %% the remote copy is merged (possibly generating siblings) and `true' is returned.
 -spec merge({metadata_pkey(), metadata_context()}, metadata_object()) -> boolean().
 merge({PKey, _Context}, Obj) ->
-    gen_server:call(?SERVER, {merge, PKey, Obj}).
+    gen_server:call(?SERVER, {merge, PKey, Obj}, infinity).
 
 %% @doc Returns false if the update (or a causally newer update) has already been
 %% received (stored locally).
 -spec is_stale({metadata_pkey(), metadata_context()}) -> boolean().
 is_stale({PKey, Context}) ->
-    gen_server:call(?SERVER, {is_stale, PKey, Context}).
+    gen_server:call(?SERVER, {is_stale, PKey, Context}, infinity).
 
 %% @doc returns the object associated with the given key and context (message id) if
 %% the currently stored version has an equal context. otherwise stale is returned.

--- a/src/riak_core_metadata_object.erl
+++ b/src/riak_core_metadata_object.erl
@@ -98,7 +98,9 @@ resolve({metadata, Object}, lww) ->
     LWW = fun ({_,TS1}, {_,TS2}) -> TS1 =< TS2 end,
     {metadata, dvvset:lww(LWW, Object)};
 resolve({metadata, Existing}, Reconcile) when is_function(Reconcile) ->
-    {metadata, dvvset:reconcile(fun({A, _}, {B, _}) -> Reconcile(A, B) end, Existing)}.
+    ResolveFun = fun({A, _}, {B, _}) -> timestamped_value(Reconcile(A, B)) end,
+    F = fun([Value | Rest]) -> lists:foldl(ResolveFun, Value, Rest) end,
+    {metadata, dvvset:reconcile(F, Existing)}.
 
 %% @doc Determines if the given context (version vector) is causually newer than
 %% an existing object. If the object missing or if the context does not represent

--- a/src/riak_core_metadata_object.erl
+++ b/src/riak_core_metadata_object.erl
@@ -59,11 +59,18 @@ context({metadata, Object}) ->
 empty_context() -> [].
 
 %% @doc modifies a potentially existing object, setting its value and updating
-%% the causual history
+%% the causual history. If a function is provided as the third argument
+%% then this function also is used for conflict resolution. The difference
+%% between this function and resolve/2 is that the logical clock is advanced in the
+%% case of this function. Additionally, the resolution functions are slightly different.
 -spec modify(metadata_object() | undefined,
              metadata_context(),
-             metadata_value(),
+             metadata_value() | metadata_modifier(),
              term()) -> metadata_object().
+modify(undefined, Context, Fun, ServerId) when is_function(Fun) ->
+    modify(undefined, Context, Fun(undefined), ServerId);
+modify(Obj, Context, Fun, ServerId) when is_function(Fun) ->
+    modify(Obj, Context, Fun(values(Obj)), ServerId);
 modify(undefined, _Context, Value, ServerId) ->
     %% Ignore the context since we dont have a value, its invalid if not
     %% empty anyways, so give it a valid one

--- a/src/riak_core_metadata_object.erl
+++ b/src/riak_core_metadata_object.erl
@@ -1,0 +1,132 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_metadata_object).
+
+-export([value/1,
+         values/1,
+         value_count/1,
+         context/1,
+         empty_context/0,
+         modify/4,
+         reconcile/2,
+         resolve/2,
+         is_stale/2,
+         equal_context/2]).
+
+-include("riak_core_metadata.hrl").
+
+%% @doc returns a single value. if the object holds more than one value an error is generated
+%% @see values/2
+-spec value(metadata_object()) -> metadata_value().
+value(Metadata) ->
+    [Value] = values(Metadata),
+    Value.
+
+%% @doc returns a list of values held in the object
+-spec values(metadata_object()) -> [metadata_value()].
+values({metadata, Object}) ->
+    [Value || {Value, _Ts} <- dvvset:values(Object)].
+
+%% @doc returns the number of siblings in the given object
+-spec value_count(metadata_object()) -> non_neg_integer().
+value_count({metadata, Object}) ->
+    dvvset:size(Object).
+
+%% @doc returns the context (opaque causal history) for the given object
+-spec context(metadata_object()) -> metadata_context().
+context({metadata, Object}) ->
+    dvvset:join(Object).
+
+%% @doc returns the representation for an empty context (opaque causal history)
+-spec empty_context() -> metadata_context().
+empty_context() -> [].
+
+%% @doc modifies a potentially existing object, setting its value and updating
+%% the causual history
+-spec modify(metadata_object() | undefined,
+             metadata_context(),
+             metadata_value(),
+             term()) -> metadata_object().
+modify(undefined, _Context, Value, ServerId) ->
+    %% Ignore the context since we dont have a value, its invalid if not
+    %% empty anyways, so give it a valid one
+    NewRecord = dvvset:new(timestamped_value(Value)),
+    {metadata, dvvset:update(NewRecord, ServerId)};
+modify({metadata, Existing}, Context, Value, ServerId) ->
+    InsertRec = dvvset:new(Context, timestamped_value(Value)),
+    {metadata, dvvset:update(InsertRec, Existing, ServerId)}.
+
+%% @doc Reconciles a remote object received during replication or anti-entropy
+%% with a local object. If the remote object is an anscestor of or is equal to the local one
+%% `false' is returned, otherwise the reconciled object is returned as the second
+%% element of the two-tuple
+-spec reconcile(metadata_object(), metadata_object() | undefined) ->
+                       false | {true, metadata_object()}.
+reconcile(RemoteObj, undefined) ->
+    {true, RemoteObj};
+reconcile({metadata, RemoteObj}, {metadata, LocalObj}) ->
+    Less  = dvvset:less(RemoteObj, LocalObj),
+    Equal = dvvset:equal(RemoteObj, LocalObj),
+    case not (Equal or Less) of
+        false -> false;
+        true ->
+            {true, {metadata, dvvset:sync([LocalObj, RemoteObj])}}
+    end.
+
+%% @doc Resolves siblings using either last-write-wins or the provided function and returns
+%% an object containing a single value. The causal history is not updated
+-spec resolve(metadata_object(), lww | fun(([metadata_value()]) -> metadata_value())) ->
+                     metadata_object().
+resolve({metadata, Object}, lww) ->
+    LWW = fun ({_,TS1}, {_,TS2}) -> TS1 =< TS2 end,
+    {metadata, dvvset:lww(LWW, Object)};
+resolve({metadata, Existing}, Reconcile) when is_function(Reconcile) ->
+    {metadata, dvvset:reconcile(fun({A, _}, {B, _}) -> Reconcile(A, B) end, Existing)}.
+
+%% @doc Determines if the given context (version vector) is causually newer than
+%% an existing object. If the object missing or if the context does not represent
+%% an anscestor of the current key, false is returned. Otherwise, when the context
+%% does represent an ancestor of the existing object or the existing object itself,
+%% true is returned
+-spec is_stale(metadata_context(), metadata_object()) -> boolean().
+is_stale(_, undefined) ->
+    false;
+is_stale(RemoteContext, {metadata, Obj}) ->
+    LocalContext = dvvset:join(Obj),
+    %% returns true (stale) when local context is causally newer or equal to remote context
+    descends(LocalContext, RemoteContext).
+
+descends(_, []) ->
+    true;
+descends(Ca, Cb) ->
+    [{NodeB, CtrB} | RestB] = Cb,
+    case lists:keyfind(NodeB, 1, Ca) of
+        false -> false;
+        {_, CtrA} ->
+            (CtrA >= CtrB) andalso descends(Ca, RestB)
+    end.
+
+%% @doc Returns true if the given context and the context of the existing object are equal
+-spec equal_context(metadata_context(), metadata_object()) -> boolean().
+equal_context(Context, {metadata, Obj}) ->
+    Context =:= dvvset:join(Obj).
+
+timestamped_value(Value) ->
+    {Value, os:timestamp()}.

--- a/src/riak_core_sup.erl
+++ b/src/riak_core_sup.erl
@@ -60,6 +60,8 @@ init([]) ->
                   ?CHILD(riak_core_eventhandler_sup, supervisor),
                   ?CHILD(riak_core_ring_events, worker),
                   ?CHILD(riak_core_ring_manager, worker),
+                  ?CHILD(riak_core_metadata_manager, worker),
+                  ?CHILD(riak_core_broadcast, worker),
                   ?CHILD(riak_core_vnode_proxy_sup, supervisor),
                   ?CHILD(riak_core_node_watcher_events, worker),
                   ?CHILD(riak_core_node_watcher, worker),

--- a/src/riak_core_util.erl
+++ b/src/riak_core_util.erl
@@ -52,7 +52,8 @@
          is_arch/1,
          format_ip_and_port/2,
          peername/2,
-         sockname/2
+         sockname/2,
+         md5/1
         ]).
 
 -ifdef(TEST).
@@ -179,9 +180,15 @@ integer_to_list(I0, Base, R0) ->
 -ifndef(old_hash).
 sha(Bin) ->
     crypto:hash(sha, Bin).
+
+md5(Bin) ->
+    crypto:hash(md5, Bin).
 -else.
 sha(Bin) ->
     crypto:sha(Bin).
+
+md5(Bin) ->
+    crypto:md5(Bin).
 -endif.
 
 %% @spec unique_id_62() -> string()


### PR DESCRIPTION
This PR is the first of two that comprises the initial version of `riak_core`'s new cluster-wide meta data store. In the future, it is intended for this store to be used in place of metadata currently stored in the ring. 

**[part 2](https://github.com/basho/riak_core/pull/370) should be merged into this PR before merging into develop**

This PR includes the following:
- in-memory (and for-now on-disk) representation of metadata objects
- per-node local storage in DETS with full in-memory copy in ETS
- API for local access to metadata (get/put/iterators/folds)
- Initial implementation of broadcast support for replication (see more below)

This PR does not yet include, but may before merge:
- subsystem documentation (in docs/)

This PR does not include (see [part 2](https://github.com/basho/riak_core/pull/370)):
- ensured at-least once delivery in `riak_core_broadcast` (this is what will be included in part 2)
- local tracking of changes for groups of keys

In addition, this PR includes an implementation of [Dotted Version Vectors](https://github.com/ricardobcl/Dotted-Version-Vectors#how-to-use) which are used as the logical clock for metadata objects. The implementation is a direct copy of the implementation [built by Carlos](https://github.com/ricardobcl/riak_core/blob/dvvset/src/dvvset.erl) including the MIT license. This license, at a minimum, must be addressed pre-merge.
