### PR TITLE
Fix ring events monitoring by riak_core_node_watcher

### DIFF
--- a/ebin/riak_core.app
+++ b/ebin/riak_core.app
@@ -54,6 +54,7 @@
              riak_core_repair,
              riak_core_ring,
              riak_core_ring_events,
+             riak_core_ring_events_sup,
              riak_core_ring_handler,
              riak_core_ring_manager,
              riak_core_ring_util,

--- a/src/riak_core_node_watcher.erl
+++ b/src/riak_core_node_watcher.erl
@@ -377,9 +377,9 @@ watch_for_ring_events() ->
     Fn = fun(R) ->
                  gen_server:cast(Self, {ring_update, R})
          end,
-    riak_core_ring_events:add_sup_callback(Fn),
+    HandlerName = riak_core_ring_events:add_sup_callback(Fn),
     case riak_core_ring_events:get_pid() of
-        P when P == RingEventsPid ->
+        P when is_pid(P), P == RingEventsPid ->
             RingEventsPid;
         _ ->
             receive
@@ -388,6 +388,7 @@ watch_for_ring_events() ->
             after 100 ->
                     ok
             end,
+            riak_core_ring_events:delete_handler(HandlerName, race_cond_retry),
             watch_for_ring_events()
     end.
 

--- a/src/riak_core_ring_events.erl
+++ b/src/riak_core_ring_events.erl
@@ -34,7 +34,8 @@
          ring_update/1,
          force_update/0,
          ring_sync_update/1,
