### PR TITLE
Add security to Riak

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -5,6 +5,7 @@
   {description, "Riak Core"},
   {vsn, "1.4.2"},
   {modules, [
+            table,
              app_helper,
              bloom,
              chash,
@@ -55,6 +56,7 @@
              riak_core_ring_handler,
              riak_core_ring_manager,
              riak_core_ring_util,
+             riak_core_security,
              riak_core_send_msg,
              riak_core_stat,
              riak_core_stat_cache,

--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -50,6 +50,7 @@
              riak_core_node_watcher,
              riak_core_node_watcher_events,
              riak_core_pb,
+             riak_core_pw_auth,
              riak_core_repair,
              riak_core_ring,
              riak_core_ring_events,

--- a/rebar.config
+++ b/rebar.config
@@ -13,5 +13,5 @@
   {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon", {branch, "develop"}}},
   {folsom, ".*", {git, "git://github.com/basho/folsom.git", {tag, "0.7.4p3"}}},
   {ranch, "0.4.0-p1", {git, "git://github.com/basho/ranch.git", {tag, "0.4.0-p1"}}},
-  {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2", {branch, "master"}}}
+  {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2", {branch, "adt-cleanups"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -12,5 +12,6 @@
   {basho_stats, ".*", {git, "git://github.com/basho/basho_stats", {branch, "develop"}}},
   {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon", {branch, "develop"}}},
   {folsom, ".*", {git, "git://github.com/basho/folsom.git", {tag, "0.7.4p3"}}},
-  {ranch, "0.4.0-p1", {git, "git://github.com/basho/ranch.git", {tag, "0.4.0-p1"}}}
-       ]}.
+  {ranch, "0.4.0-p1", {git, "git://github.com/basho/ranch.git", {tag, "0.4.0-p1"}}},
+  {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2", {branch, "master"}}}
+]}.

--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -350,10 +350,12 @@ register(App, [{bucket_validator, ValidationMod}|T]) ->
     register(App, T);
 register(App, [{stat_mod, StatMod}|T]) ->
     register_mod(App, StatMod, stat_mods),
+    register(App, T);
+register(App, [{permissions, Permissions}|T]) ->
+    register_mod(App, Permissions, permissions),
     register(App, T).
 
-
-register_mod(App, Module, Type) when is_atom(Module), is_atom(Type) ->
+register_mod(App, Module, Type) when is_atom(Type) ->
     case Type of
         vnode_modules ->
             riak_core_vnode_proxy_sup:start_proxies(Module);
@@ -378,6 +380,8 @@ register_metadata(App, Value, Type) ->
             application:set_env(riak_core, Type,
                 lists:usort([{App,Value}|Values]))
     end.
+
+
 
 %% @spec add_guarded_event_handler(HandlerMod, Handler, Args) -> AddResult
 %%       HandlerMod = module()

--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -353,6 +353,9 @@ register(App, [{stat_mod, StatMod}|T]) ->
     register(App, T);
 register(App, [{permissions, Permissions}|T]) ->
     register_mod(App, Permissions, permissions),
+    register(App, T);
+register(App, [{auth_mod, {AuthType, AuthMod}}|T]) ->
+    register_proplist({AuthType, AuthMod}, auth_mods),
     register(App, T).
 
 register_mod(App, Module, Type) when is_atom(Type) ->
@@ -379,6 +382,16 @@ register_metadata(App, Value, Type) ->
         {ok, Values} ->
             application:set_env(riak_core, Type,
                 lists:usort([{App,Value}|Values]))
+    end.
+
+register_proplist({Key, Value}, Type) ->
+    case application:get_env(riak_core, Type) of
+        undefined ->
+            application:set_env(riak_core, Type, [{Key, Value}]);
+        {ok, Values} ->
+            application:set_env(riak_core, Type, lists:keystore(Key, 1,
+                                                                Values,
+                                                                {Key, Value}))
     end.
 
 

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -69,7 +69,11 @@ start(_StartType, _StartArgs) ->
     %% Spin up the supervisor; prune ring files as necessary
     case riak_core_sup:start_link() of
         {ok, Pid} ->
-            riak_core:register(riak_core, [{stat_mod, riak_core_stat}]),
+            riak_core:register(riak_core, [{stat_mod, riak_core_stat},
+                                           {permissions, [get_bucket,
+                                                          set_bucket,
+                                                          get_bucket_type,
+                                                          set_bucket_type]}]),
             ok = riak_core_ring_events:add_guarded_handler(riak_core_ring_handler, []),
 
             riak_core_capability:register({riak_core, vnode_routing},

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -23,7 +23,8 @@
          stage_leave/1, stage_remove/1, stage_replace/1, stage_resize_ring/1,
          stage_force_replace/1, print_staged/1, commit_staged/1,
          clear_staged/1, transfer_limit/1, pending_claim_percentage/2,
-         transfers/1]).
+         transfers/1, add_user/1, add_source/1, print_users/1,
+         print_sources/1]).
 
 %% @doc Return for a given ring and node, percentage currently owned and
 %% anticipated after the transitions have been completed.
