### PR TITLE
refactored riak_core bits of the schema in here, with tests

### DIFF
--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -1,0 +1,101 @@
+%% example of super basic mapping
+%% @doc Default ring creation size.  Make sure it is a power of 2,
+%% e.g. 16, 32, 64, 128, 256, 512 etc
+{mapping, "ring_size", "riak_core.ring_creation_size", [
+  {datatype, integer},
+  {default, 64},
+  {validators, ["ring_size"]},
+  {commented, 64}
+]}.
+
+%% ring_size validator
+{validator, "ring_size", "not a power of 2 greater than 1",
+ fun(Size) -> 
+  Size > 1 andalso (Size band (Size-1) =:= 0)
+ end}.
+
+%% @doc Default location of ringstate
+{mapping, "ring.state_dir", "riak_core.ring_state_dir", [
+  {default, "{{ring_state_dir}}"}
+]}.
+
+%% @doc Default cert location for https can be overridden
+%% with the ssl config variable, for example:
+{mapping, "ssl.certfile", "riak_core.ssl.certfile", [
+  {commented, "{{platform_etc_dir}}/cert.pem"}
+]}.
+
+%% @doc Default key location for https can be overridden
+%% with the ssl config variable, for example:
+{mapping, "ssl.keyfile", "riak_core.ssl.keyfile", [
+  {commented, "{{platform_etc_dir}}/key.pem"}
+]}.
+
+%% @doc Default signing authority location for https can be overridden
+%% with the ssl config variable, for example:
+{mapping, "ssl.cacertfile", "riak_core.ssl.cacertfile", [
+  {commented, "{{platform_etc_dir}}/cacertfile.pem"}
+]}.
+
+%% @doc handoff.port is the TCP port that Riak uses for
+%% intra-cluster data handoff.
+{mapping, "handoff.port", "riak_core.handoff_port", [
+  {default, {{handoff_port}} },
+  {datatype, integer}
+]}.
+
+%% @doc To encrypt riak_core intra-cluster data handoff traffic,
+%% uncomment the following line and edit its path to an
+%% appropriate certfile and keyfile.  (This example uses a
+%% single file with both items concatenated together.)
+{mapping, "handoff.ssl.certfile", "riak_core.handoff_ssl_options.certfile", [
+  {commented, "/tmp/erlserver.pem"}
+]}.
+
+%% @doc if you need a seperate keyfile for handoff
+{mapping, "handoff.ssl.keyfile", "riak_core.handoff_ssl_options.keyfile", []}.
+
+%% @doc DTrace support
+%% Do not enable 'dtrace' unless your Erlang/OTP
+%% runtime is compiled to support DTrace.  DTrace is
+%% available in R15B01 (supported by the Erlang/OTP
+%% official source package) and in R14B04 via a custom
+%% source repository & branch.
+{mapping, "dtrace", "riak_core.dtrace_support", [
+  {default, off},
+  {datatype, {enum, [on, off]}}
+]}.
+
+%% consistent on/off (in lieu of enabled/disabled, true/false)
+{ translation,
+  "riak_core.dtrace_support",
+  fun(Conf) ->
+    Setting = cuttlefish_util:conf_get_value("dtrace", Conf), 
+    case Setting of
+      on -> true;
+      off -> false;
+      _Default -> false
+    end
+  end
+}.
+
+%% Platform-specific installation paths (substituted by rebar)
+{mapping, "platform_bin_dir", "riak_core.platform_bin_dir", [
+  {default, "{{platform_bin_dir}}"}
+]}.
+
+{mapping, "platform_data_dir", "riak_core.platform_data_dir", [
+  {default, "{{platform_data_dir}}"}
+]}.
+
+{mapping, "platform_etc_dir", "riak_core.platform_etc_dir", [
+  {default, "{{platform_etc_dir}}"}
+]}.
+
+{mapping, "platform_lib_dir", "riak_core.platform_lib_dir", [
+  {default, "{{platform_lib_dir}}"}
+]}.
+
+{mapping, "platform_log_dir", "riak_core.platform_log_dir", [
+  {default, "{{platform_log_dir}}"}
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -14,5 +14,6 @@
   {folsom, ".*", {git, "git://github.com/basho/folsom.git", {tag, "0.7.4p3"}}},
   {ranch, "0.4.0-p1", {git, "git://github.com/basho/ranch.git", {tag, "0.4.0-p1"}}},
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2", {branch, "adt-cleanups"}}},
-  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "master"}}}
+  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "master"}}},
+  {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish", {branch, "develop"}}}
 ]}.

