### PR TITLE
Move tcp-mon, connection and service manager supervisors from replication to core.

### DIFF
--- a/src/riak_core.app.src
+++ b/src/riak_core.app.src
@@ -12,6 +12,7 @@
                   stdlib,
                   lager,
                   sasl,
+                  ranch,
                   crypto,
                   riak_sysmon,
                   webmachine,

--- a/src/riak_core_conn_services_sup.erl
+++ b/src/riak_core_conn_services_sup.erl
@@ -1,8 +1,8 @@
 %% -------------------------------------------------------------------
 %%
-%% riak_core: Core Riak Application
+%% riak_core_conn_services_sup: supervise connection mananger services
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -20,11 +20,13 @@
 %%
 %% -------------------------------------------------------------------
 
--module(riak_core_sup).
+%% @doc Supervise connection manager services
 
--behaviour(supervisor).
+-module(riak_core_conn_services_sup).
+
 
 %% API
+
 -export([start_link/0]).
 
 %% Supervisor callbacks
@@ -45,26 +47,13 @@ start_link() ->
 %% Supervisor callbacks
 %% ===================================================================
 
+%% @private
 init([]) ->
     Children = lists:flatten(
-                 [?CHILD(riak_core_sysmon_minder, worker),
-                  ?CHILD(riak_core_vnode_sup, supervisor, 305000),
-                  ?CHILD(riak_core_eventhandler_sup, supervisor),
-                  ?CHILD(riak_core_handoff_sup, supervisor),
-                  ?CHILD(riak_core_ring_events, worker),
-                  ?CHILD(riak_core_ring_manager, worker),
-                  ?CHILD(riak_core_metadata_manager, worker),
-                  ?CHILD(riak_core_metadata_hashtree, worker),
-                  ?CHILD(riak_core_broadcast, worker),
-                  ?CHILD(riak_core_vnode_proxy_sup, supervisor),
-                  ?CHILD(riak_core_node_watcher_events, worker),
-                  ?CHILD(riak_core_node_watcher, worker),
-                  ?CHILD(riak_core_vnode_manager, worker),
-                  ?CHILD(riak_core_capability, worker),
-                  ?CHILD(riak_core_gossip, worker),
-                  ?CHILD(riak_core_claimant, worker),
-                  ?CHILD(riak_core_stat_sup, supervisor),
-                  ?CHILD(riak_core_conn_services_sup, supervisor)
+                 [
+                  ?CHILD(riak_core_service_mgr, worker),
+                  ?CHILD(riak_core_connection_mgr, worker),
+                  ?CHILD(riak_core_tcp_mon, worker)
                  ]),
 
     {ok, {{one_for_one, 10, 10}, Children}}.

--- a/src/riak_core_util.erl
+++ b/src/riak_core_util.erl
@@ -53,6 +53,7 @@
          format_ip_and_port/2,
          peername/2,
          sockname/2,
+         generate_socket_tag/3,
          sha/1,
          md5/1,
          make_fold_req/1,
@@ -545,6 +546,16 @@ sockname(Socket, Transport) ->
             %% just return a string so JSON doesn't blow up
             lists:flatten(io_lib:format("error:~p", [Reason]))
     end.
+
+%% @doc Generate a unique ID for a socket to log stats against
+generate_socket_tag(Prefix, Transport, Socket) ->
+    {ok, {{O1, O2, O3, O4}, PeerPort}} = Transport:peername(Socket),
+    {ok, {_Address, Portnum}} = Transport:sockname(Socket),
+    lists:flatten(io_lib:format("~s_~p -> ~p.~p.~p.~p:~p",[
+                Prefix,
+                Portnum,
+                O1, O2, O3, O4,
+                PeerPort])).
 
 %% @doc Convert a #riak_core_fold_req_v? record to the cluster's maximum
 %%      supported record version.


### PR DESCRIPTION
This is the matching PR for replication below. This is the final move to migrate the connection and service
managers from replication into their proper home in core. The riak_core_tcp_mon supervisor also belongs here.

If you build/test this on riak_ee, you will need the following PR as well, which is recently rebased on develop.
https://github.com/basho/riak_repl/pull/398
