### PR TITLE
add missing apps to src/riak_kv.app.src

### DIFF
--- a/src/riak_core.app.src
+++ b/src/riak_core.app.src
@@ -14,7 +14,11 @@
                   sasl,
                   crypto,
                   riak_sysmon,
-                  os_mon
+                  os_mon,
+                  basho_stats,
+                  eleveldb,
+                  pbkdf2,
+                  poolboy
                  ]},
   {mod, {riak_core_app, []}},
   {env, [


### PR DESCRIPTION
The basho_stats, eleveldb, pbkdf2 and poolboy apps are used in riak_core
but were not listed as application dependencies in the
src/riak_core.app.src file.
