### PR TITLE
Use raw ring when setting bucket props (develop branch)

### DIFF
--- a/src/riak_core_bucket.erl
+++ b/src/riak_core_bucket.erl
@@ -67,7 +67,7 @@ set_bucket(Name, BucketProps0) ->
     case validate_props(BucketProps0, riak_core:bucket_validators(), []) of
         {ok, BucketProps} ->
             F = fun(Ring, _Args) ->
-                        OldBucket = get_bucket(Name),
+                        OldBucket = get_bucket(Name, Ring),
                         NewBucket = merge_props(BucketProps, OldBucket),
                         {new_ring, riak_core_ring:update_meta({bucket,Name},
                                                               NewBucket,


### PR DESCRIPTION
Fix the ring trans function used by `set_bucket` so that it uses the
passed-in, raw ring.  This is important because otherwise things like
bucket prop fixups which are performed on "my ring" can leak into the
raw ring casuing issues such as a Riak Searh pre-commit hook that
exists even when the search property is set to false.
