### PR TITLE
export index type from chash

### DIFF
--- a/src/chash.erl
+++ b/src/chash.erl
@@ -50,7 +50,7 @@
          successors/3,
          update/3]).
 
--export_type([chash/0]).
+-export_type([chash/0, index/0]).
     
 -define(RINGTOP, trunc(math:pow(2,160)-1)).  % SHA-1 space
 


### PR DESCRIPTION
riak_pipe wants to use the `chash:index()` type: https://github.com/basho/riak_pipe/blob/develop/src/riak_pipe_vnode.erl#L69

Can it be exported, please?
