### PR TITLE
Fix bad type specifications.

### DIFF
--- a/include/riak_core_connection.hrl
+++ b/include/riak_core_connection.hrl
@@ -87,7 +87,7 @@
 %%                the number of accepted connections to max_nb_cons().
 %% custom := service must provide a strategy to the cluster manager for choosing nodes
 %%           UNSUPPORTED so far. Should we use a behaviour for the service module?
--type(max_nb_cons() :: non_neg_integer()).
+-type(max_nb_cons() :: non_neg_integer() | undefined).
 -type(client_scheduler_strategy() :: default | askme).
 -type(service_scheduler_strategy() :: {round_robin, max_nb_cons()} | custom).
 

--- a/src/riak_core_connection_mgr.erl
+++ b/src/riak_core_connection_mgr.erl
@@ -49,7 +49,8 @@
 -define(SERVER, riak_core_connection_manager).
 -define(MAX_LISTENERS, 100).
 
--type(counter() :: non_neg_integer()).
+-type counter() :: non_neg_integer().
+-type target()  :: {atom(), term()}.
 
 %% Connection manager strategy (per Jon M.)
 %% when a connection request comes in,
@@ -187,18 +188,18 @@ apply_locator(Name, Strategy) ->
 %% Supervision must be done by the calling process if desired. No supervision
 %% is done here.
 %%
--spec connect(Target :: string(), ClientSpec :: clientspec(), Strategy :: client_scheduler_strategy()) -> {'ok', reference()}.
+-spec connect(Target :: target(), ClientSpec :: clientspec(), Strategy :: client_scheduler_strategy()) -> {'ok', reference()}.
 connect(Target, ClientSpec, Strategy) ->
     gen_server:call(?SERVER, {connect, Target, ClientSpec, Strategy}, infinity).
 
 %% @doc same as connect(Target, ClientSpec, default).
 %% @see connect/3
--spec connect(Target :: string(), ClientSpec :: clientspec()) -> {'ok', reference()}.
+-spec connect(Target :: target(), ClientSpec :: clientspec()) -> {'ok', reference()}.
 connect(Target, ClientSpec) ->
     gen_server:call(?SERVER, {connect, Target, ClientSpec, default}, infinity).
 
 %% @doc Disconnect from the remote side.
--spec disconnect(Target :: string()) -> 'ok'.
+-spec disconnect(Target :: target()) -> 'ok'.
 disconnect(Target) ->
     gen_server:cast(?SERVER, {disconnect, Target}).
 


### PR DESCRIPTION
max_nb_const should be widened to include 'undefined', considering how
all callers into this function only ever pass undefined at this point.

Also, define a new 'target' type which is used, because currently, the
type is declared as string which is incorrect and triggering dialyzer
type warnings anywhere this type is referenced.
