### PR TITLE
Background Manager (Locks + Tokens)

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -87,7 +87,8 @@
              riak_core_ssl_util,
              supervisor_pre_r14b04,
              vclock,
-             riak_core_bg_manager
+             riak_core_bg_manager,
+             riak_core_token_manager
             ]},
   {registered, []},
   {included_applications, [folsom]},

--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -89,7 +89,8 @@
              vclock,
              riak_core_bg_manager,
              riak_core_token_manager,
-             riak_core_table_manager
+             riak_core_table_manager,
+             riak_core_bg_manager_sup
             ]},
   {registered, []},
   {included_applications, [folsom]},

--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -86,7 +86,8 @@
              riak_core_tcp_mon,
              riak_core_ssl_util,
              supervisor_pre_r14b04,
-             vclock
+             vclock,
+             riak_core_bg_manager
             ]},
   {registered, []},
   {included_applications, [folsom]},

--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -88,7 +88,8 @@
              supervisor_pre_r14b04,
              vclock,
              riak_core_bg_manager,
-             riak_core_token_manager
+             riak_core_token_manager,
+             riak_core_table_manager
             ]},
   {registered, []},
   {included_applications, [folsom]},

--- a/include/riak_core_bg_manager.hrl
+++ b/include/riak_core_bg_manager.hrl
@@ -1,0 +1,23 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-define(LM_ETS_TABLE, lock_mgr_table).   %% name of private lock manager ETS table
+-define(LM_ETS_OPTS, [private, bag]).    %% creation time properties of lock manager ETS table
+
+-type concurrency_limit() :: non_neg_integer() | infinity.

--- a/include/riak_core_token_manager.hrl
+++ b/include/riak_core_token_manager.hrl
@@ -1,3 +1,22 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
 -type tm_token() :: any().
 -type tm_meta()  :: {atom(), any()}.                %% meta data to associate with a token
 -type tm_period() :: pos_integer().                 %% refill period in milliseconds

--- a/include/riak_core_token_manager.hrl
+++ b/include/riak_core_token_manager.hrl
@@ -49,3 +49,5 @@
 -define(DEFAULT_TM_SAMPLE_WINDOW, 60).    %% in seconds
 -define(DEFAULT_TM_OUTPUT_SAMPLES, 20).   %% default number of sample windows displayed
 -define(DEFAULT_TM_KEPT_SAMPLES, 10000).  %% number of history samples to keep
+-define(TM_ETS_TABLE, token_mgr_table).   %% name of private token manager ETS table
+-define(TM_ETS_OPTS, [private, set]).     %% creation time properties of token manager ETS table

