### PR TITLE
dialyzer fixes for cluster metadata

### DIFF
--- a/src/dvvset.erl
+++ b/src/dvvset.erl
@@ -82,7 +82,7 @@
 
 %% @doc Constructs a new clock set without causal history,
 %% and receives a list of values that gos to the anonymous list.
--spec new([value()]) -> clock().
+-spec new(value() | [value()]) -> clock().
 new(Vs) when is_list(Vs) -> {[], Vs};
 new(V) -> {[], [V]}.
 
@@ -90,7 +90,7 @@ new(V) -> {[], [V]}.
 %% of the given version vector / vector clock,
 %% and receives a list of values that gos to the anonymous list.
 %% The version vector SHOULD BE a direct result of join/1.
--spec new(vector(), [value()]) -> clock().
+-spec new(vector(), value() | [value()]) -> clock().
 new(VV, Vs) when is_list(Vs) ->
     VVS = lists:sort(VV), % defense against non-order preserving serialization
     {[{I, N, []} || {I, N} <- VVS], Vs};
@@ -176,7 +176,7 @@ update({Cc,[V]}, Cr, I) ->
     {event(C, I, V), Vs}.
 
 %% Private function
--spec event(vector(), id(), value()) -> vector().
+-spec event(entries(), id(), value()) -> entries().
 event([], I, V) -> [{I, 1, [V]}];
 event([{I, N, L} | T], I, V) -> [{I, N+1, [V | L]} | T];
 event([{I1, _, _} | _]=C, I, V) when I1 > I -> [{I, 1, [V]} | C];

--- a/src/hashtree_tree.erl
+++ b/src/hashtree_tree.erl
@@ -154,7 +154,7 @@
                                                    different, binary()}]}.
 -type diff()           :: prefix_diff() | key_diffs().
 -type handler_fun(X)   :: fun((diff(), X) -> X).
--opaque remote_fun()   :: fun((prefixes(),
+-type remote_fun()     :: fun((prefixes(),
                                {get_bucket, {integer(), integer()}} |
                                {key_hashses, integer()}) -> orddict:orddict()).
 

--- a/src/riak_core_metadata.erl
+++ b/src/riak_core_metadata.erl
@@ -57,7 +57,7 @@
 -type it_opt()              :: it_opt_resolver() | it_opt_default() | it_opt_keymatch().
 -type it_opts()             :: [it_opt()].
 -type fold_opts()           :: it_opts().
--opaque iterator()          :: {riak_core_metadata_manager:metadata_iterator(), it_opts()}.
+-type iterator()            :: {riak_core_metadata_manager:metadata_iterator(), it_opts()}.
 
 %% Put Option Types
 -type put_opts()            :: [].
@@ -181,11 +181,10 @@ itr_done({It, _Opts}) ->
 %% NOTE: if resolution may be performed this function must be called at most once
 %% before calling itr_next/1 on the iterator (at which point the function can be called
 %% once more).
--spec itr_key_values(riak_core_metadata_manager:iterator()) ->
-                            {metadata_key(),
-                             [metadata_value() | metadata_tombstone()] |
-                             metadata_value() |
-                             metadata_tombstone()}.
+-spec itr_key_values(iterator()) -> {metadata_key(),
+                                     [metadata_value() | metadata_tombstone()] |
+                                     metadata_value() |
+                                     metadata_tombstone()}.
 itr_key_values({It, Opts}) ->
     Default = itr_default({It, Opts}),
     {Key, Obj} = riak_core_metadata_manager:iterator_value(It),

--- a/src/riak_core_metadata_exchange_fsm.erl
+++ b/src/riak_core_metadata_exchange_fsm.erl
@@ -245,7 +245,7 @@ repair_keys(Peer, PrefixList, {_Type, KeyBin}) ->
 merge(undefined, PKey, RemoteObj) ->
     riak_core_metadata_manager:merge({PKey, undefined}, RemoteObj);
 merge(Peer, PKey, LocalObj) ->
-    riak_core_metadata_manager:merge(Peer, {PKey, undefiend}, LocalObj).
+    riak_core_metadata_manager:merge(Peer, {PKey, undefined}, LocalObj).
 
 
 %% @privarte

--- a/src/riak_core_metadata_manager.erl
+++ b/src/riak_core_metadata_manager.erl
@@ -240,7 +240,7 @@ put({{Prefix, SubPrefix}, _Key}=PKey, Context, ValueOrFun)
     gen_server:call(?SERVER, {put, PKey, Context, ValueOrFun}, infinity).
 
 %% @doc same as merge/2 but merges the object on `Node'
--spec merge(node(), {metadata_pkey(), metadata_context()}, metadata_object()) -> boolean().
+-spec merge(node(), {metadata_pkey(), undefined | metadata_context()}, metadata_object()) -> boolean().
 merge(Node, {PKey, _Context}, Obj) ->
     gen_server:call({?SERVER, Node}, {merge, PKey, Obj}, infinity).
 
@@ -260,7 +260,7 @@ broadcast_data(#metadata_broadcast{pkey=Key, obj=Obj}) ->
 %% for the key contained in the message id. If the remote copy is causally older than
 %% the current data stored then `false' is returned and no updates are merged. Otherwise,
 %% the remote copy is merged (possibly generating siblings) and `true' is returned.
--spec merge({metadata_pkey(), metadata_context()}, undefined | metadata_object()) -> boolean().
+-spec merge({metadata_pkey(), undefined | metadata_context()}, undefined | metadata_object()) -> boolean().
 merge({PKey, _Context}, Obj) ->
     gen_server:call(?SERVER, {merge, PKey, Obj}, infinity).
 


### PR DESCRIPTION
addresses issue #392
- fix some typespecs in dvvset, riak_core_metadata and metadata manager
- change some opaque types to regular ones
- don't reuse `remote_iterator` as message to manager process since its
  a record too
- fix typo in exchange_fsm that didn't harm anything

This PR does not fix the issues found by dialyzer in
riak_core_metadata_exchange_fsm (see [here](https://gist.github.com/jrwest/760d9934c5d64d30252e)). Dialyzer isn't able to figure
out we are doing the "right thing" with the iterators here.
