### PR TITLE
Implement alter-user, del-user and del-source

### DIFF
--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -824,21 +824,31 @@ check_limit(Str) ->
     end.
 
 add_user([Username|Options]) ->
-    case riak_core_security:add_user(list_to_binary(Username),
+    try riak_core_security:add_user(list_to_binary(Username),
                                      parse_options(Options)) of
         ok -> ok;
         Error ->
             io:format("~p~n", [Error]),
             Error
+    catch
+        throw:{error, {invalid_option, Option}} ->
+            io:format("Invalid option ~p, options are of the form key=value~n",
+                      [Option]),
+            error
     end.
 
 alter_user([Username|Options]) ->
-    case riak_core_security:alter_user(list_to_binary(Username),
-                                     parse_options(Options)) of
+    try riak_core_security:alter_user(list_to_binary(Username),
+                                       parse_options(Options)) of
         ok -> ok;
         Error ->
             io:format("~p~n", [Error]),
             Error
+    catch
+        throw:{error, {invalid_option, Option}} ->
+            io:format("Invalid option ~p, options are of the form key=value~n",
+                      [Option]),
+            error
     end.
 
 del_user([Username]) ->
@@ -856,7 +866,7 @@ add_source([Users, CIDR, Source | Options]) ->
         Other ->
             [list_to_binary(O) || O <- Other]
     end,
-    case riak_core_security:add_source(Unames, parse_cidr(CIDR),
+    try riak_core_security:add_source(Unames, parse_cidr(CIDR),
                                   list_to_atom(Source),
                                   parse_options(Options)) of
         ok ->
@@ -864,6 +874,11 @@ add_source([Users, CIDR, Source | Options]) ->
         Error ->
             io:format("~p~n", [Error]),
             Error
+    catch
+        throw:{error, {invalid_option, Option}} ->
+            io:format("Invalid option ~p, options are of the form key=value~n",
+                      [Option]),
+            error
     end.
 
 del_source([Users, CIDR]) ->

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -23,7 +23,8 @@
          stage_leave/1, stage_remove/1, stage_replace/1, stage_resize_ring/1,
          stage_force_replace/1, print_staged/1, commit_staged/1,
          clear_staged/1, transfer_limit/1, pending_claim_percentage/2,
-         transfers/1, add_user/1, add_source/1, grant/1, revoke/1,
+         transfers/1, add_user/1, alter_user/1, add_source/1,
+         del_source/1, grant/1, revoke/1,
          print_users/1, print_user/1, print_sources/1, ciphers/1]).
 
 %% @doc Return for a given ring and node, percentage currently owned and
@@ -831,6 +832,15 @@ add_user([Username|Options]) ->
             Error
     end.
 
+alter_user([Username|Options]) ->
+    case riak_core_security:alter_user(list_to_binary(Username),
+                                     parse_options(Options)) of
+        ok -> ok;
+        Error ->
+            io:format("~p~n", [Error]),
+            Error
+    end.
+
 add_source([Users, CIDR, Source | Options]) ->
     Unames = case string:tokens(Users, ",") of
         ["all"] ->
@@ -841,6 +851,21 @@ add_source([Users, CIDR, Source | Options]) ->
     case riak_core_security:add_source(Unames, parse_cidr(CIDR),
                                   list_to_atom(Source),
                                   parse_options(Options)) of
+        ok ->
+            ok;
+        Error ->
+            io:format("~p~n", [Error]),
+            Error
+    end.
+
+del_source([Users, CIDR]) ->
+    Unames = case string:tokens(Users, ",") of
+        ["all"] ->
+            all;
+        Other ->
+            [list_to_binary(O) || O <- Other]
+    end,
+    case riak_core_security:del_source(Unames, parse_cidr(CIDR)) of
         ok ->
             ok;
         Error ->
@@ -961,8 +986,13 @@ parse_options(Options) ->
 parse_options([], Acc) ->
     Acc;
 parse_options([H|T], Acc) ->
-    [Key, Value] = string:tokens(H, "="),
-    parse_options(T, [{Key, Value}|Acc]).
+    case re:split(H, "=", [{parts, 2}, {return, list}]) of
+        [Key, Value] ->
+            parse_options(T, [{Key, Value}|Acc]);
+        _Other ->
+            throw({error, {invalid_option, H}})
+    end.
+
 
 parse_cidr(CIDR) ->
     [IP, Mask] = string:tokens(CIDR, "/"),

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -23,8 +23,8 @@
          stage_leave/1, stage_remove/1, stage_replace/1, stage_resize_ring/1,
          stage_force_replace/1, print_staged/1, commit_staged/1,
          clear_staged/1, transfer_limit/1, pending_claim_percentage/2,
-         transfers/1, add_user/1, alter_user/1, add_source/1,
-         del_source/1, grant/1, revoke/1,
+         transfers/1, add_user/1, alter_user/1, del_user/1,
+         add_source/1, del_source/1, grant/1, revoke/1,
          print_users/1, print_user/1, print_sources/1, ciphers/1]).
 
 %% @doc Return for a given ring and node, percentage currently owned and
@@ -835,6 +835,14 @@ add_user([Username|Options]) ->
 alter_user([Username|Options]) ->
     case riak_core_security:alter_user(list_to_binary(Username),
                                      parse_options(Options)) of
+        ok -> ok;
+        Error ->
+            io:format("~p~n", [Error]),
+            Error
+    end.
+
+del_user([Username]) ->
+    case riak_core_security:del_user(list_to_binary(Username)) of
         ok -> ok;
         Error ->
             io:format("~p~n", [Error]),

--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -86,13 +86,14 @@ print_users() ->
     Users = riak_core_metadata:fold(fun({Username, Options}, Acc) ->
                                     [{Username, Options}|Acc]
                             end, [], {<<"security">>, <<"roles">>}),
-    riak_core_console_table:print([{username, 20}, {roles, 20}, {password, 40}, {options, 30}],
+    riak_core_console_table:print([{username, 10}, {roles, 15}, {password, 40}, {options, 30}],
                 [begin
                      Roles = case proplists:get_value("roles", Options) of
                                  undefined ->
                                      "";
                                  List ->
-                                     prettyprint_permissions(List, 20)
+                                     prettyprint_permissions([binary_to_list(R)
+                                                              || R <- List], 20)
                              end,
                      Password = case proplists:get_value("password", Options) of
                                     undefined ->


### PR DESCRIPTION
Previously to this, you could add users and sources, but they were effectively immutable because I had not implemented API for changing them. alter-source does not exist because add-source will effectively do what you want. We could add a synonym at the riak-admin level if we want to.

Also, fixes a bug in print-users I found before RICON that didn't make it into the tech preview.