@@ -820,3 +821,37 @@ check_limit(Str) ->
         _:_ ->
             {false, 0}
     end.
+
+add_user([Username|Options]) ->
+    riak_core_security:add_user(Username, parse_options(Options)).
+
+add_source([Users, CIDR, Source | Options]) ->
+    Unames = case string:tokens(Users, ",") of
+        ["all"] ->
+            all;
+        Other ->
+            Other
+    end,
+    riak_core_security:add_source(Unames, parse_cidr(CIDR),
+                                  list_to_atom(Source),
+                                  parse_options(Options)).
+
+print_users([]) ->
+    riak_core_security:print_users().
+
+print_sources([]) ->
+    riak_core_security:print_sources().
+
+parse_options(Options) ->
+    parse_options(Options, []).
+
+parse_options([], Acc) ->
+    Acc;
+parse_options([H|T], Acc) ->
+    [Key, Value] = string:tokens(H, "="),
+    parse_options(T, [{Key, Value}|Acc]).
+
+parse_cidr(CIDR) ->
+    [IP, Mask] = string:tokens(CIDR, "/"),
+    {ok, Addr} = inet_parse:address(IP),
+    {Addr, list_to_integer(Mask)}.

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -23,7 +23,7 @@
          stage_leave/1, stage_remove/1, stage_replace/1, stage_resize_ring/1,
          stage_force_replace/1, print_staged/1, commit_staged/1,
          clear_staged/1, transfer_limit/1, pending_claim_percentage/2,
-         transfers/1, add_user/1, add_source/1, print_users/1,
+         transfers/1, add_user/1, add_source/1, grant/1 print_users/1,
          print_sources/1]).
 
 %% @doc Return for a given ring and node, percentage currently owned and
@@ -835,6 +835,24 @@ add_source([Users, CIDR, Source | Options]) ->
     riak_core_security:add_source(Unames, parse_cidr(CIDR),
                                   list_to_atom(Source),
                                   parse_options(Options)).
+
+grant([Grants, "ON", Bucket, "TO", Users]) ->
+    Unames = case string:tokens(Users, ",") of
+        ["all"] ->
+            all;
+        Other ->
+            Other
+    end,
+    Permissions = case string:tokens(Grants, ",") of
+        ["all"] ->
+            all;
+        Other2 ->
+            Other2
+    end,
+    riak_core_security:add_grant(Unames, Bucket, Permissions);
+grant(_) ->
+    io:format("Usage: grant <permissions> ON <bucket> TO <users>"),
+    error.
 
 print_users([]) ->
     riak_core_security:print_users().

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -23,8 +23,8 @@
          stage_leave/1, stage_remove/1, stage_replace/1, stage_resize_ring/1,
          stage_force_replace/1, print_staged/1, commit_staged/1,
          clear_staged/1, transfer_limit/1, pending_claim_percentage/2,
-         transfers/1, add_user/1, add_source/1, grant/1 print_users/1,
-         print_sources/1]).
+         transfers/1, add_user/1, add_source/1, grant/1, revoke/1,
+         print_users/1, print_sources/1]).
 
 %% @doc Return for a given ring and node, percentage currently owned and
 %% anticipated after the transitions have been completed.
@@ -853,6 +853,25 @@ grant([Grants, "ON", Bucket, "TO", Users]) ->
 grant(_) ->
     io:format("Usage: grant <permissions> ON <bucket> TO <users>"),
     error.
+
+revoke([Grants, "ON", Bucket, "FROM", Users]) ->
+    Unames = case string:tokens(Users, ",") of
+        ["all"] ->
+            all;
+        Other ->
+            Other
+    end,
+    Permissions = case string:tokens(Grants, ",") of
+        ["all"] ->
+            all;
+        Other2 ->
+            Other2
+    end,
+    riak_core_security:add_revoke(Unames, Bucket, Permissions);
+revoke(_) ->
+    io:format("Usage: revoke <permissions> ON <bucket> FROM <users>"),
+    error.
+
 
 print_users([]) ->
     riak_core_security:print_users().

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -823,18 +823,24 @@ check_limit(Str) ->
     end.
 
 add_user([Username|Options]) ->
