### PR TITLE
Removed webmachine from applications that should be started.

### DIFF
--- a/src/riak_core.app.src
+++ b/src/riak_core.app.src
@@ -14,7 +14,6 @@
                   sasl,
                   crypto,
                   riak_sysmon,
-                  webmachine,
                   os_mon
                  ]},
   {mod, {riak_core_app, []}},


### PR DESCRIPTION
This line becomes a problem when building a release with the newest version of riak_core without having webmachine in the project.