-         force_sync_update/0]).
+         force_sync_update/0,
+         get_pid/0]).
 
 %% gen_event callbacks
 -export([init/1, handle_event/2, handle_call/2,
@@ -80,6 +81,9 @@ force_sync_update() ->
 
 ring_sync_update(Ring) ->
     gen_event:sync_notify(?MODULE, {ring_update, Ring}).
+
+get_pid() ->
+    whereis(?MODULE).
 
 %% ===================================================================
 %% gen_event callbacks

--- a/src/riak_core_ring_events_sup.erl
+++ b/src/riak_core_ring_events_sup.erl
@@ -25,7 +25,7 @@
 -behaviour(supervisor).
 
 %% API
--export([start_link/0]).
+-export([start_link/0, start_late_worker/0]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -41,6 +41,12 @@
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
+late_worker_childspec() ->
+    ?CHILD(riak_core_node_watcher, worker).
+
+start_late_worker() ->
+    supervisor:start_child(?MODULE, late_worker_childspec()).
+
 %% ===================================================================
 %% Supervisor callbacks
 %% ===================================================================
@@ -48,8 +54,7 @@ start_link() ->
 init([]) ->
     Children = lists:flatten(
                  [
-                  ?CHILD(riak_core_ring_events, worker),
-                  ?CHILD(riak_core_node_watcher, worker)
+                  ?CHILD(riak_core_ring_events, worker)
                  ]),
 
     {ok, {{one_for_all, 9999, 10}, Children}}.

--- a/src/riak_core_ring_events_sup.erl
+++ b/src/riak_core_ring_events_sup.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_core: Core Riak Application
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -20,7 +20,7 @@
 %%
 %% -------------------------------------------------------------------
 
--module(riak_core_sup).
+-module(riak_core_ring_events_sup).
 
 -behaviour(supervisor).
 
@@ -47,22 +47,9 @@ start_link() ->
 
 init([]) ->
     Children = lists:flatten(
-                 [?CHILD(riak_core_sysmon_minder, worker),
-                  ?CHILD(riak_core_vnode_sup, supervisor, 305000),
-                  ?CHILD(riak_core_eventhandler_sup, supervisor),
-                  ?CHILD(riak_core_ring_events_sup, supervisor),
-                  ?CHILD(riak_core_ring_manager, worker),
-                  ?CHILD(riak_core_metadata_manager, worker),
-                  ?CHILD(riak_core_metadata_hashtree, worker),
-                  ?CHILD(riak_core_broadcast, worker),
-                  ?CHILD(riak_core_vnode_proxy_sup, supervisor),
-                  ?CHILD(riak_core_node_watcher_events, worker),
-                  ?CHILD(riak_core_vnode_manager, worker),
-                  ?CHILD(riak_core_capability, worker),
-                  ?CHILD(riak_core_handoff_sup, supervisor),
-                  ?CHILD(riak_core_gossip, worker),
-                  ?CHILD(riak_core_claimant, worker),
-                  ?CHILD(riak_core_stat_sup, supervisor)
+                 [
+                  ?CHILD(riak_core_ring_events, worker),
+                  ?CHILD(riak_core_node_watcher, worker)
                  ]),
 
-    {ok, {{one_for_one, 10, 10}, Children}}.
+    {ok, {{one_for_all, 9999, 10}, Children}}.

--- a/src/riak_core_ring_events_sup.erl
+++ b/src/riak_core_ring_events_sup.erl
@@ -25,7 +25,7 @@
 -behaviour(supervisor).
 
 %% API
--export([start_link/0, start_late_worker/0]).
+-export([start_link/0, start_riak_core_node_watcher/0]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -41,11 +41,11 @@
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
-late_worker_childspec() ->
+riak_core_node_watcher_childspec() ->
     ?CHILD(riak_core_node_watcher, worker).
 
-start_late_worker() ->
-    supervisor:start_child(?MODULE, late_worker_childspec()).
+start_riak_core_node_watcher() ->
+    supervisor:start_child(?MODULE, riak_core_node_watcher_childspec()).
 
 %% ===================================================================
 %% Supervisor callbacks

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -97,6 +97,7 @@
     }).
 
 -export([setup_ets/1, cleanup_ets/1, set_ring_global/1]). %% For EUnit testing
+-export([test_dummy_func/1]).
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
@@ -626,6 +627,9 @@ prune_write_ring(Ring, State) ->
 %% Unit tests
 %% ===================================================================
 -ifdef(TEST).
+
+test_dummy_func(_Arg) ->
+    ok.
 
 back_test() ->
     X = [1,2,3],

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -623,13 +623,13 @@ prune_write_ring(Ring, State) ->
     State2 = set_ring(Ring, State),
     State2.
 
+test_dummy_func(_Arg) ->
+    ok.
+
 %% ===================================================================
 %% Unit tests
 %% ===================================================================
 -ifdef(TEST).
-
-test_dummy_func(_Arg) ->
-    ok.
 
 back_test() ->
     X = [1,2,3],

--- a/src/riak_core_sup.erl
+++ b/src/riak_core_sup.erl
@@ -57,6 +57,12 @@ init([]) ->
                   ?CHILD(riak_core_broadcast, worker),
                   ?CHILD(riak_core_vnode_proxy_sup, supervisor),
                   ?CHILD(riak_core_node_watcher_events, worker),
+                  %% riak_core_node_watcher is no longer started here.  It is
+                  %% now a *dynamic* child of the riak_core_ring_events_sup
+                  %% and started by riak_core_vnode_manager:init/1.  If it is
+                  %% started by riak_core_ring_events_sup during its startup,
+                  %% it is too early, and Riak rings never settle after a ring
+                  %% change.
                   ?CHILD(riak_core_vnode_manager, worker),
                   ?CHILD(riak_core_capability, worker),
                   ?CHILD(riak_core_handoff_sup, supervisor),

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -206,8 +206,9 @@ get_all_vnodes(Mod) ->
 
 %% @private
 init(_State) ->
-    {ok, _Pid} = riak_core_ring_events_sup:start_late_worker(),
-    error_logger:warning_msg("YO started late worker ~p\n", [_Pid]),
+    %% See riak_core_sup:init/1 for why this call is here.
+    {ok, _Pid} = riak_core_ring_events_sup:start_riak_core_node_watcher(),
+
     {ok, Ring, CHBin} = riak_core_ring_manager:get_raw_ring_chashbin(),
     Mods = [Mod || {_, Mod} <- riak_core:vnode_modules()],
     State = #state{forwarding=dict:new(), handoff=dict:new(),

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -206,6 +206,8 @@ get_all_vnodes(Mod) ->
 
 %% @private
 init(_State) ->
+    {ok, _Pid} = riak_core_ring_events_sup:start_late_worker(),
+    error_logger:warning_msg("YO started late worker ~p\n", [_Pid]),
     {ok, Ring, CHBin} = riak_core_ring_manager:get_raw_ring_chashbin(),
     Mods = [Mod || {_, Mod} <- riak_core:vnode_modules()],
     State = #state{forwarding=dict:new(), handoff=dict:new(),


### PR DESCRIPTION
Fixes #343: riak_core_node_watcher should tolerate death of riak_core_ring_events

Before this patch, the riak_core_node_watcher.erl code assumed
that if the riak_core_ring_events proc (a gen_event server) died,
then a {gen_event_EXIT,_,_} message would be sent.  However, that
assumption is not correct.  If it dies, we get a regular {EXIT,_,_}
message.

Tested by repeated use of alternating:
- exit(whereis(riak_core_ring_events), kill).

... and looking at the length of the links list
of process_info(whereis(riak_core_ring_events), links) -- it should
be three, not two.