-    riak_core_security:add_user(Username, parse_options(Options)).
+    riak_core_security:add_user(list_to_binary(Username), parse_options(Options)).
 
 add_source([Users, CIDR, Source | Options]) ->
     Unames = case string:tokens(Users, ",") of
         ["all"] ->
             all;
         Other ->
-            Other
+            [list_to_binary(O) || O <- Other]
     end,
-    riak_core_security:add_source(Unames, parse_cidr(CIDR),
+    case riak_core_security:add_source(Unames, parse_cidr(CIDR),
                                   list_to_atom(Source),
-                                  parse_options(Options)).
+                                  parse_options(Options)) of
+        ok ->
+            ok;
+        Error ->
+            io:format("~p~n", [Error]),
+            Error
+    end.
 
 grant([Grants, "ON", Bucket, "TO", Users]) ->
     Unames = case string:tokens(Users, ",") of

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -877,12 +877,18 @@ grant(_) ->
     io:format("Usage: grant <permissions> ON <bucket> TO <users>"),
     error.
 
+revoke([Grants, "ON", Type, Bucket, "FROM", Users]) ->
+    revoke([Grants, "ON", {list_to_binary(Type), list_to_binary(Bucket)},
+            "FROM",
+           Users]);
+revoke([Grants, "ON", Bucket, "FROM", Users]) when is_list(Bucket) ->
+    revoke([Grants, "ON", list_to_binary(Bucket), "FROM", Users]);
 revoke([Grants, "ON", Bucket, "FROM", Users]) ->
     Unames = case string:tokens(Users, ",") of
         ["all"] ->
             all;
         Other ->
-            Other
+            [list_to_binary(O) || O <- Other]
     end,
     Permissions = case string:tokens(Grants, ",") of
         ["all"] ->

--- a/src/riak_core_pw_auth.erl
+++ b/src/riak_core_pw_auth.erl
@@ -1,0 +1,47 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_core_pw_auth).
+
+%% TODO
+-compile(export_all).
+
+%% TOOD should make these configurable
+-define(SALT_LENGTH, 16).
+-define(DERIVED_LENGTH, 32).
+-define(HASH_ITERATIONS, 65536).
+-define(HASH_FUNCTION, {hmac, sha}).
+
+hash_password(Password) ->
+    %% TODO: Do something more with the salt?
+    %% Generate salt the simple way
+    Salt = crypto:rand_bytes(?SALT_LENGTH),
+    
+    BinaryPass = list_to_binary(Password),
+    
+    %% Hash the original password
+    lager:info("Calling pbkdf2 with the following:"),
+    lager:info("hash_func = ~p", [?HASH_FUNCTION]),
+    lager:info("password = ~p", [BinaryPass]),
+    lager:info("salt = ~p", [Salt]),
+    lager:info("iterations = ~p", [?HASH_ITERATIONS]),
+    lager:info("length = ~p", [?DERIVED_LENGTH]),
+    {ok, HashedPass} = pbkdf2:pbkdf2(?HASH_FUNCTION, BinaryPass, Salt, ?HASH_ITERATIONS, ?DERIVED_LENGTH),
+    {ok, HashedPass, <<"pbkdf2">>, ?HASH_FUNCTION, Salt, ?HASH_ITERATIONS, ?DERIVED_LENGTH}.

--- a/src/riak_core_pw_auth.erl
+++ b/src/riak_core_pw_auth.erl
@@ -30,12 +30,10 @@
 -define(AUTH_NAME, pbkdf2).
 
 %% @doc Hash a plaintext password, returning hashed password and algorithm details
-hash_password(EnteredPassword) ->
+hash_password(BinaryPass) when is_binary(BinaryPass) ->
     % TODO: Do something more with the salt?
     % Generate salt the simple way
     Salt = crypto:rand_bytes(?SALT_LENGTH),
-
-    BinaryPass = list_to_binary(EnteredPassword),
 
     % Hash the original password and store as hex
     {ok, HashedPass} = pbkdf2:pbkdf2(?HASH_FUNCTION, BinaryPass, Salt, ?HASH_ITERATIONS),
@@ -44,10 +42,7 @@ hash_password(EnteredPassword) ->
 
 
 %% @doc Check a plaintext password with a hashed password
