### PR TITLE
Implement riak security enable/disable/status

### DIFF
--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -91,7 +91,9 @@ start(_StartType, _StartArgs) ->
             riak_core_capability:register({riak_core, fold_req_version},
                                           [v2, v1],
                                           v1),
-
+            riak_core_capability:register({riak_core, security},
+                                          [true, false],
+                                          false),
             {ok, Pid};
         {error, Reason} ->
             {error, Reason}

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -25,7 +25,8 @@
          clear_staged/1, transfer_limit/1, pending_claim_percentage/2,
          transfers/1, add_user/1, alter_user/1, del_user/1,
          add_source/1, del_source/1, grant/1, revoke/1,
-         print_users/1, print_user/1, print_sources/1, ciphers/1]).
+         print_users/1, print_user/1, print_sources/1,
+         security_enable/1, security_disable/1, security_status/1, ciphers/1]).
 
 %% @doc Return for a given ring and node, percentage currently owned and
 %% anticipated after the transitions have been completed.
@@ -1001,6 +1002,23 @@ ciphers([CipherList]) ->
             ok;
         error ->
             error
+    end.
+
+security_enable([]) ->
+    riak_core_security:enable().
+
+security_disable([]) ->
+    riak_core_security:disable().
+
+security_status([]) ->
+    case riak_core_security:status() of
+        enabled ->
+            io:format("Enabled~n");
+        disabled ->
+            io:format("Disabled~n");
+        enabled_but_no_capability ->
+            io:format("WARNING: Configured to be enabled, but not supported "
+                      "on all nodes so it is disabled!~n")
     end.
 
 parse_options(Options) ->


### PR DESCRIPTION
Implemented in terms of a cluster_metadata modulated capability.

I'm not actually sure this yields the right semantics. On the one hand it makes sure that the status of security across the cluster is consistent, but on the other it means that if you join one old (or malicious) node to the cluster, your security goes bye-bye.
