### PR TITLE
Fix rebar.config to use {branch, "name"}

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,5 +14,5 @@
   {folsom, ".*", {git, "git://github.com/basho/folsom.git", {tag, "0.7.4p3"}}},
   {ranch, "0.4.0-p1", {git, "git://github.com/basho/ranch.git", {tag, "0.4.0-p1"}}},
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2", {branch, "adt-cleanups"}}},
-  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", "master"}}
+  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "master"}}}
 ]}.


### PR DESCRIPTION
The rebar.config file currently is using "master" by itself, which does
not make rebar actually update that branch on update-deps.
