### PR TITLE
Remove protobuffs dependency from riak_core.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,6 @@
 {deps, [
   {lager, "2.0.0", {git, "git://github.com/basho/lager.git", {tag, "2.0.0"}}},
   {poolboy, ".*", {git, "git://github.com/basho/poolboy.git", {branch, "develop"}}},
-  {protobuffs, "0.8.*", {git, "git://github.com/basho/erlang_protobuffs.git", {tag, "0.8.1p3"}}},
   {basho_stats, ".*", {git, "git://github.com/basho/basho_stats.git", {branch, "develop"}}},
   {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon.git", {branch, "develop"}}},
   {folsom, "0.7.4p4", {git, "git://github.com/basho/folsom.git", {tag, "0.7.4p4"}}},

--- a/src/riak_core.proto
+++ b/src/riak_core.proto
@@ -1,6 +1,0 @@
-message RiakObject_PB {
-        required bytes bucket = 1;
-        required bytes key = 2;
-        required bytes val = 3;
-}
-


### PR DESCRIPTION
The riak_core.proto was only used in riak_kv's handoff, and has no
references elsewhere in riak_core. It is appropriately moving to
riak_kv.

/cc @Vagabond @evanmcc @jrwest