--- a/include/riak_core_token_manager.hrl
+++ b/include/riak_core_token_manager.hrl
@@ -1,0 +1,32 @@
+-type tm_token() :: any().
+-type tm_meta()  :: {atom(), any()}.                %% meta data to associate with a token
+-type tm_period() :: pos_integer().                 %% refill period in milliseconds
+-type tm_count() :: pos_integer().                  %% refill tokens to count at each refill period
+-type tm_rate() :: {tm_period(), tm_count()}.       %% token refresh rate
+-type tm_stat_event() :: refill_event | give_event. %% stat event type
+
+%% Results of a "ps" of live given or blocked tokens
+-record(tm_stat_live,
+        {
+          token      :: tm_token(),               %% token type
+          consumer   :: pid(),                    %% process asking for token
+          meta       :: [tm_meta()],              %% associated meta data
+          state      :: given | blocked | failed  %% result of last request
+        }).
+-type tm_stat_live() :: #tm_stat_live{}.
+
+%% Results of a "head" or "tail", per token
+-record(tm_stat_hist,
+        {
+          limit   :: tm_count(),       %% maximum available, defined by token rate during interval
+          refills :: tm_count(),       %% number of times this token was refilled during interval
+          given   :: tm_count(),       %% number of this token type given in interval
+          blocked :: tm_count()        %% number of blocked processes waiting for a token
+        }).
+-type tm_stat_hist() :: #tm_stat_hist{}.
+-define(DEFAULT_TM_STAT_HIST,
+        #tm_stat_hist{limit=0, refills=0, given=0, blocked=0}).
+
+-define(DEFAULT_TM_SAMPLE_WINDOW, 60).    %% in seconds
+-define(DEFAULT_TM_OUTPUT_SAMPLES, 20).   %% default number of sample windows displayed
+-define(DEFAULT_TM_KEPT_SAMPLES, 10000).  %% number of history samples to keep

--- a/include/riak_core_token_manager.hrl
+++ b/include/riak_core_token_manager.hrl
@@ -50,4 +50,4 @@
 -define(DEFAULT_TM_OUTPUT_SAMPLES, 20).   %% default number of sample windows displayed
 -define(DEFAULT_TM_KEPT_SAMPLES, 10000).  %% number of history samples to keep
 -define(TM_ETS_TABLE, token_mgr_table).   %% name of private token manager ETS table
--define(TM_ETS_OPTS, [private, set]).     %% creation time properties of token manager ETS table
+-define(TM_ETS_OPTS, [private, bag]).     %% creation time properties of token manager ETS table

--- a/src/riak_core_bg_manager.erl
+++ b/src/riak_core_bg_manager.erl
@@ -1,0 +1,210 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_bg_manager).
+
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0,
+         get_lock/1,
+         get_lock/2,
+         get_lock/3,
+         lock_count/0,
+         lock_count/1,
+         enable/1,
+         disable/1,
+         concurrency/1,
+         set_concurrency/2
+        ]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-define(DEFAULT_CONCURRENCY, 2).
+
+-define(SERVER, ?MODULE). 
+
+-record(state, { locks  :: ordict:orddict(),
+                 limits :: orddict:orddict() }).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%% @doc Starts the server
+-spec start_link() -> {ok, pid()} | ignore | {error, term}.
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+%% @doc Acquire a concurrency lock of the given type, if available,
+%%      and associate the lock with the calling process.
+-spec get_lock(any()) -> ok | max_concurrency.
+get_lock(Type) ->
+    get_lock(Type, self()).
+
+%% @doc Acquire a concurrency lock of the given type, if available,
+%%      and associate the lock with the provided pid.
+-spec get_lock(any(), pid()) -> ok | max_concurrency.
+get_lock(Type, Pid) ->
+    get_lock(Type, Pid, []).
+
+%% @doc Acquire a concurrency lock of the given type, if available,
+%%      and associate the lock with the provided pid.
+%%      TODO: info on options, but there are none right now
+-spec get_lock(any(), pid(), [{atom(), any()}]) -> ok | max_concurrency.
+get_lock(Type, Pid, Opts) ->
+    gen_server:call(?MODULE, {get_lock, Type, Pid, Opts}, infinity).
+
+%% @doc Return the current concurrency count for all lock types
+-spec lock_count() -> integer().
+lock_count() ->
+    gen_server:call(?MODULE, lock_count, infinity).
+
+%% @doc Return the current concurrency count of the given lock type.
+-spec lock_count(any()) -> integer().
+lock_count(Type) ->
+    gen_server:call(?MODULE, {lock_count, Type}, infinity).
+
+%% @doc Enable handing out of locks of the given type.
+-spec enable(any()) -> ok.
+enable(Type) ->
+    gen_server:call(?MODULE, {enable, Type}, infinity).
+
+%% @doc Disable handing out of locks of the given type.
+-spec disable(any()) -> ok.
+disable(Type) ->
+    gen_server:call(?MODULE, {disable, Type}, infinity).
+
+%% @doc Get the current maximum concurrency for the given lock type.
+-spec concurrency(any()) -> integer().
+concurrency(Type) ->
+    gen_server:call(?MODULE, {get_max_concurrency, Type}, infinity).
+
+%% @doc Set a new maximum concurrency for the given lock type;
+%%      and return the previous maximum or default.
+-spec set_concurrency(any(), integer()) -> integer().
+set_concurrency(Type, Max) ->
+    gen_server:call(?MODULE, {set_max_concurrency, Type, Max}, infinity).
+
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%% @private
+%% @doc Initializes the server
+-spec init([]) -> {ok, #state{}} |
+                  {ok, #state{}, non_neg_integer() | infinity} |
+                  ignore |
+                  {stop, term()}.
+init([]) ->
+    {ok, #state{limits=orddict:new(), locks=orddict:new()}}.
+
+%% @private
+%% @doc Handling call messages
+-spec handle_call(term(), {pid(), term()}, #state{}) ->
+                         {reply, term(), #state{}} |
+                         {reply, term(), #state{}, non_neg_integer()} |
+                         {noreply, #state{}} |
+                         {noreply, #state{}, non_neg_integer()} |
+                         {stop, term(), term(), #state{}} |
+                         {stop, term(), #state{}}.
+handle_call({get_lock, LockType, Pid, Opts}, _From, State) ->
+    {Reply, State2} = try_lock(LockType, Pid, Opts, State),
+    {reply, Reply, State2};
+handle_call({lock_count, LockType}, _From, State) ->
+    {reply, held_count(LockType, State), State};
+handle_call(lock_count, _From, State=#state{locks=Locks}) ->
+    Count = orddict:fold(fun(_, Held, Total) -> Total + length(Held) end,
+                         0, Locks),
+    {reply, Count, State}.
+
+%% @private
+%% @doc Handling cast messages
+-spec handle_cast(term(), #state{}) -> {noreply, #state{}} |
+                                       {noreply, #state{}, non_neg_integer()} |
+                                       {stop, term(), #state{}}.
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%% @private
+%% @doc Handling all non call/cast messages
+-spec handle_info(term(), #state{}) -> {noreply, #state{}} |
+                                       {noreply, #state{}, non_neg_integer()} |
+                                       {stop, term(), #state{}}.
+handle_info({'DOWN', Ref, _, _, _}, State) ->
+    State2 = release_lock(Ref, State),
+    {noreply, State2};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+-spec terminate(term(), #state{}) -> term().
+terminate(_Reason, _State) ->
+    ok.
+
+%% @private
+%% @doc Convert process state when code is changed
+-spec code_change(term() | {down, term()}, #state{}, term()) -> {ok, #state{}}.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+try_lock(LockType, Pid, Opts, State) ->
+    Limit = lock_limit(LockType, State),
+    Held  = held_count(LockType, State),
+    try_lock(Held >= Limit, LockType, Pid, Opts, State).
+
+try_lock(true, _LockType, _Pid, _Opts, State) ->
+    {max_concurrency, State};
+try_lock(false, LockType, Pid, _Opts, State=#state{locks=Locks}) ->
+    Ref = monitor(process, Pid),
+    NewLocks = orddict:append(LockType, {Pid, Ref}, Locks),
+    {ok, State#state{locks=NewLocks}}.
+
+release_lock(Ref, State=#state{locks=Locks}) ->
+    %% TODO: this makes me (jordan) :(
+    Released = orddict:map(fun(Type, Held) -> release_lock(Ref, Type, Held) end,
+                           Locks),
+    State#state{locks=Released}.
+
+release_lock(Ref, _LockType, Held) ->
+    lists:keydelete(Ref, 2, Held).
+    
+
+held_count(LockType, #state{locks=Locks}) ->
+    case orddict:find(LockType, Locks) of
+        error -> 0;             
+        {ok, Held} -> length(Held)
+    end.
+
+lock_limit(LockType, #state{limits=Limits}) ->
+    case orddict:find(LockType, Limits) of
+        error -> ?DEFAULT_CONCURRENCY;
+        {ok, Limit} -> Limit
+    end.

--- a/src/riak_core_bg_manager.erl
+++ b/src/riak_core_bg_manager.erl
@@ -358,7 +358,6 @@ enable_lock(LockType, State) ->
     update_lock_enabled(LockType, true, State).
 
 disable_lock(LockType, State) ->
-    %% TODO: should we also kill all processes that hold the lock/release all locks?
     update_lock_enabled(LockType, false, State).
 
 update_lock_enabled(LockType, Value, State) ->
@@ -368,8 +367,6 @@ update_lock_enabled(LockType, Value, State) ->
                      State).
 
 update_concurrency_limit(LockType, Limit, State) ->
-    %% TODO: if Limit < Number of Currently held locks, should we kill # Held - Limit
-    %%       processes and release their locks
     update_lock_info(LockType,
                      fun(LockInfo) -> LockInfo#lock_info{concurrency_limit=Limit} end,
                      ?DEFAULT_LOCK_INFO#lock_info{concurrency_limit=Limit},

--- a/src/riak_core_bg_manager.erl
+++ b/src/riak_core_bg_manager.erl
@@ -65,6 +65,8 @@
          tokens_waiting/1
         ]).
 
+-include("riak_core_token_manager.hrl").
+
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
@@ -110,11 +112,11 @@ disable() ->
 %%% Token API proxies to the token manager
 
 %% @doc Set the refill rate of tokens.
--spec set_token_rate(any(), riak_core_token_manager:rate()) -> riak_core_token_manager:rate().
-set_token_rate(Type, {Period, Count, StartFull}) ->
-    riak_core_token_manager:set_token_rate(Type, {Period, Count}, StartFull).
+-spec set_token_rate(any(), riak_core_token_manager:tm_rate()) -> riak_core_token_manager:tm_rate().
+set_token_rate(Type, {Period, Count}) ->
+    riak_core_token_manager:set_token_rate(Type, {Period, Count}).
 
--spec token_rate(any()) -> riak_core_token_manager:rate().
+-spec token_rate(any()) -> riak_core_token_manager:tm_rate().
 token_rate(Type) ->
     riak_core_token_manager:token_rate(Type).
 

--- a/src/riak_core_bg_manager_sup.erl
+++ b/src/riak_core_bg_manager_sup.erl
@@ -1,0 +1,47 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_core_bg_manager_sup).
+-behaviour(supervisor).
+
+%% beahvior functions
+-export([start_link/0,
+         init/1
+        ]).
+
+-define(CHILD(I,Type), {I,{I,start_link,[]},permanent,5000,Type,[I]}).
+
+%% begins the supervisor, init/1 will be called
+start_link () ->
+    supervisor:start_link({local,?MODULE},?MODULE,[]).
+
+%% Supervisor of all background manager processes
+%%
+%% Lock manager (currently in bg_manager) and Token manager both use ETS
+%% tables to manage persistent state. The table_manager is started from
+%% our parent supervisor (riak_core_sup) and creates the tables used by
+%% background managers. So, riak_core_table_manager needs to be started
+%% before this supervisor.
+
+%% @private
+init ([]) ->
+    {ok,{{one_for_all,10,10},
+         [?CHILD(riak_core_bg_manager, worker),
+          ?CHILD(riak_core_token_manager, worker)]}}.

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -90,6 +90,17 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
     SrcNode = node(),
     SrcPartition = get_src_partition(Opts),
     TargetPartition = get_target_partition(Opts),
+    LockMeta = [{direction, outbound},
+                {handoff_type, Type},
+                {target_node, TargetNode},
+                {source_node, SrcNode},
+                {target_partition, TargetPartition},
+                {source_partition, SrcPartition}],
+    case riak_core_bg_manager:get_lock(handoff, LockMeta) of
+        max_concurrency -> exit(max_concurrency);
+        ok -> ok
+    end,
+
      try
          Filter = get_filter(Opts),
          [_Name,Host] = string:tokens(atom_to_list(TargetNode), "@"),

--- a/src/riak_core_sup.erl
+++ b/src/riak_core_sup.erl
@@ -56,6 +56,7 @@ restart_webs() ->
 init([]) ->
     Children = lists:flatten(
                  [?CHILD(riak_core_sysmon_minder, worker),
+                  ?CHILD(riak_core_bg_manager, worker),
                   ?CHILD(riak_core_vnode_sup, supervisor, 305000),
                   ?CHILD(riak_core_eventhandler_sup, supervisor),
                   ?CHILD(riak_core_ring_events, worker),

--- a/src/riak_core_sup.erl
+++ b/src/riak_core_sup.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_core: Core Riak Application
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -24,6 +24,9 @@
 
 -behaviour(supervisor).
 
+-include("riak_core_bg_manager.hrl").
+-include("riak_core_token_manager.hrl").
+
 %% API
 -export([start_link/0, stop_webs/0, restart_webs/0]).
 
@@ -31,8 +34,17 @@
 -export([init/1]).
 
 %% Helper macro for declaring children of supervisor
--define(CHILD(I, Type, Timeout), {I, {I, start_link, []}, permanent, Timeout, Type, [I]}).
--define(CHILD(I, Type), ?CHILD(I, Type, 5000)).
+-define(DEFAULT_TIMEOUT, 5000).
+-define(CHILD(I, Type, Timeout, Args), {I, {I, start_link, Args}, permanent, Timeout, Type, [I]}).
+-define(CHILD(I, Type, Timeout), ?CHILD(I, Type, Timeout, [])).
+-define(CHILD(I, Type), ?CHILD(I, Type, ?DEFAULT_TIMEOUT)).
+
+%% ETS tables to be created and maintained by riak_core_table_manager, which is not linked
+%% to any processes except this supervisor. Please keep it that way so tables don't get lost
+%% when their user processes crash. Implement ETS-TRANSFER handler for user processes.
+-define(TBL_MGR_ARGS, [{?TM_ETS_TABLE, ?TM_ETS_OPTS},
+                       {?LM_ETS_TABLE, ?LM_ETS_OPTS}
+                      ]).
 
 %% ===================================================================
 %% API functions
@@ -56,7 +68,8 @@ restart_webs() ->
 init([]) ->
     Children = lists:flatten(
                  [?CHILD(riak_core_sysmon_minder, worker),
-                  ?CHILD(riak_core_bg_manager, worker),
+                  ?CHILD(riak_core_table_manager, worker, ?DEFAULT_TIMEOUT, [?TBL_MGR_ARGS]),
+                  ?CHILD(riak_core_bg_manager_sup, supervisor),
                   ?CHILD(riak_core_vnode_sup, supervisor, 305000),
                   ?CHILD(riak_core_eventhandler_sup, supervisor),
                   ?CHILD(riak_core_ring_events, worker),

--- a/src/riak_core_table_manager.erl
+++ b/src/riak_core_table_manager.erl
@@ -85,6 +85,7 @@ claim_table(TableName) ->
 %% Table specs are provided by the process that creates this table manager,
 %% presumably a supervisor such as riak_core_sup.
 init([TableSpecs]) ->
+    lager:debug("Table Manager starting up with tables: ~p", [TableSpecs]),
     Tables = lists:foldl(fun(Spec, TT) -> create_table(Spec, TT) end, [], TableSpecs),
     {ok, #state{tables=Tables}}.
 

--- a/src/riak_core_table_manager.erl
+++ b/src/riak_core_table_manager.erl
@@ -1,0 +1,186 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_core_table_manager: ETS table ownership and crash protection
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc A gen_server process that creates and serves as heir to a
+%% ETS table; and coordinates with matching user processes. If a user
+%% process exits, this server will inherit the ETS table and hand it
+%% back to the user process when it restarts.
+%%
+%% For theory of operation, please see the web page:
+%% http://steve.vinoski.net/blog/2011/03/23/dont-lose-your-ets-tables/
+
+-module(riak_core_table_manager).
+
+-behaviour(gen_server).
+
+%% API
+-export([start_link/1,
+         claim_table/1]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, {tables}).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Starts the server
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec start_link([term()]) -> {ok, Pid::pid()} | ignore | {error, Error::term()}.
+start_link(TableSpecs) ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [TableSpecs], []).
+
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Gives the registration table away to the caller, which should be
+%% the registrar process.
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec claim_table(atom()) -> ok.
+claim_table(TableName) ->
+    gen_server:call(?SERVER, {claim_table, TableName}, infinity).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Initializes the server
+%% @end
+%%--------------------------------------------------------------------
+-spec init([term()]) -> {ok, undefined}.
+%% Tables :: [{TableName, [props]}]
+%% Table specs are provided by the process that creates this table manager,
+%% presumably a supervisor such as riak_core_sup.
+init([TableSpecs]) ->
+    Tables = lists:foldl(fun(Spec, TT) -> create_table(Spec, TT) end, [], TableSpecs),
+    {ok, #state{tables=Tables}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling call messages
+%% @end
+%%--------------------------------------------------------------------
+-spec handle_call(Msg::term(), From::{pid(), term()}, State::term()) ->
+                         {reply, Reply::term(), State::term()} |
+                         {noreply, State::term()}.
+%% TableName :: atom()
+handle_call({claim_table, TableName}, {Pid, _Tag}, State) ->
+    %% The user process is (re-)claiming the table. Give it away.
+    %% We remain the heir in case the user process exits.
+    case lookup_table(TableName, State) of
+        undefined ->
+            %% Table does not exist, which is madness.
+            {reply, {undefined_table, TableName}, State};
+        TableId ->
+            lager:debug("Giving away table ~p (~p) to ~p", [TableName, TableId, Pid]),
+            ets:give_away(TableId, Pid, undefined),
+            Reply = ok,
+            {reply, Reply, State}
+    end;
+
+handle_call(_Msg, _From, State) ->
+    {noreply, State}.
+
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling cast messages
+%% @end
+%%--------------------------------------------------------------------
+-spec handle_cast(term(), term()) -> {noreply, State::term()}.
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling all non call/cast messages
+%%
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_info({'ETS-TRANSFER', TableId, FromPid, _HeirData}, State) ->
+    %% The table's user process exited and transferred the table back to us.
+    lager:debug("Table user process ~p exited, ~p received table ~p", [FromPid, self(), TableId]),
+    {noreply, State};
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec terminate(term(), term()) -> ok.
+terminate(_Reason, _State) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec code_change(term(), term(), term()) -> {ok, term()}.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+%% Create the initial table based on a table name and properties.
+%% The table will eventually be given away by claim_table, but we
+%% want to remain the heir in case the claimer crashes.
+create_table({TableName, TableProps}, Tables) ->
+    TableId = ets:new(TableName, TableProps),
+    ets:setopts(TableId, [{heir, self(), undefined}]),
+    [{TableName, TableId} | Tables].
+
+-spec lookup_table(TableName::atom(), State::term()) -> ets:tid() | undefined.
+lookup_table(TableName, #state{tables=Tables}) ->
+    proplists:get_value(TableName, Tables).

--- a/src/riak_core_token_manager.erl
+++ b/src/riak_core_token_manager.erl
@@ -16,6 +16,8 @@
 %% specific language governing permissions and limitations
 %% under the License.
 %%
+%% ./rebar skip_deps=true eunit suite=token_manager
+%%
 %% -------------------------------------------------------------------
 -module(riak_core_token_manager).
 
@@ -383,13 +385,13 @@ do_hist(End, TokenType, Offset, Count, #state{history=HistQueue}) ->
                     StatsDictList = queue:to_list(Hist),
                     [orddict:to_list(Stat) || Stat <- StatsDictList];
                 _T  ->
-                    [{TokenType, stat_window(TokenType, StatsDict)} || StatsDict <- queue:to_list(Hist)]
+                    [[{TokenType, stat_window(TokenType, StatsDict)}] || StatsDict <- queue:to_list(Hist)]
             end
     end.
 
 segment_queue(First, Last, Queue) ->
     QLen = queue:len(Queue),
-    ?debugFmt("First: ~p, Last: ~p, QLen: ~p", [First, Last, QLen]),
+%%    ?debugFmt("First: ~p, Last: ~p, QLen: ~p", [First, Last, QLen]),
     case QLen >= Last andalso QLen > 0 of
         true ->
             %% trim off extra tail, then trim head

--- a/src/riak_core_token_manager.erl
+++ b/src/riak_core_token_manager.erl
@@ -1,0 +1,232 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_token_manager).
+
+-behaviour(gen_server).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-export([start_link/0,
+         enable/0,
+         enable/1,
+         disable/0,
+         disable/1,
+         token_rate/1,
+         set_token_rate/2,
+         get_token_async/3,
+         get_token_sync/3,
+         token_types/0,
+         tokens_given/0,
+         tokens_given/1,
+         tokens_waiting/0,
+         tokens_waiting/1
+        ]).
+
+-record(state, {info    :: ordict:orddict(),
+                waiting :: queue(),
+                given   :: orddict:orddict(),
+                enabled :: boolean()}).
+
+-record(token_info, {rate      :: rate(),
+                     enabled   :: boolean()}).
+
+-type token() :: any().
+-type meta()  :: {atom(), any()}.                %% meta data to associate with a token
+-type period() :: pos_integer().                 %% refill period in milliseconds
+-type count() :: pos_integer().                  %% refill tokens to count at each refill period
+-type rate() :: {period(), count(), boolean()}.  %% token refresh rate and if starts full
+
+-define(rate(X), (X)#token_info.rate).
+-define(enabled(X), (X)#token_info.enabled).
+-define(DEFAULT_RATE, {0,0}).                    %% DO NOT CHANGE. DEFAULT SET TO ENFORCE "REGISTRATION"
+-define(DEFAULT_TOKEN_INFO, #token_info{enabled=true, rate=?DEFAULT_RATE}).
+
+-define(SERVER, ?MODULE).
+
+%% @doc Set the refill rate of tokens.
+-spec set_token_rate(token(), riak_core_token_manager:rate()) -> ok.
+set_token_rate(Type, {Period, Count, StartFull}) ->
+    riak_core_token_manager:set_token_rate(Type, {Period, Count}, StartFull).
+
+-spec token_rate(token()) -> riak_core_token_manager:rate().
+token_rate(Type) ->
+    gen_server:call(?SERVER, {token_rate, Type}, infinity).
+
+token_types() ->
+    gen_server:call(?SERVER, token_types, infinity).
+
+tokens_given() ->
+    gen_server:call(?SERVER, tokens_given, infinity).
+
+tokens_given(Type) ->
+    gen_server:call(?SERVER, {tokens_given, Type}, infinity).
+
+tokens_waiting() ->
+    gen_server:call(?SERVER, tokens_waiting, infinity).
+
+tokens_waiting(Type) ->
+    gen_server:call(?SERVER, {tokens_waiting, Type}, infinity).
+
+%% @doc Aynchronously get a token of kind Type.
+%%      Associate token with provided pid and metadata.
+%%      Returns "max_tokens" if empty.
+-spec get_token_async(token(), pid(), [meta()]) -> ok | max_concurrency.
+get_token_async(Type, Pid, Meta) ->
+    gen_server:call(?SERVER, {get_token_async, Type, Pid, Meta}, infinity).
+
+%% @doc Synchronously get a token of kind Type.
+%%      Associate token with provided pid and metadata.
+%%      Returns "max_tokens" if empty.
+-spec get_token_sync(token(), pid(), [meta()]) -> ok | max_concurrency.
+get_token_sync(Type, Pid, Meta) ->
+    gen_server:call(?SERVER, {get_token_sync, Type, Pid, Meta}, infinity).
+
+%% @doc Enable handing out of any tokens
+-spec enable() -> ok.
+enable() ->
+    gen_server:cast(?SERVER, enable).
+
+%% @doc Disable handing out of any tokens
+-spec disable() -> ok.
+disable() ->
+    gen_server:cast(?SERVER, disable).
+
+%% @doc Enable handing out of tokens of the given type.
+-spec enable(token()) -> ok.
+enable(Type) ->
+    gen_server:cast(?SERVER, {enable, Type}).
+
+
+%% @doc Siable handing out any tokens of the given type.
+-spec disable(token()) -> ok.
+disable(Type) ->
+    gen_server:cast(?SERVER, {disable, Type}).
+
+%% @doc Starts the server
+-spec start_link() -> {ok, pid()} | ignore | {error, term}.
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+%%%% Gen Server %%%%%%%
+
+%% @private
+%% @doc Initializes the server
+-spec init([]) -> {ok, #state{}} |
+                  {ok, #state{}, non_neg_integer() | infinity} |
+                  ignore |
+                  {stop, term()}.
+init([]) ->
+    {ok, #state{info=orddict:new(),
+                given=orddict:new(),
+                waiting=queue:new(),
+                enabled=true}}.
+
+%% @private
+%% @doc Handling call messages
+-spec handle_call(term(), {pid(), term()}, #state{}) ->
+                         {reply, term(), #state{}} |
+                         {reply, term(), #state{}, non_neg_integer()} |
+                         {noreply, #state{}} |
+                         {noreply, #state{}, non_neg_integer()} |
+                         {stop, term(), term(), #state{}} |
+                         {stop, term(), #state{}}.
+handle_call({token_rate, TokenType}, _From, State) ->
+    Rate = ?rate(token_info(TokenType, State)),
+    {reply, Rate, State};
+handle_call({set_token_rate, TokenType, Rate}, _From, State) ->
+    OldRate = ?rate(token_info(TokenType, State)),
+    State2 = update_token_rate(TokenType, Rate, State),
+    %% TODO: reschedule waiting callers
+    {reply, OldRate, State2};
+handle_call(Call, _From, State) ->
+    lager:warning("Unhandled call: ~p", [Call]),
+    Reply = {unhanded_call, Call},
+    {reply, Reply, State}.
+
+handle_cast({enable, Type}, State) ->
+    State2 = enable_token(Type, State),
+    {noreply, State2};
+handle_cast({disable, Type}, State) ->
+    State2 = disable_token(Type, State),
+    {noreply, State2};
+handle_cast(enable, State) ->
+    State2 = State#state{enabled=true},
+    {noreply, State2};
+handle_cast(disable, State) ->
+    State2 = State#state{enabled=false},
+    {noreply, State2};
+handle_cast(Cast, State) ->
+    lager:warning("Unhandled cast: ~p", [Cast]),
+    Reply = {unhandled_cast, Cast},
+    {reply, Reply, State}.
+
+handle_info({'DOWN', Ref, _, _, _}, State) ->
+    lager:info("Linked process died with ref ~p: ", [Ref]),
+    {noreply, State};
+handle_info(Info, State) ->
+    lager:warning("Unhandled info: ~p", [Info]),
+    {noreply, State}.
+
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+-spec terminate(term(), #state{}) -> term().
+terminate(_Reason, _State) ->
+    ok.
+
+%% @private
+%% @doc Convert process state when code is changed
+-spec code_change(term() | {down, term()}, #state{}, term()) -> {ok, #state{}}.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+
+token_info(TokenType, #state{info=Info}) ->
+    case orddict:find(TokenType, Info) of
+        error -> ?DEFAULT_TOKEN_INFO;
+        {ok, TokenInfo} -> TokenInfo
+    end.
+
+enable_token(TokenType, State) ->
+    update_token_enabled(TokenType, true, State).
+
+disable_token(TokenType, State) ->
+    update_token_enabled(TokenType, false, State).
+
+update_token_enabled(TokenType, Value, State) ->
+    update_token_info(TokenType,
+                     fun(TokenInfo) -> TokenInfo#token_info{enabled=Value} end,
+                     ?DEFAULT_TOKEN_INFO#token_info{enabled=Value},
+                     State).
+
+update_token_rate(TokenType, Rate, State) ->
+    update_token_info(TokenType,
+                     fun(TokenInfo) -> TokenInfo#token_info{rate=Rate} end,
+                     ?DEFAULT_TOKEN_INFO#token_info{rate=Rate},
+                     State).
+
+update_token_info(TokenType, Fun, Default, State=#state{info=Info}) ->
+    NewInfo = orddict:update(TokenType, Fun, Default, Info),
+    State#state{info=NewInfo}.

--- a/src/riak_core_token_manager.erl
+++ b/src/riak_core_token_manager.erl
@@ -19,13 +19,21 @@
 %% -------------------------------------------------------------------
 -module(riak_core_token_manager).
 
+-include("riak_core_token_manager.hrl").
+
 -behaviour(gen_server).
+
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
 -export([start_link/0,
+         start_link/1,
          enable/0,
          enable/1,
          disable/0,
@@ -37,66 +45,144 @@
          token_types/0,
          tokens_given/0,
          tokens_given/1,
-         tokens_waiting/0,
-         tokens_waiting/1
+         tokens_blocked/0,
+         tokens_blocked/1
         ]).
 
--record(state, {info    :: ordict:orddict(),
-                waiting :: queue(),
-                given   :: orddict:orddict(),
-                enabled :: boolean()}).
+%% reporting
+-export([clear_history/0,
+         head/0,
+         head/1,
+         head/2,
+         head/3,
+         tail/0,
+         tail/1,
+         tail/2,
+         tail/3,
+         ps/0,
+         ps/1]).
 
--record(token_info, {rate      :: rate(),
+-define(SERVER, ?MODULE).
+
+-record(state, {info    :: orddict:orddict(),    %% tm_token() -> token_info()
+                blocked :: orddict:orddict(),    %% tm_token() -> queue of token_entry()
+                given   :: orddict:orddict(),    %% tm_token() -> [token_entry()]
+                enabled :: boolean(),            %% Global enable/disable switch
+                %% stats
+                window  :: orddict:orddict(),    %% tm_token() -> tm_stat_hist()
+                history :: queue(),              %% tm_token() -> queue of tm_stat_hist()
+                window_interval :: tm_period(),  %% history window size in seconds
+                window_tref :: reference()       %% reference to history window sampler timer
+               }).
+
+%% General settings of a token type.
+-record(token_info, {rate      :: tm_rate(),
                      enabled   :: boolean()}).
-
--type token() :: any().
--type meta()  :: {atom(), any()}.                %% meta data to associate with a token
--type period() :: pos_integer().                 %% refill period in milliseconds
--type count() :: pos_integer().                  %% refill tokens to count at each refill period
--type rate() :: {period(), count(), boolean()}.  %% token refresh rate and if starts full
 
 -define(rate(X), (X)#token_info.rate).
 -define(enabled(X), (X)#token_info.enabled).
 -define(DEFAULT_RATE, {0,0}).                    %% DO NOT CHANGE. DEFAULT SET TO ENFORCE "REGISTRATION"
 -define(DEFAULT_TOKEN_INFO, #token_info{enabled=true, rate=?DEFAULT_RATE}).
 
--define(SERVER, ?MODULE).
+%% An instance of a token entry in "given" or "blocked"
+-record(token_entry, {token     :: tm_token(),
+                      pid       :: pid(),
+                      meta      :: tm_meta(),
+                      from      :: {pid(), term()},
+                      state     :: given | blocked
+                     }). %% undefined unless on queue
+
+-define(TOKEN_ENTRY(Type, Pid, Meta, From, Status),
+        #token_entry{token=Type, pid=Pid, meta=Meta, from=From, state=Status}).
+-define(token(X), (X)#token_entry.token).
+-define(pid(X), (X)#token_entry.pid).
+-define(meta(X), (X)#token_entry.meta).
+-define(from(X), (X)#token_entry.from).
+
+%% Stats
+
+clear_history() ->
+    gen_server:cast(?SERVER, clear_history).
+
+%% List history of token manager
+%% @doc show history of token request/grants over default and custom intervals.
+%%      offset is forwards-relative to the oldest sample interval
+-spec head() -> [[tm_stat_hist()]].
+head() ->
+        head(all).
+-spec head(tm_token()) -> [[tm_stat_hist()]].
+head(Token) ->
+        head(Token, ?DEFAULT_TM_OUTPUT_SAMPLES).
+-spec head(tm_token(), tm_count()) -> [[tm_stat_hist()]].
+head(Token, NumSamples) ->
+    head(Token, 0, NumSamples).
+-spec head(tm_token(), tm_count(), tm_count()) -> [[tm_stat_hist()]].
+head(Token, Offset, NumSamples) ->
+    gen_server:call(?SERVER, {head, Token, Offset, NumSamples}, infinity).
+
+%% @doc return history of token request/grants over default and custom intervals.
+%%      offset is backwards-relative to the newest sample interval
+-spec tail() -> [[tm_stat_hist()]].
+tail() ->
+    tail(all).
+-spec tail(tm_token()) -> [[tm_stat_hist()]].
+tail(Token) ->
+    tail(Token, ?DEFAULT_TM_OUTPUT_SAMPLES).
+-spec tail(tm_token(), tm_count()) -> [[tm_stat_hist()]].
+tail(Token, NumSamples) ->
+    tail(Token, NumSamples, NumSamples).
+-spec tail(tm_token(), tm_count(), tm_count()) -> [[tm_stat_hist()]].
+tail(Token, Offset, NumSamples) ->
+    gen_server:call(?SERVER, {tail, Token, Offset, NumSamples}, infinity).
+
+%% @doc List most recent requests/grants for tokens of all token types
+-spec ps() -> [tm_stat_live()].
+ps() ->
+    ps(all).
+%% @doc List most recent requests/grants for tokens for given token type
+-spec ps(tm_token()) -> [tm_stat_live()].
+ps(Token) ->
+    gen_server:call(?SERVER, {ps, Token}, infinity).
 
 %% @doc Set the refill rate of tokens.
--spec set_token_rate(token(), riak_core_token_manager:rate()) -> ok.
-set_token_rate(Type, {Period, Count, StartFull}) ->
-    riak_core_token_manager:set_token_rate(Type, {Period, Count}, StartFull).
+-spec set_token_rate(tm_token(), tm_rate()) -> ok.
+set_token_rate(Type, Rate) ->
+    gen_server:call(?SERVER, {set_token_rate, Type, Rate}, infinity).
 
--spec token_rate(token()) -> riak_core_token_manager:rate().
+-spec token_rate(tm_token()) -> tm_rate().
 token_rate(Type) ->
     gen_server:call(?SERVER, {token_rate, Type}, infinity).
 
 token_types() ->
     gen_server:call(?SERVER, token_types, infinity).
 
+%% @doc Return a list of all tokens in current given set
 tokens_given() ->
     gen_server:call(?SERVER, tokens_given, infinity).
 
+%% @doc Return a list of all tokens of type Type in current given set
 tokens_given(Type) ->
     gen_server:call(?SERVER, {tokens_given, Type}, infinity).
 
-tokens_waiting() ->
-    gen_server:call(?SERVER, tokens_waiting, infinity).
+%% @doc Return a list of all blocked tokens
+tokens_blocked() ->
+    gen_server:call(?SERVER, tokens_blocked, infinity).
 
-tokens_waiting(Type) ->
-    gen_server:call(?SERVER, {tokens_waiting, Type}, infinity).
+%% @doc Return a list of all blocked tokens of type Type
+tokens_blocked(Type) ->
+    gen_server:call(?SERVER, {tokens_blocked, Type}, infinity).
 
-%% @doc Aynchronously get a token of kind Type.
+%% @doc Asynchronously get a token of kind Type.
 %%      Associate token with provided pid and metadata.
 %%      Returns "max_tokens" if empty.
--spec get_token_async(token(), pid(), [meta()]) -> ok | max_concurrency.
+-spec get_token_async(tm_token(), pid(), [tm_meta()]) -> ok | max_tokens.
 get_token_async(Type, Pid, Meta) ->
     gen_server:call(?SERVER, {get_token_async, Type, Pid, Meta}, infinity).
 
 %% @doc Synchronously get a token of kind Type.
 %%      Associate token with provided pid and metadata.
 %%      Returns "max_tokens" if empty.
--spec get_token_sync(token(), pid(), [meta()]) -> ok | max_concurrency.
+-spec get_token_sync(tm_token(), pid(), [tm_meta()]) -> ok | max_tokens.
 get_token_sync(Type, Pid, Meta) ->
     gen_server:call(?SERVER, {get_token_sync, Type, Pid, Meta}, infinity).
 
@@ -111,34 +197,43 @@ disable() ->
     gen_server:cast(?SERVER, disable).
 
 %% @doc Enable handing out of tokens of the given type.
--spec enable(token()) -> ok.
+-spec enable(tm_token()) -> ok.
 enable(Type) ->
     gen_server:cast(?SERVER, {enable, Type}).
 
 
 %% @doc Siable handing out any tokens of the given type.
--spec disable(token()) -> ok.
+-spec disable(tm_token()) -> ok.
 disable(Type) ->
     gen_server:cast(?SERVER, {disable, Type}).
 
 %% @doc Starts the server
 -spec start_link() -> {ok, pid()} | ignore | {error, term}.
 start_link() ->
-    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+    start_link(?DEFAULT_TM_SAMPLE_WINDOW).
+
+-spec start_link(tm_period()) -> {ok, pid()} | ignore | {error, term}.
+start_link(Interval) ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [Interval], []).
 
 %%%% Gen Server %%%%%%%
 
 %% @private
-%% @doc Initializes the server
--spec init([]) -> {ok, #state{}} |
-                  {ok, #state{}, non_neg_integer() | infinity} |
-                  ignore |
-                  {stop, term()}.
-init([]) ->
-    {ok, #state{info=orddict:new(),
-                given=orddict:new(),
-                waiting=queue:new(),
-                enabled=true}}.
+%% @doc Initializes the server with a history window interval in seconds
+-spec init([tm_period()]) -> {ok, #state{}} |
+                             {ok, #state{}, non_neg_integer() | infinity} |
+                             ignore |
+                             {stop, term()}.
+init([Interval]) ->
+    State = #state{info=orddict:new(),
+                   given=orddict:new(),
+                   blocked=orddict:new(),
+                   window=orddict:new(),
+                   history=queue:new(),
+                   enabled=true,
+                   window_interval=Interval},
+    State2 = schedule_sample_history(State),
+    {ok, State2}.
 
 %% @private
 %% @doc Handling call messages
@@ -153,15 +248,44 @@ handle_call({token_rate, TokenType}, _From, State) ->
     Rate = ?rate(token_info(TokenType, State)),
     {reply, Rate, State};
 handle_call({set_token_rate, TokenType, Rate}, _From, State) ->
-    OldRate = ?rate(token_info(TokenType, State)),
-    State2 = update_token_rate(TokenType, Rate, State),
-    %% TODO: reschedule waiting callers
+    {OldRate, State2} = do_set_token_rate(TokenType, Rate, State),
     {reply, OldRate, State2};
+handle_call(token_types, _From, State) ->
+    Result = do_token_types(State),
+    {reply, Result, State};
+handle_call(tokens_given, _From, State) ->
+    Result = do_ps(all, [given], State),
+    {reply, Result, State};
+handle_call({tokens_given, Token}, _From, State) ->
+    Result = do_ps(Token, [given], State),
+    {reply, Result, State};
+handle_call(tokens_blocked, _From, State) ->
+    Result = do_ps(all, [blocked], State),
+    {reply, Result, State};
+handle_call({tokens_blocked, Token}, _From, State) ->
+    Result = do_ps(Token, [blocked], State),
+    {reply, Result, State};
+handle_call({get_token_async, Type, Pid, Meta}, _From, State) ->
+    do_get_token_async(Type, Pid, Meta, State);
+handle_call({get_token_sync, Type, Pid, Meta}, From, State) ->
+    do_get_token_sync(Type, Pid, Meta, From, State);
+handle_call({head, Token, Offset, Count}, _From, State) ->
+    Result = do_hist(head, Token, Offset, Count, State),
+    {reply, Result, State};
+handle_call({tail, Token, Offset, Count}, _From, State) ->
+    Result = do_hist(tail, Token, Offset, Count, State),
+    {reply, Result, State};
+handle_call({ps, Token}, _From, State) ->
+    Result = do_ps(Token, [given, blocked], State),
+    {reply, Result, State};
 handle_call(Call, _From, State) ->
     lager:warning("Unhandled call: ~p", [Call]),
     Reply = {unhanded_call, Call},
     {reply, Reply, State}.
 
+handle_cast(clear_history, State) ->
+    State2 = do_clear_history(State),
+    {noreply, State2};
 handle_cast({enable, Type}, State) ->
     State2 = enable_token(Type, State),
     {noreply, State2};
@@ -179,6 +303,14 @@ handle_cast(Cast, State) ->
     Reply = {unhandled_cast, Cast},
     {reply, Reply, State}.
 
+handle_info(sample_history, State) ->
+    State2 = schedule_sample_history(State),
+    State3 = do_sample_history(State2),
+    {noreply, State3};
+handle_info({refill_tokens, Type}, State) ->
+    State2 = do_refill_tokens(Type, State),
+    schedule_refill_tokens(Type, State2),
+    {noreply, State2};
 handle_info({'DOWN', Ref, _, _, _}, State) ->
     lager:info("Linked process died with ref ~p: ", [Ref]),
     {noreply, State};
@@ -202,11 +334,243 @@ terminate(_Reason, _State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+%% Get stat history for given token type from sample set
+-spec stat_window(tm_token(), orddict:orddict()) -> tm_stat_hist().
+stat_window(TokenType, Window) ->
+    case orddict:find(TokenType, Window) of
+        error -> ?DEFAULT_TM_STAT_HIST;
+        {ok, StatHist} -> StatHist
+    end.
+
+do_token_types(#state{info=Tokens}) ->
+    orddict:fetch_keys(Tokens).
+
+do_set_token_rate(TokenType, Rate, State) ->
+    OldRate = ?rate(token_info(TokenType, State)),
+    State2 = update_token_rate(TokenType, Rate, State),
+    schedule_refill_tokens(TokenType, State2),
+    %% maybe reschedule blocked callers
+    State3 = maybe_unblock_blocked(TokenType, State2),
+    {OldRate, State3}.
+
+%% erase saved history
+do_clear_history(State=#state{window_tref=TRef}) ->
+    erlang:cancel_timer(TRef),
+    State2 = State#state{history=queue:new()},
+    schedule_sample_history(State2).
+
+%% Return stats history from head or tail of stats history queue
+do_hist(End, TokenType, Offset, Count, State) when Offset =< 0 ->
+    do_hist(End, TokenType, 1, Count, State);
+do_hist(End, TokenType, Offset, Count, State) when Count =< 0 ->
+    do_hist(End, TokenType, Offset, ?DEFAULT_TM_OUTPUT_SAMPLES, State);
+do_hist(End, TokenType, Offset, Count, #state{history=HistQueue}) ->
+    QLen = queue:len(HistQueue),
+    First = max(1, case End of
+                       head -> Offset;
+                       tail -> QLen - Offset + 1
+                   end),
+    Last = min(QLen, max(First + Count - 1, 1)),
+    case segment_queue(First, Last, HistQueue) of
+        empty -> [];
+        {ok, Hist } -> 
+            case TokenType of
+                all ->
+                    StatsDictList = queue:to_list(Hist),
+                    [orddict:to_list(Stat) || Stat <- StatsDictList];
+                _T  ->
+                    [{TokenType, stat_window(TokenType, StatsDict)} || StatsDict <- queue:to_list(Hist)]
+            end
+    end.
+
+segment_queue(First, Last, Queue) ->
+    QLen = queue:len(Queue),
+    ?debugFmt("First: ~p, Last: ~p, QLen: ~p", [First, Last, QLen]),
+    case QLen >= Last andalso QLen > 0 of
+        true ->
+            %% trim off extra tail, then trim head
+            Front = case QLen == Last of
+                        true -> Queue;
+                        false ->
+                            {QFirst, _QRest} = queue:split(Last, Queue),
+                            QFirst
+                    end,
+            case First == 1 of
+                true -> {ok, Front};
+                false ->
+                    {_Skip, Back} = queue:split(First-1, Front),
+                    {ok, Back}
+            end;
+        false ->
+            %% empty
+            empty
+    end.
+    
+
+format_entry(Entry) ->
+%%  ?debugFmt("Entry: ~p~n", [Entry]),
+    #tm_stat_live
+        {
+          token = Entry#token_entry.token,
+          consumer = Entry#token_entry.pid,
+          meta = Entry#token_entry.meta,
+          state = Entry#token_entry.state
+        }.
+
+fmt_live_tokens(Entries) ->
+    [format_entry(Entry) || Entry <- Entries].
+
+do_ps(all, Status, #state{given=Given, blocked=Blocked}) ->
+    E1 = case lists:member(given, Status) of
+             true -> 
+                 lists:flatten([Entries || {_T, Entries} <- orddict:to_list(Given)]);
+             false ->
+                 []
+         end,
+    E2 = case lists:member(blocked, Status) of
+             true ->
+                 E1 ++ lists:flatten(
+                         [[Entry || Entry <- queue:to_list(Q)] || {_T, Q} <- orddict:to_list(Blocked)]);
+             false ->
+                 E1
+         end,
+    fmt_live_tokens(E2);
+do_ps(TokenType, Status, State) ->
+    E1 = case lists:member(given, Status) of
+             true ->
+                 tokens_given(TokenType, State);
+             false ->
+                 []
+         end,
+    E2 = case lists:member(blocked, Status) of
+             true ->
+                 E1 ++ queue:to_list(token_queue(TokenType, State));
+             false ->
+                 E1
+         end,
+    fmt_live_tokens(E2).
+
+%% Possibly send replies to processes blocked on tokens of Type.
+%% Returns new State.
+give_available_tokens(Type, 0, TokenQueue, State) ->
+    %% no more available tokens to give out
+    update_token_queue(Type, TokenQueue, State);
+give_available_tokens(Type, NumAvailable, TokenQueue, State) ->
+    case queue:out(TokenQueue) of
+        {empty, _Q} ->
+            %% no more blocked entries
+            State;
+        {{value, Entry}, TokenQueue2} ->
+%%            ?debugFmt("Entry: ~p", [Entry]),
+            %% queue entry to unblock
+            Pid = ?pid(Entry),
+            Meta = ?meta(Entry),
+            From = ?from(Entry),
+            %% account for given token
+            State2 = give_token(Type, Pid, Meta, State),
+            %% send reply to blocked caller, unblocking them.
+            gen_server:reply(From, ok),
+            %% unblock next blocked in queue
+            give_available_tokens(Type, NumAvailable-1,TokenQueue2,State2)
+    end.
+
+%% For the given type, check the current given count and if less
+%% than the rate limit, give out as many tokens as are available
+%% to callers on the blocked list. They need a reply because they
+%% made a gen_server:call() that we have not replied to yet.
+maybe_unblock_blocked(Type, State) ->
+    Entries = tokens_given(Type, State),
+    {_Period, MaxCount} = ?rate(token_info(Type, State)),
+    PosNumAvailable = erlang:max(MaxCount - length(Entries), 0),
+    Queue = token_queue(Type, State),
+    give_available_tokens(Type, PosNumAvailable, Queue, State).
+
+%% Schedule a timer event to refill tokens of given type
+schedule_refill_tokens(Type, State) ->
+    {Period, _Count} = ?rate(token_info(Type, State)),
+    erlang:send_after(Period*1000, self(), {refill_tokens, Type}).
+
+%% Schedule a timer event to snapshot the current history
+schedule_sample_history(State=#state{window_interval=Interval}) ->
+    TRef = erlang:send_after(Interval*1000, self(), sample_history),
+    State#state{window_tref=TRef}.
+
+do_sample_history(State=#state{window=Window, history=Histories}) ->
+    %% Move the current window of measurements onto the history queues.
+    %% Trim queue down to DEFAULT_TM_KEPT_SAMPLES if too big now.
+    Queue2 = queue:in(Window, Histories),
+    Trimmed = case queue:len(Queue2) > ?DEFAULT_TM_KEPT_SAMPLES of
+                  true ->
+                      {_Discarded, Rest} = queue:out(Queue2),
+                      Rest;
+                  false ->
+                      Queue2
+              end,
+%%    ?debugFmt("Storing a sample history, Queue[~p]: ~p", [queue:len(Trimmed), Trimmed]),
+    EmptyWindow = orddict:new(),
+    State#state{window=EmptyWindow, history=Trimmed}.
+
+update_stat_window(TokenType, Fun, Default, State=#state{window=Window}) ->
+    NewWindow = orddict:update(TokenType, Fun, Default, Window),
+    State#state{window=NewWindow}.
+
+default_refill(Token, State) ->
+%%    ?debugFmt("default_refill: ~p", [Token]),
+    {_Rate, Limit} = ?rate(token_info(Token, State)),
+    ?DEFAULT_TM_STAT_HIST#tm_stat_hist{refills=1, limit=Limit}.
+
+default_given(Token, State) ->
+%%    ?debugFmt("default_given: ~p", [Token]),
+    {_Rate, Limit} = ?rate(token_info(Token, State)),
+    ?DEFAULT_TM_STAT_HIST#tm_stat_hist{given=1, limit=Limit}.
+
+increment_stat_refills(Token, State) ->
+    update_stat_window(Token,
+                       fun(Stat) -> Stat#tm_stat_hist{refills=1+Stat#tm_stat_hist.refills} end,
+                       default_refill(Token, State),
+                       State).
+
+increment_stat_given(Token, State) ->
+    update_stat_window(Token,
+                       fun(Stat) -> Stat#tm_stat_hist{given=1+Stat#tm_stat_hist.given} end,
+                       default_given(Token, State),
+                       State).
+
+increment_stat_blocked(Token, State) ->
+    {_Rate, Limit} = ?rate(token_info(Token, State)),
+    update_stat_window(Token,
+                       fun(Stat) -> Stat#tm_stat_hist{blocked=1+Stat#tm_stat_hist.blocked} end,
+                       ?DEFAULT_TM_STAT_HIST#tm_stat_hist{blocked=1, limit=Limit},
+                       State).
+
+%% Token refill timer event handler.
+%%   Capture stats of what was given in the previous period,
+%%   Clear all tokens of this type from the given set,
+%%   Unblock blocked processes if possible.
+do_refill_tokens(Type, State=#state{given=Given}) ->
+%%    ?debugFmt("refilling tokens for type: ~p", [Type]),
+    State2 = increment_stat_refills(Type, State),
+    NewGiven = orddict:erase(Type, Given),
+    maybe_unblock_blocked(Type, State2#state{given=NewGiven}).
 
 token_info(TokenType, #state{info=Info}) ->
     case orddict:find(TokenType, Info) of
         error -> ?DEFAULT_TOKEN_INFO;
         {ok, TokenInfo} -> TokenInfo
+    end.
+
+update_token_queue(TokenType, TokenQueue, State=#state{blocked=Orddict1}) ->
+    Fun = fun(_Val) -> TokenQueue end,
+    State#state{blocked=orddict:update(TokenType, Fun, TokenQueue, Orddict1)}.
+
+token_queue(TokenType, #state{blocked=Orddict1}) ->
+    case orddict:find(TokenType, Orddict1) of
+        error -> queue:new();
+        {ok, TokenQueue} -> TokenQueue
     end.
 
 enable_token(TokenType, State) ->
@@ -230,3 +594,50 @@ update_token_rate(TokenType, Rate, State) ->
 update_token_info(TokenType, Fun, Default, State=#state{info=Info}) ->
     NewInfo = orddict:update(TokenType, Fun, Default, Info),
     State#state{info=NewInfo}.
+
+tokens_given(Type, #state{given=AllGiven}) ->
+    case orddict:find(Type, AllGiven) of
+        error -> [];
+        {ok, Given} -> Given
+    end.
+
+%% Add a token of type to our given set and remove it from blocked set if present
+give_token(Type, Pid, Meta, State=#state{given=Given, blocked=Blocked}) ->
+    Entry = ?TOKEN_ENTRY(Type, Pid, Meta, undefined, given),
+    NewGiven = orddict:append(Type, Entry, Given),
+    NewBlocked = orddict:erase(Type, Blocked),
+    %% update given stats
+    State2 = increment_stat_given(Type, State),
+    State2#state{given=NewGiven, blocked=NewBlocked}.
+
+%% Put a token request on the blocked queue. We'll reply later when a token
+%% becomes available
+enqueue_request(Type, Pid, Meta, From, State) ->
+    OldQueue = token_queue(Type, State),
+    NewQueue = queue:in(?TOKEN_ENTRY(Type, Pid, Meta, From, blocked), OldQueue),
+    %% update blocked stats
+    State2 = increment_stat_blocked(Type, State),
+    %% Put new queue back in state
+    update_token_queue(Type, NewQueue, State2).
+
+%% reply ok now if available or max_tokens if not. Non-blocking
+do_get_token_async(Type, Pid, Meta, State) ->
+    Info = token_info(Type, State),
+    Entries = tokens_given(Type, State),
+    {_Period, MaxCount} = ?rate(Info),
+    case length(Entries) < MaxCount of
+        true ->
+            %% tokens are available
+            {reply, ok, give_token(Type, Pid, Meta, State)};
+        false ->
+            {reply, max_tokens, State}
+    end.
+
+%% reply now if available or reply later if en-queued. Blocking
+do_get_token_sync(Type, Pid, Meta, From, State) ->
+    case do_get_token_async(Type, Pid, Meta, State) of
+        {reply, max_tokens, _S} ->
+            {noreply, enqueue_request(Type, Pid, Meta, From, State)};
+        {reply, ok, State2} ->
+            {reply, ok, State2}
+    end.

--- a/test/token_manager_tests.erl
+++ b/test/token_manager_tests.erl
@@ -1,0 +1,249 @@
+-module(token_manager_tests).
+-compile(export_all).
+
+-include_lib("riak_core_token_manager.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(TOK_MGR, riak_core_token_manager).
+
+token_mgr_test_() ->
+    {timeout, 60000,  %% Seconds to finish all of the tests
+     {setup, fun() -> ?TOK_MGR:start_link(1) end, %% setup with history window to 1 seconds
+      fun(_) -> ok end,                           %% cleanup
+      fun(_) ->
+              [ %% Tests
+                { "set/get token rates",
+                  fun() ->
+                          setup_token_rates(),
+                          verify_token_rates()
+                  end},
+
+                { "head - empty",
+                  fun() ->
+                          %% we haven't taken a sample yet, so history is empty
+                          Hist = ?TOK_MGR:head(),
+                          ?assertEqual([], Hist)
+                  end},
+
+                { "token types",
+                  fun() ->
+                          Types = ?TOK_MGR:token_types(),
+                          ?assertEqual(lists:sort(expected_token_types()), lists:sort(Types))
+                  end},
+
+                { "no tokens given",
+                  fun() ->
+                          Given = ?TOK_MGR:tokens_given(),
+                          ?assertEqual([], Given)
+                  end},
+                
+                { "get_token_sync + tokens_given",
+                  fun() ->
+                          Meta1 = [{foo,bar}],
+                          Meta2 = [{moo,tar,blar}],
+                          Pid = self(),
+                          ok = ?TOK_MGR:get_token_async(token1, Pid, Meta1),
+                          ok = ?TOK_MGR:get_token_async(token2, Pid, Meta2),
+                          AllGiven = ?TOK_MGR:tokens_given(),
+                          ?assertEqual(lists:sort([make_live_stat(token1, Pid, Meta1, given),
+                                                   make_live_stat(token2, Pid, Meta2, given)]),
+                                       lists:sort(AllGiven)),
+                          Given = ?TOK_MGR:tokens_given(token1),
+                          ?assertEqual([make_live_stat(token1, Pid, Meta1, given)], Given)
+                  end},
+
+                { "get_token_sync + tokens_given + max_concurrency",
+                  fun() ->
+                          ?assertNot([] == ?TOK_MGR:tokens_given()),
+                          %% let tokens refill and confirm available
+                          MaxPeriod = (max_token_period() * 1000) + 100,
+                          timer:sleep(MaxPeriod),
+                          ?assertEqual([], ?TOK_MGR:tokens_given()),
+
+                          Pid = self(),
+                          DoOne =
+                              fun(Token) ->
+                                      %% Max out the tokens for this period
+                                      N = expected_token_limit(Token),
+                                      [ok = ?TOK_MGR:get_token_async(Token,Pid,[{meta,M}])
+                                       || M <- lists:seq(1,N)],
+                                      Expected = [make_live_stat(Token,Pid,[{meta,M}],given)
+                                                  || M <- lists:seq(1,N)],
+                                      %% try to get another, but it should fail
+                                      ?assertEqual(max_tokens, ?TOK_MGR:get_token_async(Token,Pid,{meta,N+1})),
+                                      Given = ?TOK_MGR:tokens_given(Token),
+                                      ?assertEqual(Expected, Given)
+                              end,
+                          %% all of our test token types
+                          Tokens = expected_token_types(),
+                          %% can get requested and nothing should balk
+                          [DoOne(Token) || Token <- Tokens],
+                          %% Does the total number of given tokens add up the expected limit?
+                          TotalLimits = lists:foldl(fun(Limit,Sum) -> Limit+Sum end, 0,
+                                                    [expected_token_limit(Token) || Token <- Tokens]),
+                          AllGiven = ?TOK_MGR:tokens_given(),
+                          ?assertEqual(TotalLimits, erlang:length(AllGiven))
+                  end},
+
+                { "get_token_sync blocking",
+                  fun() ->
+                          %% all the tokens have been max'd out now.
+                          %% start sub-process that will block on a token
+                          Meta = [{i,am,blocked}],
+                          TestPid = self(),
+                          Pid = spawn(fun() ->
+                                              TestPid ! {blocking, self()},
+                                              ok = ?TOK_MGR:get_token_sync(token1, self(), Meta),
+                                              TestPid ! {unblocked, self()}
+                                      end),
+                          receive
+                              {blocking, Pid} ->
+                                  timer:sleep(10),
+                                  %% check that we have one on the waiting list
+                                  Blocked1 = ?TOK_MGR:tokens_blocked(),
+                                  ?assertEqual([make_live_stat(token1, Pid, Meta, blocked)], Blocked1)
+                          end,
+                          %% let tokens refill and confirm available and blocked is now given
+                          MaxPeriod = (max_token_period() * 1000) + 100,
+                          receive
+                              {unblocked,Pid} ->
+                                  %% check that our token was given and the blocked queue is empty
+                                  Blocked2 = ?TOK_MGR:tokens_blocked(),
+                                  Given2 = ?TOK_MGR:tokens_given(token1),
+                                  ?assertEqual([make_live_stat(token1, Pid, Meta, given)], Given2),
+                                  ?assertEqual([],Blocked2)
+                          after MaxPeriod ->
+                                  ?assert(false)
+                          end
+                  end},
+
+                { "head - with samples",
+                  fun() ->
+                          %% 
+                          Hist = ?TOK_MGR:head(),
+%%                          ?debugFmt("History: ~p", [Hist]),
+                          ?assertNot([] == Hist)
+                  end},
+
+                { "clear history",
+                  fun() ->
+                          ?TOK_MGR:clear_history(),
+                          Hist = ?TOK_MGR:head(),
+                          ?assertEqual([], Hist)
+                  end},
+
+                { "clear all tokens given and confirm none given",
+                  fun() ->
+                          %% wait a little longer than longest refill time.
+                          MaxPeriod = (max_token_period() * 1000) + 100,
+                          timer:sleep(MaxPeriod),
+                          %% confirm none given now
+                          ?assertEqual([], ?TOK_MGR:tokens_given())
+                  end},
+                
+                { "synchronous gets and history test",
+                  fun() ->
+                          Tokens = expected_token_types(),
+                          %% clear history and let 1 sample be taken with empty stats
+                          %% Sample1: empty
+                          ?TOK_MGR:clear_history(),
+                          E1 = [{Token, make_hist_stat(expected_token_limit(Token),1,0,0)} || Token <- Tokens],
+                          timer:sleep(1000),
+                          %% Sample2: 1 given for each token
+                          E2 = [get_n_tokens(Token, self(), 1) || Token <- Tokens],
+                          timer:sleep(1000),
+                          %% Sample3: max given for each token, plus 2 blocked
+                          E3 = [max_out_plus(Token, self(), 2) || Token <- Tokens],
+                          timer:sleep(1000),
+                          %% verify history
+                          %% TODO: refills is hard to calculate and needs a better solution
+                          ?assertEqual([E1,E2,E3], ?TOK_MGR:head()),
+                          ?assertEqual([E1], ?TOK_MGR:head(all,1)),
+                          ?assertEqual([E2], ?TOK_MGR:head(all,2,1)),  %% head(offset, count)
+                          ?assertEqual([E3], ?TOK_MGR:head(all,3,1)),
+                          ?assertEqual([E1,E2], ?TOK_MGR:head(all,2)),
+                          ?assertEqual([E2,E3], ?TOK_MGR:head(all,2,2)),
+                          ?assertEqual([E1,E2,E3], ?TOK_MGR:head(all,3)),
+                          ?assertEqual([E3], ?TOK_MGR:tail(all,1)),
+                          ?assertEqual([E2,E3], ?TOK_MGR:tail(all,2)),  %% tail(offset)
+                          ?assertEqual([E1,E2,E3], ?TOK_MGR:tail(all,3)),
+                          ?assertEqual([E2,E3], ?TOK_MGR:tail(all,2,2)),  %% tail(offset,count)
+                          ?assertEqual([E2], ?TOK_MGR:tail(all,2,1)),
+                          %% test range guards on head/tail
+                          ?assertEqual([E1,E2,E3], ?TOK_MGR:head(all,0)),
+                          ?assertEqual([E1,E2,E3], ?TOK_MGR:head(all,-1)),
+                          ?assertEqual([E3], ?TOK_MGR:tail(all,0)),
+                          ?assertEqual([E3], ?TOK_MGR:tail(all,-1))
+
+                  end}
+
+              ] end}
+    }.
+
+spawn_sync_request(Token, Pid, Meta) ->
+    spawn(fun() -> ok = ?TOK_MGR:get_token_sync(Token, Pid, Meta) end).
+
+get_n_tokens(Token, Pid, N) ->
+    Limit = expected_token_limit(Token),
+    [spawn_sync_request(Token,Pid,[{meta,M}]) || M <- lists:seq(1,N)],
+    {Token, make_hist_stat(Limit, 1, N, 0)}.
+
+max_out_plus(Token, Pid, X) ->
+    %% Max out the tokens for this period and request X more than Max
+    N = expected_token_limit(Token),
+    get_n_tokens(Token, Pid, N+X),
+    %% Hack alert: given is N + X becuase we "know" we got a refill in this period.
+    {Token, make_hist_stat(N, 1, N+X, X)}.
+
+make_hist_stat(Limit, Refills, Given, Blocked) ->
+     #tm_stat_hist
+        {
+          limit=Limit,
+          refills=Refills,
+          given=Given,
+          blocked=Blocked
+        }.
+          
+make_live_stat(Token, Pid, Meta, Status) ->
+    #tm_stat_live
+        {
+          token=Token,
+          consumer=Pid,
+          meta=Meta,
+          state=Status
+        }.
+
+-spec some_token_rates() -> [{tm_token(), {tm_period(), tm_count()}}].
+some_token_rates() ->
+    [ {token1, {1, 5}},
+      {token2, {1, 4}},
+      {{token3,stuff3}, {1, 3}}
+    ].
+
+expected_token_types() ->
+    [ Type || {Type, _Rate} <- some_token_rates()].
+
+max_token_period() ->
+    lists:foldl(fun({_T,{Period,_Limit}},Max) -> erlang:max(Period,Max) end, 0, some_token_rates()).
+
+expected_token_limit(Token) ->
+    {_Period, Limit} = proplists:get_value(Token, some_token_rates()),
+    Limit.
+
+setup_token_rates() ->
+    [?TOK_MGR:set_token_rate(Type, Rate) || {Type, Rate} <- some_token_rates()].
+
+verify_token_rate(Type, ExpectedRate) ->
+    Rate = ?TOK_MGR:token_rate(Type),
+    ?assertEqual(ExpectedRate, Rate).
+
+verify_token_rates() ->
+    [verify_token_rate(Type, Rate) || {Type, Rate} <- some_token_rates()],
+    %% check un-registered token is not setup
+    Rate = ?TOK_MGR:token_rate(bogusToken),
+    DefaultRate = {0,0},
+    ?assertEqual(DefaultRate, Rate).
+
+-endif.

--- a/test/token_manager_tests.erl
+++ b/test/token_manager_tests.erl
@@ -11,7 +11,7 @@
 token_mgr_test_() ->
     {timeout, 60000,  %% Seconds to finish all of the tests
      {setup, fun() ->
-                     riak_core_table_manager:start_link([{?TM_ETS_TABLE, [private, set]}]),
+                     riak_core_table_manager:start_link([{?TM_ETS_TABLE, ?TM_ETS_OPTS}]),
                      ?TOK_MGR:start_link(1) %% setup with history window to 1 seconds
              end, 
       fun(_) -> ok end,                           %% cleanup
@@ -126,7 +126,6 @@ token_mgr_test_() ->
                   fun() ->
                           %% 
                           Hist = ?TOK_MGR:head(),
-%%                          ?debugFmt("History: ~p", [Hist]),
                           ?assertNot([] == Hist)
                   end},
 

--- a/test/token_manager_tests.erl
+++ b/test/token_manager_tests.erl
@@ -10,7 +10,10 @@
 
 token_mgr_test_() ->
     {timeout, 60000,  %% Seconds to finish all of the tests
-     {setup, fun() -> ?TOK_MGR:start_link(1) end, %% setup with history window to 1 seconds
+     {setup, fun() ->
+                     riak_core_table_manager:start_link([{?TM_ETS_TABLE, [private, set]}]),
+                     ?TOK_MGR:start_link(1) %% setup with history window to 1 seconds
+             end, 
       fun(_) -> ok end,                           %% cleanup
       fun(_) ->
               [ %% Tests


### PR DESCRIPTION
Background Manager = Lock Manager + Token Manager

Token manager is broken out to a separate gen_server. Someday, I will break lock manager out as well. Not time now.
Token calls are available in the background manager and proxied to the token manager server.
Changed enabled/disabled in BG manager to affect BOTH subsystems.
Renamed enable/disable for locks to enable_lock/disable_lock to match API for tokens: enable_tokens/disable_tokens

The token manager has a separate set of eunit tests that have good coverage:
rebar skip_deps=true eunit suite=token_manager

This PR also includes a new module "riak_core_table_manager", which creates and owns tables until a process claims them. It remains the heir of a table so that a crashed table user process can get it back again, without the table going away. The table manager is supervised by riak_core_sup, as is a new riak_core_bg_manager_sup which oversees the lock and token managers.

Theory of operation...
The table manager is started by the riak_core_sup and is given the names and options for the new lock and token manager servers. These tables persist across crashed lock/token managers so that locks and tokens are not lost.

The "background" manager is really locks + tokens, but they don't interact except for the master on/off switch. Lock manager allows locks to be taken and handles release when processes die with locks held. Also, if the maximum count for a lock is lowered, processes will be killed to enforce that new limit. Tokens are dispensed as a token bucket scheduling mechanism. Tokens are replenished at some specified rate. Both lock limits and token rates must be registered ahead of their use.

As an example, the AAE entropy manager from riak_kv has been ported to use the locks and tokens from bg manager. It is on a separate branch named "cet-bg-mgr-aae": https://github.com/basho/riak_kv/pull/645

It is anticipated that other subsystems will start using the background manager. We might even add locks and tokens to vnode folds to avoid thrashing the backends.
