### PR TITLE
Supports riak_kv changes for riak_kv#679

### DIFF
--- a/src/riak_core_util.erl
+++ b/src/riak_core_util.erl
@@ -123,17 +123,21 @@ make_tmp_dir() ->
 
 replace_file(FN, Data) ->
     TmpFN = FN ++ ".tmp",
-    {ok, FH} = file:open(TmpFN, [write, raw]),
-    try
-        ok = file:write(FH, Data),
-        ok = file:sync(FH),
-        ok = file:close(FH),
-        ok = file:rename(TmpFN, FN),
-        {ok, Contents} = read_file(FN),
-        true = (Contents == iolist_to_binary(Data)),
-        ok
-    catch _:Err ->
-            {error, Err}
+    case file:open(TmpFN, [write, raw]) of
+        {ok, FH} ->
+            try
+                ok = file:write(FH, Data),
+                ok = file:sync(FH),
+                ok = file:close(FH),
+                ok = file:rename(TmpFN, FN),
+                {ok, Contents} = read_file(FN),
+                true = (Contents == iolist_to_binary(Data)),
+                ok
+            catch _:Err ->
+                    {error, Err}
+            end;
+        Err ->
+            Err
     end.
 
 %% @doc Similar to {@link file:read_file} but uses raw file I/O

--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% riak_core: Core Riak Application
+%% Riak_Core: Core Riak Application
 %%
 %% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
 %%
@@ -34,6 +34,7 @@
 -export([fresh/0,descends/2,merge/1,get_counter/2,get_timestamp/2,
 	increment/2,increment/3,all_nodes/1,equal/2,prune/3,timestamp/0]).
 -export([fresh/2]).
+-export([fresh/3]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -58,6 +59,11 @@ fresh() ->
 -spec fresh(vclock_node(), counter()) -> vclock().
 fresh(Node, Count) ->
     [{Node, {Count, timestamp()}}].
+
+-spec fresh(vclock_node(), counter(), timestamp()) ->
+                   vclock().
+fresh(Node, Count, Ts) ->
+    [{Node, {Count, Ts}}].
 
 % @doc Return true if Va is a direct descendant of Vb, else false -- remember, a vclock is its own descendant!
 -spec descends(Va :: vclock()|[], Vb :: vclock()|[]) -> boolean().

--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -62,7 +62,8 @@ fresh(Node, Count) ->
 
 -spec fresh(vclock_node(), counter(), timestamp()) ->
                    vclock().
-fresh(Node, Count, Ts) ->
+fresh(Node, Count, Ts) when is_integer(Ts) andalso  Ts > 0,
+                            is_integer(Count) andalso Count > 0 ->
     [{Node, {Count, Ts}}].
 
 % @doc Return true if Va is a direct descendant of Vb, else false -- remember, a vclock is its own descendant!

--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -31,7 +31,7 @@
 
 -module(vclock).
 
--export([fresh/0,descends/2,merge/1,get_counter/2,get_timestamp/2,
+-export([fresh/0,descends/2,merge/1,get_counter/2,get_timestamp/2, get_entry/2,
 	increment/2,increment/3,all_nodes/1,equal/2,prune/3,timestamp/0]).
 
 -ifdef(TEST).
@@ -110,6 +110,13 @@ get_timestamp(Node, VClock) ->
     case lists:keyfind(Node, 1, VClock) of
 	{_, {_Ctr, TS}} -> TS;
 	false           -> undefined
+    end.
+
+get_entry(Node, VClock) ->
+    case lists:keyfind(Node, 1, VClock) of
+        false ->
+            undefined;
+        Entry -> Entry
     end.
 
 % @doc Increment VClock at Node.


### PR DESCRIPTION
Some additions to vclock API to support creating fresh vclocks with a given timestamp.

A change to riak_core_util so that opening a non-existent file returns an error rather than crashing on a badmatch.
