### PR TITLE
Proper Bucket Type Creation

### DIFF
--- a/src/riak_core_bucket_props.erl
+++ b/src/riak_core_bucket_props.erl
@@ -90,73 +90,40 @@ resolve({allow_mult, Mult1}, {allow_mult, Mult2}) ->
 resolve({basic_quorum, Basic1}, {basic_quorum, Basic2}) ->
     Basic1 andalso Basic2;
 resolve({big_vclock, Big1}, {big_vclock, Big2}) ->
-    case Big1 > Big2 of
-        true -> Big1;
-        false -> Big2
-    end;
+    max(Big1, Big2);
 resolve({chash_keyfun, KeyFun1}, {chash_keyfun, _KeyFun2}) ->
     KeyFun1; %% arbitrary choice
 resolve({dw, DW1}, {dw, DW2}) ->
     %% 'quorum' wins over set numbers
-    case DW1 > DW2 of
-        true -> DW1;
-        false -> DW2
-    end;
+    max(DW1, DW2);
 resolve({last_write_wins, LWW1}, {last_write_wins, LWW2}) ->
     LWW1 andalso LWW2;
 resolve({linkfun, LinkFun1}, {linkfun, _LinkFun2}) ->
     LinkFun1; %% arbitrary choice
 resolve({n_val, N1}, {n_val, N2}) ->
-    case N1 > N2 of
-        true -> N1;
-        false -> N2
-    end;
+    max(N1, N2);
 resolve({notfound_ok, NF1}, {notfound_ok, NF2}) ->
     NF1 orelse NF2;
 resolve({old_vclock, Old1}, {old_vclock, Old2}) ->
-    case Old1 > Old2 of
-        true -> Old1;
-        false -> Old2
-    end;
+    max(Old1, Old2);
 resolve({postcommit, PC1}, {postcommit, PC2}) ->
     resolve_hooks(PC1, PC2);
 resolve({pr, PR1}, {pr, PR2}) ->
-    case PR1 > PR2 of
-        true -> PR1;
-        false -> PR2
-    end;
+    max(PR1, PR2);
 resolve({precommit, PC1}, {precommit, PC2}) ->
     resolve_hooks(PC1, PC2);
 resolve({pw, PW1}, {pw, PW2}) ->
-    case PW1 > PW2 of
-        true -> PW1;
-        false -> PW2
-    end;
+    max(PW1, PW2);
 resolve({r, R1}, {r, R2}) ->
-    case R1 > R2 of
-        true -> R1;
-        false -> R2
-    end;
+    max(R1, R2);
 resolve({rw, RW1}, {rw, RW2}) ->
-    case RW1 > RW2 of
-        true -> RW1;
-        false -> RW2
-    end;
+    max(RW1, RW2);
 resolve({small_vclock, Small1}, {small_vclock, Small2}) ->
-    case Small1 > Small2 of
-        true -> Small1;
-        false -> Small2
-    end;
+    max(Small1, Small2);
 resolve({w, W1}, {w, W2}) ->
-    case W1 > W2 of
-        true -> W1;
-        false -> W2
-    end;
+    max(W1, W2);
 resolve({young_vclock, Young1}, {young_vclock, Young2}) ->
-    case Young1 > Young2 of
-        true -> Young1;
-        false -> Young2
-    end;
+    max(Young1, Young2);
 resolve({_, V1}, {_, _V2}) ->
     V1.
 


### PR DESCRIPTION
Features that plan to use bucket types require that certain properties be "create-only" -- they cannot change after data has been written to buckets under the type. To ensure these semantics it is important that nodes see either no "create-only" properties for a type, or only one version of the "create-only" properties. Since types are stored in Cluster Metadata, the current implementation does not guarantee this. To ensure that it does, we take the following two steps to handle concurrent writers:
1. all writes are serialized through the current claimant
2. to handle the case where the claimant changes over before properties have had a chance to fully propogate, creation is a two step process. Only when all nodes agree can the second step be reached, and nodes do not see the properties (while handling requests, etc) until the second step is complete.

This, also, allows for the "create-only" properties to be changed between the first and second steps, referred to as "creation" and "activation". This is useful in the case where a user accidentally specifies the wrong value for a "create-only" property. After activating the type, all properties that are not "create-only" may continue to be updated. More details can be found in the module edoc for `riak_core_bucket_type`.

riak_core does not enforce the notion of "create-only" types. This PR includes an extension to riak_core's bucket validators (changing the interface to validator modules). Validation functions are now passed an atom indicating if the properties are being validated are for bucket type creation, or are type or bucket properties for updating. In addition, the function is passed the type and bucket, as well as the old properties if they existed. Validators can use this information to enforce "create-only" types.

Lastly, this PR makes a minor change to `riak_core_bucket_props` to use the `max` function in `resolve` -- as suggested somewhere during review of an earlier PR.

NOTE: currently this PR does not include very comprehensive tests. I've begun an eqc test but that may have to wait until pre4. The bucket types riak_test has been updated (https://github.com/basho/riak_test/pull/394) and should pass
