### PR TITLE
share segment store accross all nodes in hashtree_tree

### DIFF
--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -103,6 +103,7 @@
 
 -export([new/0,
          new/2,
+         new/3,
          insert/3,
          insert/4,
          delete/2,


### PR DESCRIPTION
this ensures that we don't create an unbounded number of segment
stores (leveldb databases), instead only creating one.

addresses #428 

exports `hashtree:new/3` so that each level can still pass different size options
