### PR TITLE
do not serialize through gen_server on metadata get

### DIFF
--- a/src/riak_core_metadata_manager.erl
+++ b/src/riak_core_metadata_manager.erl
@@ -122,10 +122,12 @@ start_link(Opts) ->
 -spec get(metadata_pkey()) -> metadata_object() | undefined.
 get({{Prefix, SubPrefix}, _Key}=PKey) when (is_binary(Prefix) orelse is_atom(Prefix)) andalso
                                            (is_binary(SubPrefix) orelse is_atom(SubPrefix)) ->
-    gen_server:call(?SERVER, {get, PKey}, infinity).
+    read(PKey).
 
 %% @doc Same as get/1 but reads the value from `Node'
 -spec get(node(), metadata_pkey()) -> metadata_object() | undefined.
+get(Node, PKey) when node() =:= Node ->
+    ?MODULE:get(PKey);
 get(Node, {{Prefix, SubPrefix}, _Key}=PKey)
   when (is_binary(Prefix) orelse is_atom(Prefix)) andalso
        (is_binary(SubPrefix) orelse is_atom(SubPrefix)) ->


### PR DESCRIPTION
addresses #409 

The reason we serialized is historical and no longer applies (and was going to be removed).

https://github.com/basho/riak_test/pull/388 should still pass w/ this change.

cc/ @engelsanchez 
