### PR TITLE
Update otp_release list in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ notifications:
   webhooks: http://basho-engbot.herokuapp.com/travis?key=72ce513a4a26166521f60f72511bfb905329db87
   email: eng@basho.com
 otp_release:
+  - R16B
+  - R15B03
+  - R15B02
   - R15B01
   - R15B
-  - R14B04
-  - R14B03
 


### PR DESCRIPTION
Changes:
- Removed R14\* Erlang version targets from `.travis.yml`
- Added R15B\* and R16B Erlang version targets to `.travis.yml`

Background:
Until this change Travis CI was building against Erlang R14 which is not
supported for Riak (KV) according to [Basho documentation](http://docs.basho.com/riak/latest/ops/building/installing/erlang/),
which states, _"Riak requires Erlang R15B01"_. The R14 builds consistently 
failed since the ring resizing change was merged.

Since `.travis.yml` was updated last (a year ago) R15B0{2-3} and R16B
were released. R16B01 and R16B02 do not appear to be offered as choices
in Travis CI yet ([according to Travis CI's documentation](http://about.travis-ci.org/docs/user/languages/erlang/)).
