### PR TITLE
Fix meck related unit test problems

### DIFF
--- a/src/riak_core_stat_cache.erl
+++ b/src/riak_core_stat_cache.erl
@@ -272,7 +272,7 @@ cache_test_() ->
     {setup,
      fun() ->
              folsom:start(),
-             [meck:new(Mock, [passthrough]) || Mock <- ?MOCKS],
+             [meck:new(Mock, [non_strict, passthrough]) || Mock <- ?MOCKS],
              riak_core_stat_cache:start_link()
      end,
      fun(_) ->

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -988,10 +988,10 @@ current_state(Pid) ->
     gen_fsm:sync_send_all_state_event(Pid, current_state).
 
 pool_death_test() ->
-    meck:new(test_vnode),
+    meck:new(test_vnode, [non_strict, no_link]),
     meck:expect(test_vnode, init, fun(_) -> {ok, [], [{pool, test_pool_mod, 1, []}]} end),
     meck:expect(test_vnode, terminate, fun(_, _) -> normal end),
-    meck:new(test_pool_mod),
+    meck:new(test_pool_mod, [non_strict, no_link]),
     meck:expect(test_pool_mod, init_worker, fun(_, _, _) -> {ok, []} end),
 
     {ok, Pid} = ?MODULE:test_link(test_vnode, 0),

--- a/test/node_watcher_qc.erl
+++ b/test/node_watcher_qc.erl
@@ -55,7 +55,7 @@ prop_main() ->
     riak_core_node_watcher_events:start_link(),
 
     %% meck used for health watch / threshold
-    meck:new(mod_health),
+    meck:new(mod_health, [non_strict]),
 
     ?FORALL(Cmds, commands(?MODULE),
             begin


### PR DESCRIPTION
Meck now needs a couple of flags in meck:new for some of our tests:
- non_strict so we can create a fresh non-existent module
- no_link so it doesn't link to the processes created with a meck
- module. Bad when we kill things on purpose.