--- a/test/riak_core_schema_tests.erl
+++ b/test/riak_core_schema_tests.erl
@@ -1,0 +1,68 @@
+-module(riak_core_schema_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-compile(export_all).
+
+basic_schema_test() ->
+    Config = cuttlefish_unit:generate_templated_config("../priv/riak_core.schema", [], context()),
+
+    cuttlefish_unit:assert_config(Config, "riak_core.ring_creation_size", 64),
+    cuttlefish_unit:assert_config(Config, "riak_core.ring_state_dir", "./ring"),
+    cuttlefish_unit:assert_config(Config, "riak_core.handoff_port", 8099 ),
+    cuttlefish_unit:assert_config(Config,"riak_core.dtrace_support", false),
+    cuttlefish_unit:assert_config(Config, "riak_core.platform_bin_dir",  "./bin"),
+    cuttlefish_unit:assert_config(Config, "riak_core.platform_data_dir", "./data"),
+    cuttlefish_unit:assert_config(Config, "riak_core.platform_etc_dir",  "./etc"),
+    cuttlefish_unit:assert_config(Config, "riak_core.platform_lib_dir",  "./lib"),
+    cuttlefish_unit:assert_config(Config, "riak_core.platform_log_dir",  "./log"),
+    ok.
+
+override_schema_test() ->
+    Conf = [
+        {["ring_size"], 8},
+        {["ring", "state_dir"], "/absolute/ring"},
+        {["handoff", "port"], 8888},
+        {["dtrace"], on},
+        %% Platform-specific installation paths (substituted by rebar)
+        {["platform_bin_dir"], "/absolute/bin"},
+        {["platform_data_dir"],"/absolute/data" },
+        {["platform_etc_dir"], "/absolute/etc"},
+        {["platform_lib_dir"], "/absolute/lib"},
+        {["platform_log_dir"], "/absolute/log"},
+
+        %% Optional
+        {["ssl", "certfile"], "/absolute/etc/cert.pem"},
+        {["ssl", "keyfile"], "/absolute/etc/key.pem"},
+        {["ssl", "cacertfile"], "/absolute/etc/cacertfile.pem"},
+        {["handoff", "ssl", "certfile"], "/tmp/erlserver.pem"},
+        {["handoff", "ssl", "keyfile"], "/tmp/erlkey/pem"}
+    ],
+
+    Config = cuttlefish_unit:generate_templated_config("../priv/riak_core.schema", Conf, context()),
+
+    cuttlefish_unit:assert_config(Config, "riak_core.ring_creation_size", 8),
+    cuttlefish_unit:assert_config(Config, "riak_core.ring_state_dir", "/absolute/ring"),
+    cuttlefish_unit:assert_config(Config, "riak_core.handoff_port", 8888),
+    cuttlefish_unit:assert_config(Config, "riak_core.dtrace_support", true),
+    cuttlefish_unit:assert_config(Config, "riak_core.platform_bin_dir", "/absolute/bin"),
+    cuttlefish_unit:assert_config(Config, "riak_core.platform_data_dir", "/absolute/data"),
+    cuttlefish_unit:assert_config(Config, "riak_core.platform_etc_dir", "/absolute/etc"),
+    cuttlefish_unit:assert_config(Config, "riak_core.platform_lib_dir", "/absolute/lib"),
+    cuttlefish_unit:assert_config(Config, "riak_core.platform_log_dir", "/absolute/log"),
+    cuttlefish_unit:assert_config(Config, "riak_core.ssl.certfile", "/absolute/etc/cert.pem"),
+    cuttlefish_unit:assert_config(Config, "riak_core.ssl.keyfile", "/absolute/etc/key.pem"),
+    cuttlefish_unit:assert_config(Config, "riak_core.ssl.cacertfile", "/absolute/etc/cacertfile.pem"),
+    cuttlefish_unit:assert_config(Config, "riak_core.handoff_ssl_options.certfile", "/tmp/erlserver.pem"),
+    cuttlefish_unit:assert_config(Config, "riak_core.handoff_ssl_options.keyfile", "/tmp/erlkey/pem"),
+    ok.
+
+context() ->
+    [
+        {handoff_port, "8099"},
+        {ring_state_dir , "./ring"},
+        {platform_bin_dir , "./bin"},
+        {platform_data_dir, "./data"},
+        {platform_etc_dir , "./etc"},
+        {platform_lib_dir , "./lib"},
+        {platform_log_dir , "./log"}
+    ].

--- a/test/riak_core_schema_tests.erl
+++ b/test/riak_core_schema_tests.erl
@@ -3,7 +3,10 @@
 -include_lib("eunit/include/eunit.hrl").
 -compile(export_all).
 
+%% basic schema test will check to make sure that all defaults from the schema
+%% make it into the generated app.config
 basic_schema_test() ->
+    %% The defaults are defined in ../priv/riak_core.schema. it is the file under test. 
     Config = cuttlefish_unit:generate_templated_config("../priv/riak_core.schema", [], context()),
 
     cuttlefish_unit:assert_config(Config, "riak_core.ring_creation_size", 64),
@@ -18,6 +21,8 @@ basic_schema_test() ->
     ok.
 
 override_schema_test() ->
+    %% Conf represents the riak.conf file that would be read in by cuttlefish.
+    %% this proplists is what would be output by the conf_parse module
     Conf = [
         {["ring_size"], 8},
         {["ring", "state_dir"], "/absolute/ring"},
@@ -56,6 +61,10 @@ override_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_core.handoff_ssl_options.keyfile", "/tmp/erlkey/pem"),
     ok.
 
+%% this context() represents the substitution variables that rebar will use during the build process.
+%% riak_core's schema file is written with some {{mustache_vars}} for substitution during packaging
+%% cuttlefish doesn't have a great time parsing those, so we perform the substitutions first, because
+%% that's how it would work in real life.
 context() ->
     [
         {handoff_port, "8099"},


### PR DESCRIPTION
Although the rebar.config specifies `cuttlefish:develop`, it will need jd-test-tools to run until https://github.com/basho/cuttlefish/pull/42 is merged. If you do review this, be a dear and review that too? :)

I've refactored the riak_core bits of the schema into the riak_core project for easier testing and less duplication of schema files between the riak and riak-ee repos..
