### PR TITLE
FIx set_bucket (don't leak "my ring" into "raw ring")

### DIFF
--- a/src/riak_core_bucket.erl
+++ b/src/riak_core_bucket.erl
@@ -65,7 +65,7 @@ set_bucket(Name, BucketProps0) ->
     case validate_props(BucketProps0, riak_core:bucket_validators(), []) of
         {ok, BucketProps} ->
             F = fun(Ring, _Args) ->
-                        OldBucket = get_bucket(Name),
+                        OldBucket = get_bucket(Name, Ring),
                         NewBucket = merge_props(BucketProps, OldBucket),
                         {new_ring, riak_core_ring:update_meta({bucket,Name},
                                                               NewBucket,


### PR DESCRIPTION
While writing a test for migration from Riak Search to Yokozuna I noticed that after setting the bucket property `search` to false the Riak Search pre-commit hook property was being store in the **raw ring**.  This should **never** happen as that bucket prop is written to the "tainted wring" (also called "my ring") by the bucket fixup process.

I noticed this issues on 1.4 which also has changes to how bucket properties are stored.  I'm not sure this can actually happen on 1.3.  BUT, even so a ring transition should **NEVER** use anything but the `Ring` passed into the transition function so this fix applies no matter what.  I.e. it can only help and not hurt.

This fix should also be applied to 1.4 and the latest development, but this will act as the canonical PR.
