### PR TITLE
Fix eunit test failures

### DIFF
--- a/src/riak_core_stat_cache.erl
+++ b/src/riak_core_stat_cache.erl
@@ -74,7 +74,7 @@ clear_cache(App) ->
     gen_server:call(?SERVER, {clear, App}, infinity).
 
 stop() ->
-    gen_server:cast(?SERVER, stop, infinity).
+    gen_server:cast(?SERVER, stop).
 
 %%% gen server
 

--- a/test/node_watcher_qc.erl
+++ b/test/node_watcher_qc.erl
@@ -55,7 +55,7 @@ prop_main() ->
     riak_core_node_watcher_events:start_link(),
 
     %% meck used for health watch / threshold
-    meck:new(mod_health, [non_strict]),
+    meck:new(mod_health, [non_strict, no_link]),
 
     ?FORALL(Cmds, commands(?MODULE),
             begin


### PR DESCRIPTION
- Scott's accidental cast to infinity (and beyond!!)
- core_vnode_eqc was failing due to meck unload module on process death
  behavior, removed with no_link flag