-check_password(EnteredPassword, HashedPassword, HashFunction, Salt, HashIterations) ->
-
-    % Passwords are stored as binaries
-    BinaryPass = list_to_binary(EnteredPassword),
+check_password(BinaryPass, HashedPassword, HashFunction, Salt, HashIterations) when is_binary(BinaryPass) ->
 
     % Hash EnteredPassword to compare to HashedPassword
     {ok, HashedPass} = pbkdf2:pbkdf2(HashFunction, BinaryPass, Salt, HashIterations),

--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -1,0 +1,282 @@
+-module(riak_core_security).
+
+%% TODO
+-compile(export_all).
+
+initial_config() ->
+    %[{users, [{"andrew", [{password, "foo"}]}]},
+    [{users, []},
+     {sources, []},
+     {grants, []},
+     {revokes, []}
+    ].
+
+get_meta() ->
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    case riak_core_ring:get_meta(?MODULE, Ring) of
+        undefined ->
+            initial_config();
+        {ok, Meta} ->
+            Meta
+    end.
+
+put_meta(Meta) ->
+    riak_core_ring_manager:ring_trans(fun(Ring, M) ->
+                {new_ring, riak_core_ring:update_meta(?MODULE, M, Ring)}
+        end, Meta).
+
+%% lookup a key in a list of key/value tuples. Like proplists:get_value but
+%% faster.
+lookup(Key, List, Default) ->
+    case lists:keyfind(Key, 1, List) of
+        false ->
+            Default;
+        {Key, Value} ->
+            Value
+    end.
+
+lookup(Key, List) ->
+    lookup(Key, List, undefined).
+
+stash(Key, Value, List) ->
+    lists:keystore(Key, 1, List, Value).
+
+%% @doc Get the subnet mask as an integer, stolen from an old post on
+%%      erlang-questions.
+mask_address(Addr={_, _, _, _}, Maskbits) ->
+    B = list_to_binary(tuple_to_list(Addr)),
+    <<Subnet:Maskbits, _Host/bitstring>> = B,
+    Subnet;
+mask_address({A, B, C, D, E, F, G, H}, Maskbits) ->
+    <<Subnet:Maskbits, _Host/bitstring>> = <<A:16, B:16, C:16, D:16, E:16,
+                                             F:16, G:16, H:16>>,
+    Subnet.
+
+%% @doc returns the real bottom of a netmask. Eg if 192.168.1.1/16 is
+%% provided, return 192.168.0.0/16
+anchor_mask(Addr={_, _, _, _}, Maskbits) ->
+    M = mask_address(Addr, Maskbits),
+    Rem = 32 - Maskbits,
+    <<A:8, B:8, C:8, D:8>> = <<M:Maskbits, 0:Rem>>,
+    {{A, B, C, D}, Maskbits};
+anchor_mask(Addr={_, _, _, _, _, _, _, _}, Maskbits) ->
+    M = mask_address(Addr, Maskbits),
+    Rem = 128 - Maskbits,
+    <<A:16, B:16, C:16, D:16, E:16, F:16, G:16, H:16>> = <<M:Maskbits, 0:Rem>>,
+    {{A, B, C, D, E, F, G, H}, Maskbits}.
+
+anchor_mask({Addr, Mask}) ->
+    anchor_mask(Addr, Mask).
+
+prettyprint_cidr({Addr, Mask}) ->
+    io_lib:format("~s/~B", [inet_parse:ntoa(Addr), Mask]).
+
+prettyprint_users([all]) ->
+    "all";
+prettyprint_users(Users) ->
+    string:join(Users, ", ").
+
+match_source([], _User, _PeerIP) ->
+    {error, no_matching_sources};
+match_source([{{UserName, {IP,Mask}, Source}, Options}|Tail], User, PeerIP) ->
+    case (UserName == all orelse
+          UserName == User) andalso
+        mask_address(IP, Mask) == mask_address(PeerIP, Mask) of
+        true ->
+            {ok, Source, Options};
+        false ->
+            match_source(Tail, User, PeerIP)
+    end.
+
+sort_sources(Sources) ->
+    %% sort sources first by userlist, so that 'all' matches come last
+    %% and then by CIDR, so that most sprcific masks come first
+    Sources1 = lists:sort(fun({{UserA, _}, _, _}, {{UserB, _}, _, _}) ->
+                    case {UserA, UserB} of
+                        {all, all} ->
+                            true;
+                        {all, _} ->
+                            %% anything is greater than 'all'
+                            true;
+                        {_, all} ->
+                            false;
+                        {_, _} ->
+                            true
+                    end
+            end, Sources),
+    lists:sort(fun({{_, {_, MaskA}}, _, _}, {{_, {_, MaskB}}, _, _}) ->
+                MaskA > MaskB
+        end, Sources1).
+
+%% group users sharing the same CIDR/Source/Options
+group_sources(Sources) ->
+    D = lists:foldl(fun({{User, CIDR}, Source, Options}, Acc) ->
+                dict:append({CIDR, Source, Options}, User, Acc)
+        end, dict:new(), Sources),
+    R1 = [{Users, CIDR, Source, Options} || {{CIDR, Source, Options}, Users} <-
+                                       dict:to_list(D)],
+    %% sort the result by the same criteria that sort_sources uses
+    R2 = lists:sort(fun({UserA, _, _, _}, {UserB, _, _, _}) ->
+                    case {UserA, UserB} of
+                        {[all], [all]} ->
+                            true;
+                        {[all], _} ->
+                            %% anything is greater than 'all'
+                            true;
+                        {_, [all]} ->
+                            false;
+                        {_, _} ->
+                            true
+                    end
+            end, R1),
+    lists:sort(fun({_, {_, MaskA}, _, _}, {_, {_, MaskB}, _, _}) ->
+                MaskA > MaskB
+        end, R2).
+
+print_sources(Sources) ->
+    GS = group_sources(Sources),
+    table:print([{users, 20}, {cidr, 10}, {source, 10}, {options, 10}],
+                [[prettyprint_users(Users), prettyprint_cidr(CIDR),
+                  atom_to_list(Source), io_lib:format("~p", [Options])] ||
+            {Users, CIDR, Source, Options} <- GS]).
+
+
+%% TODO a context should only be valid for a short time, eg. 5 seconds.
+%% Or perhaps every grant change should increment some value on the user
+%% information so we can detect when we need to re-pull the context.
+get_context(Username, Meta) ->
+    Empty = term_to_binary([]),
+    Grants = lookup(Username, lookup(grants, Meta, []), Empty),
+    Revokes = lookup(Username, lookup(revokes, Meta, []), Empty),
+    %% XXX this is more or less pseudocode since we don't have a structure for
+    %% grants yet
+    lists:keymerge(1, binary_to_term(Grants), binary_to_term(Revokes)).
+
+authenticate(Username, Password, PeerIP) ->
+    Meta = get_meta(),
+    Users = lookup(users, Meta, []),
+    case lookup(Username, Users) of
+        undefined ->
+            {error, unknown_user};
+        UserData ->
+            Sources = sort_sources(lookup(sources, Meta, [])),
+            case match_source(Sources, Username, PeerIP) of
+                {ok, Source, _Options} ->
+                    case Source of
+                        trust ->
+                            %% trust always authenticates
+                            {ok, get_context(Username, Meta)};
+                        password ->
+                            %% pull the password out of the userdata
+                            case lookup(password, UserData) of
+                                undefined ->
+                                    lager:warning("User ~p is configured for "
+                                                  "password authentication, but has "
+                                                  "no password", [Username]),
+                                    {error, missing_password};
+                                Pass ->
+                                    %% This should be bcrypted or something...
+                                    case Password == Pass of
+                                        true ->
+                                            {ok, get_context(Username, Meta)};
+                                        false ->
+                                            {error, bad_password}
+                                    end
+                            end;
+                        Source ->
+                            lager:warning("User ~p is configured with unknown "
+                                          "authentication source ~p",
+                                          [Username, Source]),
+                            {error, unknown_source}
+                    end;
+                {error, Reason} ->
+                    {error, Reason}
+            end
+    end.
+
+add_user(Username, Options) ->
+    Meta = get_meta(),
+    Users = lookup(users, Meta, []),
+    case lookup(Username, Users) of
+        undefined ->
+            case validate_options(Options) of
+                {ok, NewOptions} ->
+                    put_meta(stash(users, {users, stash(Username,
+                                                        {Username, NewOptions},
+                                                        Users)},
+                                   Meta)),
+                    ok;
+                Error ->
+                    Error
+            end;
+        _ ->
+            {error, user_exists}
+    end.
+
+add_source(all, CIDR, Source, Options) ->
+    %% all is always valid
+    Meta = get_meta(),
+    put_meta(add_source_int([all], anchor_mask(CIDR), Source, Options, Meta)),
+    ok;
+add_source([H|_T]=UserList, CIDR, Source, Options) when is_list(H) ->
+    %% list of lists, weeeee
+    %% validate the users...
+    Meta = get_meta(),
+    Users = lookup(users, Meta, []),
+    Valid = lists:foldl(fun(User, ok) ->
+                    case lists:keymember(User, 1, Users) of
+                        true ->
+                            ok;
+                        false ->
+                            {error, {unknown_user, User}}
+                    end;
+                (_User, Acc) ->
+                    Acc
+            end, ok, UserList),
+    case Valid of
+        ok ->
+            %% add a source for each user
+            put_meta(add_source_int(UserList, anchor_mask(CIDR), Source,
+                                    Options, Meta)),
+            ok;
+        Error ->
+            Error
+    end;
+add_source(User, CIDR, Source, Options) ->
+    %% single user
+    add_source([User], CIDR, Source, Options).
+
+add_source_int([], _, _, _, Meta) ->
+    Meta;
+add_source_int([User|Users], CIDR, Source, Options, Meta) ->
+    Sources = lookup(sources, Meta, []),
+    NewMeta = stash(sources, {sources, stash({User, CIDR}, {{User, CIDR},
+                                                            Source, Options},
+                                             Sources)}, Meta),
+    add_source_int(Users, CIDR, Source, Options, NewMeta).
+
+rm_source(all, CIDR) ->
+    Meta = get_meta(),
+    put_meta(rm_source_int(all, anchor_mask(CIDR), Meta)),
+    ok;
+rm_source([H|_]=UserList, CIDR) when is_list(H) ->
+    Meta = get_meta(),
+    put_meta(rm_source_int(UserList, anchor_mask(CIDR), Meta)),
+    ok;
+rm_source(User, CIDR) ->
+    %% single user
+    rm_source([User], CIDR).
+
+rm_source_int([], _, Meta) ->
+    Meta;
+rm_source_int([User|Users], CIDR, Meta) ->
+    Sources = lookup(sources, Meta, []),
+    NewMeta = stash(sources, {sources, lists:keydelete({User, CIDR}, 1,
+                                                       Sources)}, Meta),
+    rm_source_int(Users, CIDR, NewMeta).
+
+
+%% XXX this is a stub for now, should tie in JoeD's stuff for validation
+validate_options(Options) ->
+    {ok, Options}.
+

--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -189,7 +189,7 @@ match_grant(Bucket, Grants) ->
     lists:foldl(fun({B, P}, undefined) ->
                 case lists:last(B) == $* of
                     true ->
-                        L = lists:length(B) - 1,
+                        L = length(B) - 1,
                         case string:substr(Bucket, 1, L) ==
                              string:substr(B, 1, L) of
                             true ->

--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -1,13 +1,27 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
 -module(riak_core_security).
 
 %% TODO
 -compile(export_all).
 
-%% TOOD should make these configurable
--define(SALT_LENGTH, 16).
--define(DERIVED_LENGTH, 32).
--define(HASH_ITERATIONS, 65536).
--define(HASH_FUNCTION, {hmac, sha}).
 
 initial_config() ->
     %[{users, [{"andrew", [{password, "foo"}]}]},
@@ -523,37 +537,23 @@ validate_options(Options) ->
             {ok, Options};
         Pass ->
             lager:info("Hashing password: ~p", [Pass]),
-            {ok, HashedPass, Algorithm, HashFunction, Salt, Iterations, DerivedLength} =  hash_password(Pass),
-            %% Add to options 
-            NewOptions = stash(hash, {hash, 
-                                      [{hash_pass, HashedPass},
-                                       {algorithm, Algorithm},
-                                       {hash_func, HashFunction},
-                                       {salt, Salt},
-                                       {iterations, Iterations},
-                                       {length, DerivedLength}]},
-                               Options),
-            {ok, NewOptions}
+            case riak_core_pw_auth:hash_password(Pass) of
+                {ok, HashedPass, Algorithm, HashFunction, Salt, Iterations, DerivedLength} ->
+                    %% Add to options 
+                    NewOptions = stash(hash, {hash, 
+                                              [{hash_pass, HashedPass},
+                                               {algorithm, Algorithm},
+                                               {hash_func, HashFunction},
+                                               {salt, Salt},
+                                               {iterations, Iterations},
+                                               {length, DerivedLength}]},
+                                       Options),
+                    {ok, NewOptions};
+                {error, Error} ->
+                    {error, Error}
+            end
     end.
             
-            
-hash_password(Password) ->
-    %% TODO: Do something more with the salt?
-    %% Generate salt the simple way
-    Salt = crypto:rand_bytes(?SALT_LENGTH),
-    
-    BinaryPass = list_to_binary(Password),
-    
-    %% Hash the original password
-    lager:info("Calling pbkdf2 with the following:"),
-    lager:info("hash_func = ~p", [?HASH_FUNCTION]),
-    lager:info("password = ~p", [BinaryPass]),
-    lager:info("salt = ~p", [Salt]),
-    lager:info("iterations = ~p", [?HASH_ITERATIONS]),
-    lager:info("length = ~p", [?DERIVED_LENGTH]),
-    {ok, HashedPass} = pbkdf2:pbkdf2(?HASH_FUNCTION, BinaryPass, Salt, ?HASH_ITERATIONS, ?DERIVED_LENGTH),
-    {ok, HashedPass, <<"pbkdf2">>, ?HASH_FUNCTION, Salt, ?HASH_ITERATIONS, ?DERIVED_LENGTH}.
-    
 
 validate_permissions(Perms) ->
     KnownPermissions = app_helper:get_env(riak_core, permissions, []),

--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -22,7 +22,6 @@
 %% TODO
 -compile(export_all).
 
-
 initial_config() ->
     %[{users, [{"andrew", [{password, "foo"}]}]},
     [{users, []},

--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -562,7 +562,6 @@ validate_options(Options) ->
 
 %% Handle 'password' option if given
 validate_password_option(Pass, Options) ->
-    lager:info("Hashing password: ~p", [Pass]),
     case riak_core_pw_auth:hash_password(Pass) of
         {ok, HashedPass, AuthName, HashFunction, Salt, Iterations} ->
             %% Add to options, replacing plaintext password

--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -557,13 +557,7 @@ validate_options(Options) ->
         undefined ->
             {ok, Options};
         Pass ->
-            case validate_password_option(Pass, Options) of
-                {ok, NewOptions} ->
-                    %% Do not continue to store the plaintext password
-                    {ok, NewOptions};
-                {error, _E} ->
-                    {error, _E}
-            end
+            validate_password_option(Pass, Options)
     end.
 
 %% Handle 'password' option if given
@@ -571,7 +565,7 @@ validate_password_option(Pass, Options) ->
     lager:info("Hashing password: ~p", [Pass]),
     case riak_core_pw_auth:hash_password(Pass) of
         {ok, HashedPass, AuthName, HashFunction, Salt, Iterations} ->
-            %% Add to options
+            %% Add to options, replacing plaintext password
             NewOptions = stash("password", {"password",
                                             [{hash_pass, HashedPass},
                                              {auth_name, AuthName},

--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -7,7 +7,7 @@
 -define(SALT_LENGTH, 16).
 -define(DERIVED_LENGTH, 32).
 -define(HASH_ITERATIONS, 65536).
--define(HASH_FUNCTION, {hmac, sha512}).
+-define(HASH_FUNCTION, {hmac, sha}).
 
 initial_config() ->
     %[{users, [{"andrew", [{password, "foo"}]}]},
@@ -525,12 +525,13 @@ validate_options(Options) ->
             lager:info("Hashing password: ~p", [Pass]),
             {ok, HashedPass, Algorithm, HashFunction, Salt, Iterations, DerivedLength} =  hash_password(Pass),
             %% Add to options 
-            NewOptions = stash(hash, [{hash_pass, HashedPass},
-                                     {algorithm, Algorithm},
-                                     {hash_func, HashFunction},
-                                     {salt, Salt},
-                                     {iterations, Iterations},
-                                     {length, DerivedLength}],
+            NewOptions = stash(hash, {hash, 
+                                      [{hash_pass, HashedPass},
+                                       {algorithm, Algorithm},
+                                       {hash_func, HashFunction},
+                                       {salt, Salt},
+                                       {iterations, Iterations},
+                                       {length, DerivedLength}]},
                                Options),
             {ok, NewOptions}
     end.

--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -25,7 +25,7 @@
 %% API
 -export([authenticate/3, add_user/2, add_source/4, add_grant/3,
          add_revoke/3, check_permission/2, check_permissions/2,
-         get_username/1]).
+         get_username/1, is_enabled/0]).
 %% TODO add rm_source, API to deactivate/remove users
 
 -record(context,
@@ -364,6 +364,10 @@ add_source([H|_T]=UserList, CIDR, Source, Options) when is_binary(H) ->
 add_source(User, CIDR, Source, Options) ->
     %% single user
     add_source([User], CIDR, Source, Options).
+
+is_enabled() ->
+    %% TODO this should be some kind of capability or cluster-wide config
+    app_helper:get_env(riak_core, security, false).
 
 
 %% ============

--- a/src/riak_core_ssl_util.erl
+++ b/src/riak_core_ssl_util.erl
@@ -29,7 +29,9 @@
 -export([maybe_use_ssl/1,
          validate_ssl_config/1,
          upgrade_client_to_ssl/2,
-         upgrade_server_to_ssl/2]).
+         upgrade_server_to_ssl/2,
+         get_common_name/1
+        ]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/table.erl
+++ b/src/table.erl
@@ -1,0 +1,84 @@
+-module(table).
+
+%% API
+-export([print/2,
+         create_table/2]).
+
+-spec print(list(), list()) -> ok.
+print(Spec, Rows) ->
+    Table = create_table(Spec, Rows),
+    io:format("~s", [Table]).
+
+-spec create_table(list(), list()) -> iolist().
+create_table(Spec, Rows) ->
+    Length = get_row_length(Spec),
+    create_table(Spec, Rows, Length, []).
+
+-spec create_table(list(), list(), non_neg_integer(), iolist()) -> iolist().
+create_table(Spec, Rows, Length, []) ->
+    FirstThreeRows = [vertical_border(Length), titles(Spec), vertical_border(Length)],
+    create_table(Spec, Rows, Length, FirstThreeRows);
+create_table(_Spec, [], Length, IoList) when length(IoList) =:= 2 ->
+    BottomBorder = vertical_border(Length),
+    %% There are no more rows to print so return the table
+    lists:reverse([BottomBorder | IoList]);
+create_table(_Spec, [], _Length, IoList) ->
+    lists:reverse(IoList);
+create_table(Spec, [Row | Rows], Length, IoList) ->
+    create_table(Spec, Rows, Length, [row(Spec, Row) | IoList]).
+
+-spec get_row_length(list(tuple())) -> non_neg_integer().
+get_row_length(Spec) ->
+    lists:foldl(fun({_Name, Size}, Total) ->
+                    Total + Size + 2 
+                end, 0, Spec) + 2.
+
+-spec row(list(), list(string())) -> iolist().
+row(Spec, Row) ->
+    ["| " | lists:reverse(
+        ["\n" | lists:foldl(fun({{_, Size}, Str}, Acc) ->
+                                [align(Str, Size) | Acc]
+                            end, [], lists:zip(Spec, Row))])].
+
+-spec titles(list()) -> iolist().
+titles(Spec) ->
+    [ "| " | lists:reverse(
+        ["\n" | lists:foldl(fun({Title, Size}, TitleRow) ->
+                               [align(atom_to_list(Title), Size) | TitleRow]
+                            end, [], Spec)])].
+
+-spec align(string(), non_neg_integer()) -> iolist().
+align(undefined, Size) ->
+    align("", Size);
+align(Str, Size) when is_integer(Str) ->
+    align(integer_to_list(Str), Size);
+align(Str, Size) when is_binary(Str) ->
+    align(binary_to_list(Str), Size);
+align(Str, Size) when is_atom(Str) ->
+    align(atom_to_list(Str), Size);
+align(Str, Size) when is_list(Str), length(Str) > Size -> 
+    Truncated = lists:sublist(Str, Size),
+    Truncated ++ " |"; 
+align(Str, Size) when is_list(Str), length(Str) =:= Size ->
+    Str ++ " |";
+align(Str, Size) when is_list(Str) ->
+    StrLen = length(Str),
+    LeftSpaces = (Size - StrLen) div 2,
+    RightSpaces = Size - StrLen - LeftSpaces,
+    spaces(LeftSpaces) ++ Str ++ spaces(RightSpaces) ++ " |";
+align(Term, Size) ->
+    Str = lists:flatten(io_lib:format("~p", [Term])),
+    align(Str, Size).
+
+-spec vertical_border(non_neg_integer()) -> string().
+vertical_border(Length) ->
+    lists:reverse(["\n" | char_seq(Length, $-)]).
+
+-spec spaces(non_neg_integer()) -> string().
+spaces(Length) ->
+    char_seq(Length, $\s).
+
+-spec char_seq(non_neg_integer(), char()) -> string().
+char_seq(Length, Char) ->
+    [Char || _ <- lists:seq(1, Length)].
+


### PR DESCRIPTION
This PR implements all the riak_core bits of security, that is, a place security information is stored and modified and APIs for checking a user has a particular set of permissions. riak_core applications are expected to use these APIs themselves, which is why there's no actual security checking done anywhere in this PR. The riak_kv and riak_api repos are where that happens.

See also basho/riak#355
