### PR TITLE
WIP: Moving AAE to riak_core

### DIFF
--- a/docs/aae.md
+++ b/docs/aae.md
@@ -11,7 +11,7 @@
 * Add the required config parameters.
 
 
-## Entropy Manger (riak_core_entropy_manager)
+## Entropy Manger (`riak_core_entropy_manager`)
 One is started per vnode service, as part of the of the main apps supervisor. It needs the service name and the vnode module passed as arguments.
 
 Here an example how to start it for the `snarl_user` service that is implemented in the `snarl_user_vnode`.
@@ -22,18 +22,18 @@ Here an example how to start it for the `snarl_user` service that is implemented
 
 The manager is responsible of coordinating the AAE tree build and exchange with other nodes.
 
-## Entropy Info (riak_core_entropy_info)
+## Entropy Info (`riak_core_entropy_info`)
 A helper module to get information about the entropy system, nothing needs touching here.
 
-## Exchange FSM (riak_core_exchange_fsm)
+## Exchange FSM (`riak_core_exchange_fsm`)
 FSM to do the actual work of exchange.
 
-## Index Hash Tree (riak_core_index_hashtree)
+## Index Hash Tree (`riak_core_index_hashtree`)
 One of those is started for each combination of service/partition, it handles the hash tree and takes care of keeping track of the changes.
 
 The VNode will need to take care of creating the hash tree for it's partition and also send updates on writes and deletes to keep the data in check. The hash tree will also fold over the entries for the first bootup.
 
-## VNode (riak_core_aae_vnode)
+## VNode (`riak_core_aae_vnode`)
 `riak_core_aae_vnode` implements a behavior for all the functions that need to be implemented for this.
 
 In addition to the functions described there the vnode needs to respond to the following calls to handle_info and command:
@@ -89,5 +89,12 @@ do_delete(Key, State) ->
     riak_core_index_hashtree:delete({<<"bucket">>, Key}, State#state.hashtrees),
     State#state{dict = Dict1}.
 
+```
 
+## Application (`*_app.erl`)
+
+A ets table has to be created for aae to work adding the following line to the `*_app.erl` file (or anywhere really):
+
+```erlang
+    riak_core_entropy_info:create_table()
 ```

--- a/docs/aae.md
+++ b/docs/aae.md
@@ -4,10 +4,9 @@
 ## Quickstart:
 
 * Add the Entropy Manager to your apps supervisor tree.
-* Add the `riak_core_aae_vnode` behavior to the vnode in question.
-* Implement the functions required by the behavior.
+* Add the `riak_core_aae_vnode` behavior to the vnode in question. Implement the functions required by the behavior.
 * Implement the callback matches detailed in the VNode section.
-* Makre sure that `init/1` creates a hashtree, see `maybe_create_hashtrees/2` as example how to do that.
+* Make sure that `init/1` creates a hashtree, see `maybe_create_hashtrees/2` as example how to do that.
 * Make all data changing calls in your VNode also call `update_hashtree/3` (or something similar) or `riak_core_index_hashtree:delete`.
 * Add the required config parameters.
 
@@ -18,11 +17,7 @@ One is started per vnode service, as part of the of the main apps supervisor. It
 Here an example how to start it for the `snarl_user` service that is implemented in the `snarl_user_vnode`.
 
 ```erlang
-    EntropyManagerUser =
-        {snarl_user_entropy_manager,
-         {riak_core_entropy_manager, start_link,
-          [snarl_user, snarl_user_vnode]},
-         permanent, 30000, worker, [riak_core_entropy_manager]},
+    EntropyManagerUser = riak_core_entropy_manager:supervisor_spec(snarl_user, snarl_user_vnode),
 ```
 
 The manager is responsible of coordinating the AAE tree build and exchange with other nodes.
@@ -45,108 +40,54 @@ In addition to the functions described there the vnode needs to respond to the f
 
 ```erlang
 % ...
+
+%% Create a hahstree on init
+init([Idx]) ->
+    HT = riak_core_aae_vnode:maybe_create_hashtrees(?SERVICE, Idx, undefined),
+    {ok, #state{dict = orddict:new(), hashtrees = HT, index = Idx}}.
+% ...
+%% This is used for rehashing the tree
 handle_command(?FOLD_REQ{foldfun=Fun, acc0=Acc0}, _Sender, State) ->
     lager:debug("Fold on ~p", [State#state.partition]),
-    Acc = fifo_db:fold(State#state.db, <<"user">>,
-                       fun(K, V, O) ->
-                               Fun({<<"user">>, K}, V, O)
-                       end, Acc0),
+    Acc = orddict:fold(State#state.dict, fun(K, V, A) ->
+    	 Fun({<<"bucket">>, K}, V, A)
+      end, Acc0),
     {reply, Acc, State};
 
 % ...
-handle_info(retry_create_hashtree, State=#state{hashtrees=undefined}) ->
-    State2 = maybe_create_hashtrees(State),
-    case State2#state.hashtrees of
-        undefined ->
-            ok;
-        _ ->
-            lager:info("riak_core/~p: successfully started index_hashtree on retry",
-                       [State#state.partition])
-    end,
-    {ok, State2};
+
+%% retry_create_hashtree is required by `riak_core_aae_vnode:maybe_create_hashtrees`
+%% if the creation failed
+handle_info(retry_create_hashtree, State=#state{hashtrees=undefined, index=Idx}) ->
+    lager:debug("~p/~p retrying to create a hash tree.", [?SERVICE, Idx]),
+    HT = riak_core_aae_vnode:maybe_create_hashtrees(?SERVICE, Idx, undefined),
+    {ok, State#state{hashtrees = HT}};
 handle_info(retry_create_hashtree, State) ->
     {ok, State};
-handle_info({'DOWN', _, _, Pid, _}, State=#state{hashtrees=Pid}) ->
-    State2 = State#state{hashtrees=undefined},
-    State3 = maybe_create_hashtrees(State2),
-    {ok, State3};
+%% When the hashtree goes down we want to create a new one.
+handle_info({'DOWN', _, _, Pid, _}, State=#state{hashtrees=Pid, index=Idx}) ->
+    lager:debug("~p/~p hashtree ~p went down.", [?SERVICE, Idx, Pid]),
+    erlang:send_after(1000, self(), retry_create_hashtree),
+    {ok, State#state{hashtrees = undefined}};
 handle_info({'DOWN', _, _, _, _}, State) ->
     {ok, State};
 handle_info(_, State) ->
     {ok, State}.
-```
 
-An example implementation (taken from `riak_kv`) for internal utility functions used to create and maintain the hashtree:
-
-```erlang
--define(DEFAULT_HASHTREE_TOKENS, 90).
-
--spec maybe_create_hashtrees(state()) -> state().
-maybe_create_hashtrees(State) ->
-    maybe_create_hashtrees(riak_core_entropy_manager:enabled(), State).
-
--spec maybe_create_hashtrees(boolean(), state()) -> state().
-maybe_create_hashtrees(false, State) ->
-    lager:info("snarl_user: Hashtree not enabled."),
-    State;
-
-maybe_create_hashtrees(true, State=#state{partition=Index}) ->
-    %% Only maintain a hashtree if a primary vnode
-    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
-    lager:debug("snarl_user/~p: creating hashtree.", [Index]),
-    case riak_core_ring:vnode_type(Ring, Index) of
-        primary ->
-            RP = riak_core_util:responsible_preflists(Index),
-            case riak_core_index_hashtree:start(snarl_user, Index, RP, self(),
-                                                ?MODULE) of
-                {ok, Trees} ->
-                    lager:debug("snarl_user/~p: hashtree created: ~p.", [Index, Trees]),
-                    monitor(process, Trees),
-                    State#state{hashtrees=Trees};
-                Error ->
-                    lager:info("snarl_user/~p: unable to start index_hashtree: ~p",
-                               [Index, Error]),
-                    erlang:send_after(1000, self(), retry_create_hashtree),
-                    State#state{hashtrees=undefined}
-            end;
-        _ ->
-            lager:debug("snarl_user/~p: not primary", [Index]),
-            State
-    end.
-
--spec update_hashtree(binary(), binary(), state()) -> ok.
-update_hashtree(Key, Val, #state{hashtrees=Trees}) ->
-    case get_hashtree_token() of
-        true ->
-            riak_core_index_hashtree:async_insert_object({<<"user">>, Key}, Val, Trees),
-            ok;
-        false ->
-            riak_core_index_hashtree:insert_object({<<"user">>, Key}, Val, Trees),
-            put(hashtree_tokens, max_hashtree_tokens()),
-            ok
-    end.
-
-get_hashtree_token() ->
-    Tokens = get(hashtree_tokens),
-    case Tokens of
-        undefined ->
-            put(hashtree_tokens, max_hashtree_tokens() - 1),
-            true;
-        N when N > 0 ->
-            put(hashtree_tokens, Tokens - 1),
-            true;
-        _ ->
-            false
-    end.
-
+%% Example write operation that uses `riak_core_aae_vnode:update_hashtree` to update
+%% the hashtree.
 do_put(Key, Obj, State) ->
-    fifo_db:put(State#state.db, <<"user">>, Key, Obj),
-    update_hashtree(Key, term_to_binary(Obj), State).
+    Dict1 = orddict:store(State#state.dict, Key, Obj),
+    riak_core_aae_vnode:update_hashtree(<<"bucket">>, Key, term_to_binary(Obj),
+                                        State#state.hashtrees),
+    State#state{dict = Dict1}.
+
+%% Example delete operation that uses `riak_core_index_hashtree:delete` to update
+%% the hashtree.
+do_delete(Key, State) ->
+    Dict1 = orddict:erase(State#state.dict, Key),
+    riak_core_index_hashtree:delete({<<"bucket">>, Key}, State#state.hashtrees),
+    State#state{dict = Dict1}.
 
 
--spec max_hashtree_tokens() -> pos_integer().
-max_hashtree_tokens() ->
-    app_helper:get_env(riak_core,
-                       anti_entropy_max_async,
-                       ?DEFAULT_HASHTREE_TOKENS).
 ```

--- a/docs/aae.md
+++ b/docs/aae.md
@@ -1,0 +1,131 @@
+# AAE
+
+
+## Entropy Manger (riak_core_entropy_manager)
+One is started per vnode service, as part of the of the main apps supervisor. It needs the service name and the vnode module passed as arguments.
+
+Here an example how to start it for the `snarl_user` service that is implemented in the `snarl_user_vnode`.
+
+```erlang
+    EntropyManagerUser =
+        {snarl_user_entropy_manager,
+         {riak_core_entropy_manager, start_link,
+          [snarl_user, snarl_user_vnode]},
+         permanent, 30000, worker, [riak_core_entropy_manager]},
+```
+
+The manager is responsible of coordinating the AAE tree build and exchange with other nodes.
+
+## Entropy Info (riak_core_entropy_info)
+A helper module to get information about the entropy system, nothing needs touching here.
+
+## Exchange FSM (riak_core_exchange_fsm)
+FSM to do the actual work of exchange.
+
+## Index Hash Tree (riak_core_index_hashtree)
+One of those is started for each combination of service/partition, it handles the hash tree and takes care of keeping track of the changes.
+
+The VNode will need to take care of creating the hash tree for it's partition and also send updates on writes and deletes to keep the data in check. The hash tree will also fold over the entries for the first bootup.
+
+## VNode (riak_core_aae_vnode)
+`riak_core_aae_vnode` implements a behavior for all the functions that need to be implemented for this.
+
+In addition to the functions described there the vnode needs to respond to the following calls to handle_info:
+
+```erlang
+handle_info(retry_create_hashtree, State=#state{hashtrees=undefined}) ->
+    State2 = maybe_create_hashtrees(State),
+    case State2#state.hashtrees of
+        undefined ->
+            ok;
+        _ ->
+            lager:info("riak_core/~p: successfully started index_hashtree on retry",
+                       [State#state.partition])
+    end,
+    {ok, State2};
+handle_info(retry_create_hashtree, State) ->
+    {ok, State};
+handle_info({'DOWN', _, _, Pid, _}, State=#state{hashtrees=Pid}) ->
+    State2 = State#state{hashtrees=undefined},
+    State3 = maybe_create_hashtrees(State2),
+    {ok, State3};
+handle_info({'DOWN', _, _, _, _}, State) ->
+    {ok, State};
+handle_info(_, State) ->
+    {ok, State}.
+```
+
+An example implementation (taken from `riak_kv`) for internal utility functions used to create and maintain the hashtree:
+
+```erlang
+-define(DEFAULT_HASHTREE_TOKENS, 90).
+
+-spec maybe_create_hashtrees(state()) -> state().
+maybe_create_hashtrees(State) ->
+    maybe_create_hashtrees(riak_core_entropy_manager:enabled(), State).
+
+-spec maybe_create_hashtrees(boolean(), state()) -> state().
+maybe_create_hashtrees(false, State) ->
+    lager:info("snarl_user: Hashtree not enabled."),
+    State;
+
+maybe_create_hashtrees(true, State=#state{partition=Index}) ->
+    %% Only maintain a hashtree if a primary vnode
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    lager:debug("snarl_user/~p: creating hashtree.", [Index]),
+    case riak_core_ring:vnode_type(Ring, Index) of
+        primary ->
+            RP = riak_core_util:responsible_preflists(Index),
+            case riak_core_index_hashtree:start(snarl_user, Index, RP, self(),
+                                                ?MODULE) of
+                {ok, Trees} ->
+                    lager:debug("snarl_user/~p: hashtree created: ~p.", [Index, Trees]),
+                    monitor(process, Trees),
+                    State#state{hashtrees=Trees};
+                Error ->
+                    lager:info("snarl_user/~p: unable to start index_hashtree: ~p",
+                               [Index, Error]),
+                    erlang:send_after(1000, self(), retry_create_hashtree),
+                    State#state{hashtrees=undefined}
+            end;
+        _ ->
+            lager:debug("snarl_user/~p: not primary", [Index]),
+            State
+    end.
+
+-spec update_hashtree(binary(), binary(), state()) -> ok.
+update_hashtree(Key, Val, #state{hashtrees=Trees}) ->
+    case get_hashtree_token() of
+        true ->
+            riak_core_index_hashtree:async_insert_object({<<"user">>, Key}, Val, Trees),
+            ok;
+        false ->
+            riak_core_index_hashtree:insert_object({<<"user">>, Key}, Val, Trees),
+            put(hashtree_tokens, max_hashtree_tokens()),
+            ok
+    end.
+
+get_hashtree_token() ->
+    Tokens = get(hashtree_tokens),
+    case Tokens of
+        undefined ->
+            put(hashtree_tokens, max_hashtree_tokens() - 1),
+            true;
+        N when N > 0 ->
+            put(hashtree_tokens, Tokens - 1),
+            true;
+        _ ->
+            false
+    end.
+
+do_put(Key, Obj, State) ->
+    fifo_db:put(State#state.db, <<"user">>, Key, Obj),
+    update_hashtree(Key, term_to_binary(Obj), State).
+
+
+-spec max_hashtree_tokens() -> pos_integer().
+max_hashtree_tokens() ->
+    app_helper:get_env(riak_core,
+                       anti_entropy_max_async,
+                       ?DEFAULT_HASHTREE_TOKENS).
+```

--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -1,3 +1,93 @@
+%% -*- erlang -*-
+
+%% @doc enable active anti-entropy subsystem
+{mapping, "anti_entropy", "riak_kv.anti_entropy", [
+  {datatype, {enum, [on, off, debug]}},
+  {default, on}
+]}.
+
+{ translation,
+  "riak_core.anti_entropy",
+  fun(Conf) ->
+    Setting = cuttlefish_util:conf_get_value("anti_entropy", Conf),
+    case Setting of
+      on -> {on, []};
+      debug -> {on, [debug]};
+      off -> {off, []};
+      _Default -> {on, []}
+    end
+  end
+}.
+
+%% @doc Restrict how fast AAE can build hash trees. Building the tree
+%% for a given partition requires a full scan over that partition's
+%% data. Once built, trees stay built until they are expired.
+%% Config is of the form:
+%%   {num-builds, per-timespan}
+%% Default is 1 build per hour.
+{mapping, "anti_entropy.build_limit.number", "riak_core.anti_entropy_build_limit", [
+  {default, 1},
+  {datatype, integer}
+]}.
+
+{mapping, "anti_entropy.build_limit.per_timespan", "riak_core.anti_entropy_build_limit", [
+  {default, "1h"},
+  {datatype, {duration, ms}}
+]}.
+
+{translation,
+ "riak_core.anti_entropy_build_limit",
+ fun(Conf) ->
+    {cuttlefish_util:conf_get_value("anti_entropy.build_limit.number", Conf),
+     cuttlefish_util:conf_get_value("anti_entropy.build_limit.per_timespan", Conf)}
+ end}.
+
+%% @doc Determine how often hash trees are expired after being built.
+%% Periodically expiring a hash tree ensures the on-disk hash tree
+%% data stays consistent with the actual k/v backend data. It also
+%% helps Riak identify silent disk failures and bit rot. However,
+%% expiration is not needed for normal AAE operation and should be
+%% infrequent for performance reasons. The time is specified in
+%% milliseconds. The default is 1 week.
+{mapping, "anti_entropy.expire", "riak_core.anti_entropy_expire", [
+  {default, "1w"},
+  {datatype, {duration, ms}}
+]}.
+
+%% @doc Limit how many AAE exchanges/builds can happen concurrently.
+{mapping, "anti_entropy.concurrency", "riak_core.anti_entropy_concurrency", [
+  {default, 2},
+  {datatype, integer}
+]}.
+
+%% @doc The tick determines how often the AAE manager looks for work
+%% to do (building/expiring trees, triggering exchanges, etc).
+%% The default is every 15 seconds. Lowering this value will
+%% speedup the rate that all replicas are synced across the cluster.
+%% Increasing the value is not recommended.
+{mapping, "anti_entropy.tick", "riak_core.anti_entropy_tick", [
+  {default, "15s"},
+  {datatype, {duration, ms}}
+]}.
+
+%% @doc The directory where AAE hash trees are stored.
+{mapping, "anti_entropy.data_dir", "riak_core.anti_entropy_data_dir", [
+  {default, "{{platform_data_dir}}/anti_entropy"}
+]}.
+
+%% @doc The LevelDB options used by AAE to generate the LevelDB-backed
+%% on-disk hashtrees.
+{mapping, "anti_entropy.write_buffer_size", "riak_core.anti_entropy_leveldb_opts.write_buffer_size", [
+  {default, "4MB"},
+  {datatype, bytesize}
+]}.
+
+{mapping, "anti_entropy.max_open_files", "riak_core.anti_entropy_leveldb_opts.max_open_files", [
+  {default, 20},
+  {datatype, integer}
+]}.
+
+
 %% Default Bucket Properties
 
 %% @doc the number of replicas stored. Note: See CAP Controls for further discussion.
@@ -13,9 +103,9 @@
   {level, advanced}
 ]}.
 
-%% Cut and paste translation screams to be rewritten as a datatype, but that's a 
+%% Cut and paste translation screams to be rewritten as a datatype, but that's a
 %% "nice to have"
-{translation, 
+{translation,
   "riak_core.default_bucket_props.pr",
   fun(Conf) ->
     Setting = cuttlefish_util:conf_get_value("buckets.default.pr", Conf),
@@ -25,7 +115,7 @@
       X ->
         try list_to_integer(Setting) of
           Int -> Int
-        catch 
+        catch
           E:R -> error
         end
     end
@@ -36,7 +126,7 @@
   {default, "quorum"},
   {level, advanced}
 ]}.
-{translation, 
+{translation,
   "riak_core.default_bucket_props.r",
   fun(Conf) ->
     Setting = cuttlefish_util:conf_get_value("buckets.default.r", Conf),
@@ -46,7 +136,7 @@
       X ->
         try list_to_integer(Setting) of
           Int -> Int
-        catch 
+        catch
           E:R -> error
         end
     end
@@ -57,7 +147,7 @@
   {default, "quorum"},
   {level, advanced}
 ]}.
-{translation, 
+{translation,
   "riak_core.default_bucket_props.w",
   fun(Conf) ->
     Setting = cuttlefish_util:conf_get_value("buckets.default.w", Conf),
@@ -67,7 +157,7 @@
       X ->
         try list_to_integer(Setting) of
           Int -> Int
-        catch 
+        catch
           E:R -> error
         end
     end
@@ -78,7 +168,7 @@
   {default, "0"},
   {level, advanced}
 ]}.
-{translation, 
+{translation,
   "riak_core.default_bucket_props.pw",
   fun(Conf) ->
     Setting = cuttlefish_util:conf_get_value("buckets.default.pw", Conf),
@@ -88,7 +178,7 @@
       X ->
         try list_to_integer(Setting) of
           Int -> Int
-        catch 
+        catch
           E:R -> error
         end
     end
@@ -99,7 +189,7 @@
   {default, "quorum"},
   {level, advanced}
 ]}.
-{translation, 
+{translation,
   "riak_core.default_bucket_props.dw",
   fun(Conf) ->
     Setting = cuttlefish_util:conf_get_value("buckets.default.dw", Conf),
@@ -109,7 +199,7 @@
       X ->
         try list_to_integer(Setting) of
           Int -> Int
-        catch 
+        catch
           E:R -> error
         end
     end
@@ -120,7 +210,7 @@
   {default, "quorum"},
   {level, advanced}
 ]}.
-{translation, 
+{translation,
   "riak_core.default_bucket_props.rw",
   fun(Conf) ->
     Setting = cuttlefish_util:conf_get_value("buckets.default.rw", Conf),
@@ -130,7 +220,7 @@
       X ->
         try list_to_integer(Setting) of
           Int -> Int
-        catch 
+        catch
           E:R -> error
         end
     end
@@ -148,15 +238,15 @@
   {level, advanced}
 ]}.
 
-{translation, 
- "riak_core.default_bucket_props.allow_mult", 
- fun(Conf) -> 
+{translation,
+ "riak_core.default_bucket_props.allow_mult",
+ fun(Conf) ->
   Setting = cuttlefish_util:conf_get_value("buckets.default.siblings", Conf),
     case Setting of
       on -> true;
       off -> false;
       _Default -> true
-    end  
+    end
  end}.
 
 {mapping, "buckets.default.last_write_wins", "riak_core.default_bucket_props.last_write_wins", [
@@ -164,11 +254,6 @@
   {default, false},
   {level, advanced}
 ]}.
-
-%{mapping, "buckets.default.precommit", "riak_core.default_bucket_props.precommit", []},
-%{mapping, "buckets.default.postcommit", "riak_core.default_bucket_props.postcommit", []},
-%{mapping, "buckets.default.chash_keyfun", "riak_core.default_bucket_props.chash_keyfun", {riak_core_util, chash_std_keyfun}},
-%{mapping, "buckets.default.linkfun", "riak_core.default_bucket_props.linkfun", {modfun, riak_kv_wm_link_walker, mapreduce_linkfun}}
 
 %% example of super basic mapping
 %% @doc Default ring creation size.  Make sure it is a power of 2,
@@ -182,7 +267,7 @@
 
 %% ring_size validator
 {validator, "ring_size", "not a power of 2 greater than 1",
- fun(Size) -> 
+ fun(Size) ->
   Size > 1 andalso (Size band (Size-1) =:= 0)
  end}.
 
@@ -242,7 +327,7 @@
 { translation,
   "riak_core.dtrace_support",
   fun(Conf) ->
-    Setting = cuttlefish_util:conf_get_value("dtrace", Conf), 
+    Setting = cuttlefish_util:conf_get_value("dtrace", Conf),
     case Setting of
       on -> true;
       off -> false;

--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -1,7 +1,7 @@
 %% -*- erlang -*-
 
 %% @doc enable active anti-entropy subsystem
-{mapping, "anti_entropy", "riak_kv.anti_entropy", [
+{mapping, "anti_entropy", "riak_core.anti_entropy", [
   {datatype, {enum, [on, off, debug]}},
   {default, on}
 ]}.

--- a/src/riak_core_aae_vnode.erl
+++ b/src/riak_core_aae_vnode.erl
@@ -28,10 +28,7 @@
 behaviour_info(callbacks) ->
     [{aae_repair, 2},
      {hash_object, 2},
-     {request_hashtree_pid, 1},
-     {hashtree_pid, 1},
-     {master, 0},
-     {rehash, 3}];
+     {master, 0}];
 
 behaviour_info(_Other) ->
     undefined.

--- a/src/riak_core_aae_vnode.erl
+++ b/src/riak_core_aae_vnode.erl
@@ -1,0 +1,14 @@
+-module(riak_core_aae_vnode).
+
+-export([behaviour_info/1]).
+
+-spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
+behaviour_info(callbacks) ->
+    [{aae_repair, 2},
+     {hash_object, 2},
+     {request_hashtree_pid, 1},
+     {hashtree_pid, 1},
+     {master, 0},
+     {rehash, 3}];
+behaviour_info(_Other) ->
+    undefined.

--- a/src/riak_core_aae_vnode.erl
+++ b/src/riak_core_aae_vnode.erl
@@ -62,7 +62,7 @@ maybe_create_hashtrees(true, Service, Index, Last) ->
                     lager:debug("~p/~p: hashtree created: ~p.",
                                 [Service, Index, Trees]),
                     monitor(process, Trees),
-                    {ok, Trees};
+                    Trees;
                 Error ->
                     lager:info("~p/~p: unable to start index_hashtree: ~p",
                                [Service, Index, Error]),

--- a/src/riak_core_aae_vnode.erl
+++ b/src/riak_core_aae_vnode.erl
@@ -2,6 +2,22 @@
 
 -export([behaviour_info/1]).
 
+
+-export([aae_repair/2,
+         hash_object/2,
+         request_hashtree_pid/1,
+         hashtree_pid/1,
+         master/0,
+         rehash/3]).
+-xref_ignore([aae_repair/2,
+              hash_object/2,
+              request_hashtree_pid/1,
+              hashtree_pid/1,
+              master/0,
+              rehash/3]).
+
+-type preflist() :: [{Index::integer(), Node :: term()}].
+
 -spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
 behaviour_info(callbacks) ->
     [{aae_repair, 2},
@@ -12,3 +28,54 @@ behaviour_info(callbacks) ->
      {rehash, 3}];
 behaviour_info(_Other) ->
     undefined.
+
+
+%% @doc aae_repair is called when the AAE system detectes a difference
+%% the simplest method to handle this is causing a read-repair if the
+%% system supports it. But the actuall implemetation is left to the
+%% vnode to handle whatever is best.
+-spec aae_repair(Bucket::binary(), Key::binary()) -> term().
+aae_repair(_Bucket, _Key) ->
+    ok.
+
+
+%% @doc hash_object is called to hash a object, how it does this is opaque
+%% to the aae system as long as it returns a binary and is deterministic in
+%% it's outcome.
+-spec hash_object({Bucket::binary(), Key::binary()}, Obj::term()) -> binary().
+hash_object(_BKey, _Obj) ->
+    <<>>.
+
+
+%% @doc This is a asyncronous command that needs to send a term in the form
+%% `{ok, Hashtree::pid()}` or `{error, wrong_node}` to the process it was called
+%% from.
+-spec request_hashtree_pid(Partition::non_neg_integer()) -> ok.
+request_hashtree_pid(_Partition) ->
+    ok.
+
+%% @doc Returns the hashtree for the partiion of this service/vnode combination.
+-spec hashtree_pid(Partition::non_neg_integer()) ->
+                          {error, wrong_node} |
+                          {ok, HashTree::pid()}.
+hashtree_pid(_Partition) ->
+    {error, wrong_node}.
+
+%% @doc Returns the vnode master for this vnode type, that is the same
+%% used when registering the vnode.
+
+-spec master() -> Master::atom().
+master() ->
+    ok.
+
+%% Used by {@link riak_core_exchange_fsm} to force a vnode to update the hashtree
+%% for repaired keys. Typically, repairing keys will trigger read repair that
+%% will update the AAE hash in the write path. However, if the AAE tree is
+%% divergent from the KV data, it is possible that AAE will try to repair keys
+%% that do not have divergent KV replicas. In that case, read repair is never
+%% triggered. Always rehashing keys after any attempt at repair ensures that
+%% AAE does not try to repair the same non-divergent keys over and over.
+
+-spec rehash(_Preflist::preflist(), _Bucket::binary(), _Key::binary()) -> ok.
+rehash(_Preflist, _Bucket, _Key) ->
+    ok.

--- a/src/riak_core_aae_vnode.erl
+++ b/src/riak_core_aae_vnode.erl
@@ -5,16 +5,9 @@
 -export([maybe_create_hashtrees/3,
          update_hashtree/4]).
 
--export([aae_repair/2,
-         hash_object/2,
-         master/0,
-         request_hashtree_pid/2,
+-export([request_hashtree_pid/2,
          hashtree_pid/2,
          rehash/4]).
-
--xref_ignore([aae_repair/2,
-              hash_object/2,
-              master/0]).
 
 -define(DEFAULT_HASHTREE_TOKENS, 90).
 

--- a/src/riak_core_aae_vnode.erl
+++ b/src/riak_core_aae_vnode.erl
@@ -180,24 +180,24 @@ reset_hashtree_token() ->
 %% the simplest method to handle this is causing a read-repair if the
 %% system supports it. But the actual implemetation is left to the
 %% vnode to handle whatever is best.
--spec aae_repair(Bucket::binary(), Key::binary()) -> term().
-aae_repair(_Bucket, _Key) ->
-    ok.
+%% -spec aae_repair(Bucket::binary(), Key::binary()) -> term().
+%%aae_repair(_Bucket, _Key) ->
+%%    aae_repair.
 
 
 %% @doc hash_object is called by the AAE subsyste to hash a object when the
 %% tree first gets generated, a object needs to be hash or is inserted.
 %% To AAE system does not care for the details as long as it returns a binary
 %% and is deterministic in it's outcome. (see {@link riak_core_index_hashtree})
--spec hash_object({Bucket::binary(), Key::binary()}, Obj::term()) -> binary().
-hash_object(_BKey, _Obj) ->
-    <<>>.
+%% -spec hash_object({Bucket::binary(), Key::binary()}, Obj::term()) -> binary().
+%% hash_object(_BKey, _Obj) ->
+%%    <<>>.
 
 %% @doc Returns the vnode master for this vnode type, that is the same
 %% used when registering the vnode.
 %% This function is required by the {@link riak_core_index_hashtree} to
 %% send rehash requests to a vnode.
 
--spec master() -> Master::atom().
-master() ->
-    ok.
+%% -spec master() -> Master::atom().
+%% master() ->
+%%    some_other_strange_atom_form_master.

--- a/src/riak_core_aae_vnode.erl
+++ b/src/riak_core_aae_vnode.erl
@@ -45,13 +45,13 @@ behaviour_info(_Other) ->
 
 
 %% @doc This function is a working example of how to implement hashtree
-%% creatin for a VNode, using this is recommanded, it will need to be
+%% creation for a VNode, using this is recommended, it will need to be
 %% called during the init process.
 %% It also requires the calling vnode to implement a handle_info match on
 %% `retry_create_hashtree` which will need to either call this function
 %% again or do nothing if a valid hashtree already exists.
-%% In addtioj to that the calling VNode will be set up to monitor the
-%% created hashtree so it is adviced to listen for
+%% In addition to that the calling VNode will be set up to monitor the
+%% created hashtree so it should listen for
 %% `{'DOWN', _, _, Pid, _}` where Pid is the pid of the created hashtree
 %% to recreate a new one if this should die.
 -spec maybe_create_hashtrees(atom(), integer(), pid()|undefined) ->
@@ -148,9 +148,10 @@ aae_repair(_Bucket, _Key) ->
     ok.
 
 
-%% @doc hash_object is called to hash a object, how it does this is opaque
-%% to the aae system as long as it returns a binary and is deterministic in
-%% it's outcome.
+%% @doc hash_object is called by the AAE subsyste to hash a object when the
+%% tree first gets generated, a object needs to be hash or is inserted.
+%% To AAE system does not care for the details as long as it returns a binary
+%% and is deterministic in it's outcome. (see {@link riak_core_index_hashtree})
 -spec hash_object({Bucket::binary(), Key::binary()}, Obj::term()) -> binary().
 hash_object(_BKey, _Obj) ->
     <<>>.
@@ -159,6 +160,8 @@ hash_object(_BKey, _Obj) ->
 %% @doc This is a asyncronous command that needs to send a term in the form
 %% `{ok, Hashtree::pid()}` or `{error, wrong_node}` to the process it was called
 %% from.
+%% It is required by the {@link riak_core_entropy_manager} to determin what
+%% hashtree serves a partition on a given erlang node.
 -spec request_hashtree_pid(Partition::non_neg_integer()) -> ok.
 request_hashtree_pid(_Partition) ->
     ok.
@@ -172,6 +175,8 @@ hashtree_pid(_Partition) ->
 
 %% @doc Returns the vnode master for this vnode type, that is the same
 %% used when registering the vnode.
+%% This function is required by the {@link riak_core_index_hashtree} to
+%% send rehash requests to a vnode.
 
 -spec master() -> Master::atom().
 master() ->

--- a/src/riak_core_entropy_info.erl
+++ b/src/riak_core_entropy_info.erl
@@ -1,0 +1,209 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% This is a direct copy of:
+%% https://github.com/basho/riak_kv/blob/develop/src/riak_kv_entropy_info.erl
+%% -------------------------------------------------------------------
+-module(riak_core_entropy_info).
+
+-export([tree_built/3,
+         exchange_complete/5,
+         create_table/0,
+         dump/0,
+         compute_exchange_info/1,
+         compute_exchange_info/2,
+         compute_tree_info/1,
+         all_exchanges/2]).
+
+-define(ETS, ets_riak_core_entropy).
+
+-type index() :: non_neg_integer().
+-type index_n() :: {index(), pos_integer()}.
+-type exchange_id() :: {index(), index_n()}.
+-type orddict(K,V) :: [{K,V}].
+-type riak_core_ring() :: riak_core_ring:riak_core_ring().
+-type t_now() :: calendar:t_now().
+
+-record(simple_stat, {last, min, max, count, sum}).
+
+-type repair_stats() :: {Last :: pos_integer(),
+                         Min  :: pos_integer(),
+                         Max  :: pos_integer(),
+                         Mean :: pos_integer()}.
+
+-record(exchange_info, {time :: t_now(),
+                        repaired :: pos_integer()}).
+
+-type exchange_info() :: #exchange_info{}.
+
+-record(index_info, {build_time    = undefined     :: t_now(),
+                     repaired      = undefined     :: pos_integer(),
+                     exchanges     = orddict:new() :: orddict(exchange_id(), exchange_info()),
+                     last_exchange = undefined     :: exchange_id()}).
+
+-type index_info() :: #index_info{}.
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%% @doc Store AAE tree build time
+-spec tree_built(atom(), index(), t_now()) -> ok.
+tree_built(Type, Index, Time) ->
+    update_index_info({Type, Index}, {tree_built, Time}).
+
+%% @doc Store information about a just-completed AAE exchange
+-spec exchange_complete(atom(), index(), index(), index_n(), pos_integer()) -> ok.
+exchange_complete(Type, Index, RemoteIdx, IndexN, Repaired) ->
+    update_index_info({Type, Index},
+                      {exchange_complete, RemoteIdx, IndexN, Repaired}).
+
+%% @doc Called by {@link riak_kv_sup} to create public ETS table used for
+%%      holding AAE information for reporting. Table will be owned by
+%%      the `riak_kv_sup' to ensure longevity.
+create_table() ->
+    (ets:info(?ETS) /= undefined) orelse
+        ets:new(?ETS, [named_table, public, set, {write_concurrency, true}]).
+
+%% @doc Return state of ets_riak_kv_entropy table as a list
+dump() ->
+    ets:tab2list(?ETS).
+
+%% @doc
+%% Return a list containing information about exchanges for all locally owned
+%% indices. For each index, return a tuple containing time of most recent
+%% exchange; time since the index completed exchanges with all sibling indices;
+%% as well as statistics about repairs triggered by different exchanges.
+-spec compute_exchange_info(atom())  ->
+                                   [{index(), Last :: t_now(), All :: t_now(),
+                                     repair_stats()}].
+compute_exchange_info(Type) ->
+    compute_exchange_info(Type, {?MODULE, all_exchanges}).
+
+-spec compute_exchange_info(atom(), {atom(), atom()})  ->
+                                   [{index(), Last :: t_now(), All :: t_now(),
+                                     repair_stats()}].
+compute_exchange_info(Type, {M,F}) ->
+    filter_index_info(),
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    Indices = riak_core_ring:my_indices(Ring),
+    Defaults = [{Index, undefined, undefined, undefined} || Index <- Indices],
+    KnownInfo = [compute_exchange_info({M,F}, Ring, Index, Info)
+                 || {{Type2, Index}, Info} <- all_index_info(), Type2 == Type],
+    merge_to_first(KnownInfo, Defaults).
+
+%% @doc Return a list of AAE build times for each locally owned index.
+-spec compute_tree_info(atom()) -> [{index(), t_now()}].
+compute_tree_info(Type) ->
+    filter_index_info(),
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    Indices = riak_core_ring:my_indices(Ring),
+    Defaults = [{Index, undefined} || Index <- Indices],
+    KnownInfo = [{Index, Info#index_info.build_time}
+                 || {{Type2, Index}, Info} <- all_index_info(), Type2 == Type],
+    merge_to_first(KnownInfo, Defaults).
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+%% Utility function to load stored information for a given index,
+%% invoke `handle_index_info' to update the information, and then
+%% store the new info back into the ETS table.
+-spec update_index_info({atom(), index()}, term()) -> ok.
+update_index_info(Key, Cmd) ->
+    Info = case ets:lookup(?ETS, {index, Key}) of
+               [] ->
+                   #index_info{};
+               [{_, I}] ->
+                   I
+           end,
+    Info2 = handle_index_info(Cmd, Key, Info),
+    ets:insert(?ETS, {{index, Key}, Info2}),
+    ok.
+
+%% Return a list of all stored index information.
+-spec all_index_info() -> [{{atom(), index()}, index_info()}].
+all_index_info() ->
+    ets:select(?ETS, [{{{index, '$1'}, '$2'}, [], [{{'$1','$2'}}]}]).
+
+%% Remove information for indices that this node no longer owns.
+filter_index_info() ->
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    Primaries = riak_core_ring:my_indices(Ring),
+    Indices = ets:select(?ETS, [{{{index, {'_', '$1'}}, '_'}, [], ['$1']}]),
+    Others = ordsets:subtract(ordsets:from_list(Indices),
+                              ordsets:from_list(Primaries)),
+    [ets:match_delete(?ETS, {{index, {'_', Idx}}, '_'}) || Idx <- Others],
+    ok.
+
+%% Update provided index info based on request.
+-spec handle_index_info(term(), index(), index_info()) -> index_info().
+handle_index_info({tree_built, Time}, _, Info) ->
+    Info#index_info{build_time=Time};
+
+handle_index_info({exchange_complete, RemoteIdx, IndexN, Repaired}, _, Info) ->
+    ExInfo = #exchange_info{time=os:timestamp(),
+                            repaired=Repaired},
+    ExId = {RemoteIdx, IndexN},
+    Exchanges = orddict:store(ExId, ExInfo, Info#index_info.exchanges),
+    RepairStat = update_simple_stat(Repaired, Info#index_info.repaired),
+    Info#index_info{exchanges=Exchanges,
+                    repaired=RepairStat,
+                    last_exchange=ExId}.
+
+%% Return a list of all exchanges necessary to guarantee that `Index' is
+%% fully up-to-date.
+-spec all_exchanges(riak_core_ring(), index())
+                   -> {index(), [{index(), index_n()}]}.
+all_exchanges(Ring, Index) ->
+    L1 = riak_core_entropy_manager:all_pairwise_exchanges(Index, Ring),
+    L2 = [{RemoteIdx, IndexN} || {_, RemoteIdx, IndexN} <- L1],
+    {Index, L2}.
+
+compute_exchange_info({M,F}, Ring, Index, #index_info{exchanges=Exchanges,
+                                                      repaired=Repaired}) ->
+    {_, AllExchanges} = M:F(Ring, Index),
+    Defaults = [{Exchange, undefined} || Exchange <- AllExchanges],
+    KnownTime = [{Exchange, EI#exchange_info.time} || {Exchange, EI} <- Exchanges],
+    AllTime = merge_to_first(KnownTime, Defaults),
+    %% Rely upon fact that undefined < tuple
+    AllTime2 = lists:keysort(2, AllTime),
+    {_, LastAll} = hd(AllTime2),
+    {_, Recent} = hd(lists:reverse(AllTime2)),
+    {Index, Recent, LastAll, stat_tuple(Repaired)}.
+
+%% Merge two lists together based on the key at position 1. When both lists
+%% contain the same key, the value associated with `L1' is kept.
+merge_to_first(L1, L2) ->
+    lists:ukeysort(1, L1 ++ L2).
+
+update_simple_stat(Value, undefined) ->
+    #simple_stat{last=Value, min=Value, max=Value, sum=Value, count=1};
+update_simple_stat(Value, Stat=#simple_stat{max=Max, min=Min, sum=Sum, count=Cnt}) ->
+    Stat#simple_stat{last=Value,
+                     max=erlang:max(Value, Max),
+                     min=erlang:min(Value, Min),
+                     sum=Sum+Value,
+                     count=Cnt+1}.
+
+stat_tuple(undefined) ->
+    undefined;
+stat_tuple(#simple_stat{last=Last, max=Max, min=Min, sum=Sum, count=Cnt}) ->
+    Mean = Sum div Cnt,
+    {Last, Min, Max, Mean}.

--- a/src/riak_core_entropy_info.erl
+++ b/src/riak_core_entropy_info.erl
@@ -73,9 +73,9 @@ exchange_complete(Type, Index, RemoteIdx, IndexN, Repaired) ->
     update_index_info({Type, Index},
                       {exchange_complete, RemoteIdx, IndexN, Repaired}).
 
-%% @doc Called by {@link riak_kv_sup} to create public ETS table used for
+%% @doc Called by {@link <app>_sup} to create public ETS table used for
 %%      holding AAE information for reporting. Table will be owned by
-%%      the `riak_kv_sup' to ensure longevity.
+%%      the `<app>_sup' to ensure longevity.
 create_table() ->
     (ets:info(?ETS) /= undefined) orelse
         ets:new(?ETS, [named_table, public, set, {write_concurrency, true}]).

--- a/src/riak_core_entropy_manager.erl
+++ b/src/riak_core_entropy_manager.erl
@@ -1,0 +1,715 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% This is a direct copy of:
+%% https://github.com/basho/riak_kv/blob/develop/src/riak_kv_entropy_manager.erl
+%% -------------------------------------------------------------------
+
+-module(riak_core_entropy_manager).
+-behaviour(gen_server).
+
+%% API
+-export([start_link/2,
+         manual_exchange/2,
+         enabled/0,
+         enable/1,
+         disable/1,
+         set_mode/2,
+         set_debug/1,
+         cancel_exchange/2,
+         cancel_exchanges/1,
+         get_lock/2,
+         get_lock/3,
+         requeue_poke/2,
+         start_exchange_remote/4,
+         exchange_status/5]).
+-export([all_pairwise_exchanges/2]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-type index() :: non_neg_integer().
+-type index_n() :: {index(), pos_integer()}.
+-type vnode() :: {index(), node()}.
+-type exchange() :: {index(), index(), index_n()}.
+-type riak_core_ring() :: riak_core_ring:riak_core_ring().
+
+-record(state, {mode           = automatic :: automatic | manual,
+                trees          = []        :: [{index(), pid()}],
+                tree_queue     = []        :: [{index(), pid()}],
+                locks          = []        :: [{pid(), reference()}],
+                build_tokens   = 0         :: non_neg_integer(),
+                exchange_queue = []        :: [exchange()],
+                exchanges      = []        :: [{index(), reference(), pid()}],
+                service        = undefined :: atom(),
+                vnode          = undefined :: atom()
+               }).
+
+-type state() :: #state{}.
+
+-define(DEFAULT_CONCURRENCY, 2).
+-define(DEFAULT_BUILD_LIMIT, {1, 36000}). %% Once per hour
+%%-define(DEFAULT_BUILD_LIMIT, {1, 3600000}). %% Once per hour
+
+
+gen_name(Service) ->
+    list_to_atom(atom_to_list(Service) ++ "_entropy_manager").
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec start_link(atom(), atom()) -> {ok, pid()} | {error, term()}.
+start_link(Service, VNode) ->
+    Name = gen_name(Service),
+    gen_server:start_link({local, Name}, ?MODULE, [Service, VNode], []).
+
+%% @doc Acquire an exchange concurrency lock if available, and associate
+%%      the lock with the calling process.
+-spec get_lock(atom(), any()) -> ok | max_concurrency.
+get_lock(Service, Type) ->
+    get_lock(Service, Type, self()).
+
+%% @doc Acquire an exchange concurrency lock if available, and associate
+%%      the lock with the provided pid.
+-spec get_lock(atom(), any(), pid()) -> ok | max_concurrency.
+get_lock(Service, Type, Pid) ->
+    Name = gen_name(Service),
+    gen_server:call(Name, {get_lock, Type, Pid}, infinity).
+
+%% @doc Acquire the necessary locks for an entropy exchange with the specified
+%%      remote vnode. The request is sent to the remote entropy manager which
+%%      will try to acquire a concurrency lock. If successsful, the request is
+%%      then forwarded to the relevant index_hashtree to acquire a tree lock.
+%%      If both locks are acquired, the pid of the remote index_hashtree is
+%%      returned.
+-spec start_exchange_remote(atom(), {index(), node()}, index_n(), pid())
+                           -> {remote_exchange, pid()} |
+                              {remote_exchange, anti_entropy_disabled} |
+                              {remote_exchange, max_concurrency} |
+                              {remote_exchange, not_built} |
+                              {remote_exchange, already_locked}.
+start_exchange_remote(Service, _VNode={Index, Node}, IndexN, FsmPid) ->
+    Name = gen_name(Service),
+    gen_server:call({Name, Node},
+                    {start_exchange_remote, FsmPid, Index, IndexN},
+                    infinity).
+
+%% @doc Used by {@link riak_kv_index_hashtree} to requeue a poke on
+%%      build failure.
+-spec requeue_poke(atom(), index()) -> ok.
+requeue_poke(Service, Index) ->
+    Name = gen_name(Service),
+    gen_server:cast(Name, {requeue_poke, Index}).
+
+%% @doc Used by {@link riak_kv_exchange_fsm} to inform the entropy
+%%      manager about the status of an exchange (ie. completed without
+%%      issue, failed, etc)
+-spec exchange_status(atom(), vnode(), vnode(), index_n(), any()) -> ok.
+exchange_status(Service, LocalVN, RemoteVN, IndexN, Reply) ->
+    Name = gen_name(Service),
+    gen_server:cast(Name,
+                    {exchange_status,
+                     self(), LocalVN, RemoteVN, IndexN, Reply}).
+
+%% @doc Returns true of AAE is enabled, false otherwise.
+-spec enabled() -> boolean().
+enabled() ->
+    {Enabled, _} = settings(),
+    Enabled.
+
+%% @doc Set AAE to either `automatic' or `manual' mode. In automatic mode, the
+%%      entropy manager triggers all necessary hashtree exchanges. In manual
+%%      mode, exchanges must be triggered using {@link manual_exchange/1}.
+%%      Regardless of exchange mode, the entropy manager will always ensure
+%%      local hashtrees are built and rebuilt as necessary.
+-spec set_mode(atom(), automatic | manual) -> ok.
+set_mode(Service, Mode=automatic) ->
+    Name = gen_name(Service),
+    ok = gen_server:call(Name, {set_mode, Mode}, infinity);
+set_mode(Service, Mode=manual) ->
+    Name = gen_name(Service),
+    ok = gen_server:call(Name, {set_mode, Mode}, infinity).
+
+%% @doc Toggle debug mode, which prints verbose AAE information to the console.
+-spec set_debug(boolean()) -> ok.
+set_debug(Enabled) ->
+    Modules = [riak_core_index_hashtree,
+               riak_core_entropy_manager,
+               riak_core_exchange_fsm],
+    case Enabled of
+        true ->
+            [lager:trace_console([{module, Mod}]) || Mod <- Modules];
+        false ->
+            [begin
+                 {ok, Trace} = lager:trace_console([{module, Mod}]),
+                 lager:stop_trace(Trace)
+             end || Mod <- Modules]
+    end,
+    ok.
+
+enable(Service) ->
+    gen_server:call(gen_name(Service), enable, infinity).
+
+disable(Service) ->
+    gen_server:call(gen_name(Service), disable, infinity).
+
+%% @doc Manually trigger hashtree exchanges.
+%%      -- If an index is provided, trigger exchanges between the index and all
+%%         sibling indices for all index_n.
+%%      -- If both an index and index_n are provided, trigger exchanges between
+%%         the index and all sibling indices associated with the specified
+%%         index_n.
+%%      -- If an index, remote index, and index_n are provided, trigger an
+%%         exchange between the index and remote index for the specified
+%%         index_n.
+-spec manual_exchange(atom(),
+                      index() |
+                      {index(), index_n()} |
+                      {index(), index(), index_n()}) -> ok.
+manual_exchange(Service, Exchange) ->
+    gen_server:call(gen_name(Service), {manual_exchange, Exchange}, infinity).
+
+-spec cancel_exchange(atom(), index()) -> ok | undefined.
+cancel_exchange(Service, Index) ->
+    gen_server:call(gen_name(Service), {cancel_exchange, Index}, infinity).
+
+-spec cancel_exchanges(atom()) -> [index()].
+cancel_exchanges(Service) ->
+    gen_server:call(gen_name(Service), cancel_exchanges, infinity).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+-spec init([]) -> {'ok',state()}.
+init([Service, VNode]) ->
+    schedule_tick(gen_name(Service)),
+    {_, Opts} = settings(),
+    Mode = case proplists:is_defined(manual, Opts) of
+               true ->
+                   manual;
+               false ->
+                   automatic
+           end,
+    set_debug(proplists:is_defined(debug, Opts)),
+    State = #state{mode=Mode,
+                   trees=[],
+                   tree_queue=[],
+                   locks=[],
+                   exchanges=[],
+                   exchange_queue=[],
+                   service = Service,
+                   vnode = VNode},
+    State2 = reset_build_tokens(State),
+    schedule_reset_build_tokens(),
+    {ok, State2}.
+
+handle_call({set_mode, Mode}, _From, State) ->
+    {reply, ok, State#state{mode=Mode}};
+handle_call({manual_exchange, Exchange}, _From, State) ->
+    State2 = enqueue_exchange(Exchange, State),
+    {reply, ok, State2};
+handle_call(enable, _From, State) ->
+    {_, Opts} = settings(),
+    application:set_env(riak_core, anti_entropy, {on, Opts}),
+    {reply, ok, State};
+handle_call(disable, _From, State) ->
+    {_, Opts} = settings(),
+    application:set_env(riak_core, anti_entropy, {off, Opts}),
+    [riak_core_index_hashtree:stop(T) || {_,T} <- State#state.trees],
+    {reply, ok, State};
+handle_call({get_lock, Type, Pid}, _From, State) ->
+    {Reply, State2} = do_get_lock(Type, Pid, State),
+    {reply, Reply, State2};
+handle_call({start_exchange_remote, FsmPid, Index, IndexN}, From, State) ->
+    case {enabled(),
+          orddict:find(Index, State#state.trees)} of
+        {false, _} ->
+            {reply, {remote_exchange, anti_entropy_disabled}, State};
+        {_, error} ->
+            {reply, {remote_exchange, not_built}, State};
+        {_, {ok, Tree}} ->
+            case do_get_lock(exchange_remote, FsmPid, State) of
+                {ok, State2} ->
+                    %% Concurrency lock acquired, now forward to index_hashtree
+                    %% to acquire tree lock.
+                    riak_core_index_hashtree:start_exchange_remote(FsmPid, From, IndexN, Tree),
+                    {noreply, State2};
+                {Reply, State2} ->
+                    {reply, {remote_exchange, Reply}, State2}
+            end
+    end;
+handle_call({cancel_exchange, Index}, _From, State) ->
+    case lists:keyfind(Index, 1, State#state.exchanges) of
+        false ->
+            {reply, undefined, State};
+        {Index, _Ref, Pid} ->
+            exit(Pid, kill),
+            {reply, ok, State}
+    end;
+handle_call(cancel_exchanges, _From, State=#state{exchanges=Exchanges}) ->
+    Indices = [begin
+                   exit(Pid, kill),
+                   Index
+               end || {Index, _Ref, Pid} <- Exchanges],
+    {reply, Indices, State};
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast({requeue_poke, Index}, State) ->
+    State2 = requeue_poke_int(Index, State),
+    {noreply, State2};
+handle_cast({exchange_status, Pid, LocalVN, RemoteVN, IndexN, Reply}, State) ->
+    State2 = do_exchange_status(Pid, LocalVN, RemoteVN, IndexN, Reply, State),
+    {noreply, State2};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(tick, State) ->
+    State2 = maybe_tick(State),
+    {noreply, State2};
+handle_info(reset_build_tokens, State) ->
+    State2 = reset_build_tokens(State),
+    schedule_reset_build_tokens(),
+    {noreply, State2};
+handle_info({{hashtree_pid, Index}, Reply}, State) ->
+    case Reply of
+        {ok, Pid} when is_pid(Pid) ->
+            State2 = add_hashtree_pid(Index, Pid, State),
+            {noreply, State2};
+        _ ->
+            {noreply, State}
+    end;
+handle_info({'DOWN', Ref, _, Obj, Status}, State) ->
+    State2 = maybe_release_lock(Ref, State),
+    State3 = maybe_clear_exchange(Ref, Status, State2),
+    State4 = maybe_clear_registered_tree(Obj, State3),
+    {noreply, State4};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+schedule_reset_build_tokens() ->
+    {_, Reset} = app_helper:get_env(riak_core, anti_entropy_build_limit,
+                                    ?DEFAULT_BUILD_LIMIT),
+    erlang:send_after(Reset, self(), reset_build_tokens).
+
+reset_build_tokens(State) ->
+    {Tokens, _} = app_helper:get_env(riak_core, anti_entropy_build_limit,
+                                     ?DEFAULT_BUILD_LIMIT),
+    State#state{build_tokens=Tokens}.
+
+-spec settings() -> {boolean(), proplists:proplist()}.
+settings() ->
+    case app_helper:get_env(riak_core, anti_entropy, {off, []}) of
+        {on, Opts} ->
+            {true, Opts};
+        {off, Opts} ->
+            {false, Opts};
+        X ->
+            lager:warning("Invalid setting for riak_kv/anti_entropy: ~p", [X]),
+            application:set_env(riak_core, anti_entropy, {off, []}),
+            {false, []}
+    end.
+
+-spec maybe_reload_hashtrees(riak_core_ring(), state()) -> state().
+maybe_reload_hashtrees(Ring, State) ->
+    case lists:member(State#state.service,
+                      riak_core_node_watcher:services(node())) of
+        true ->
+            reload_hashtrees(Ring, State);
+        false ->
+            State
+    end.
+
+%% Determine the index_hashtree pid for each running primary vnode. This
+%% function is called each tick to ensure that any newly spawned vnodes are
+%% queried.
+-spec reload_hashtrees(riak_core_ring(), state()) -> state().
+reload_hashtrees(Ring, State=#state{trees=Trees}) ->
+    Indices = riak_core_ring:my_indices(Ring),
+    Existing = dict:from_list(Trees),
+    MissingIdx = [Idx || Idx <- Indices,
+                         not dict:is_key(Idx, Existing)],
+    VNode = State#state.vnode,
+    [VNode:request_hashtree_pid(Idx) || Idx <- MissingIdx],
+    State.
+
+add_hashtree_pid(Index, Pid, State) ->
+    add_hashtree_pid(enabled(), Index, Pid, State).
+
+add_hashtree_pid(false, _Index, Pid, State) ->
+    riak_core_index_hashtree:stop(Pid),
+    State;
+add_hashtree_pid(true, Index, Pid, State=#state{trees=Trees}) ->
+    case orddict:find(Index, Trees) of
+        {ok, Pid} ->
+            %% Already know about this hashtree
+            State;
+        _ ->
+            monitor(process, Pid),
+            Trees2 = orddict:store(Index, Pid, Trees),
+            State2 = State#state{trees=Trees2},
+            State3 = add_index_exchanges(Index, State2),
+            State3
+    end.
+
+-spec do_get_lock(any(),pid(),state())
+                 -> {ok | max_concurrency | build_limit_reached, state()}.
+do_get_lock(Type, Pid, State=#state{locks=Locks}) ->
+    Concurrency = app_helper:get_env(riak_core,
+                                     anti_entropy_concurrency,
+                                     ?DEFAULT_CONCURRENCY),
+    case length(Locks) >= Concurrency of
+        true ->
+            {max_concurrency, State};
+        false ->
+            case check_lock_type(Type, State) of
+                {ok, State2} ->
+                    Ref = monitor(process, Pid),
+                    lager:debug("Get lock: ~p", [Ref]),
+                    State3 = State2#state{locks=[{Pid,Ref}|Locks]},
+                    {ok, State3};
+                Error ->
+                    {Error, State}
+            end
+    end.
+
+check_lock_type(build, State=#state{build_tokens=Tokens}) ->
+    if Tokens > 0 ->
+            {ok, State#state{build_tokens=Tokens-1}};
+       true ->
+            build_limit_reached
+    end;
+check_lock_type(_Type, State) ->
+    {ok, State}.
+
+-spec maybe_release_lock(reference(), state()) -> state().
+maybe_release_lock(Ref, State) ->
+    lager:debug("Release lock: ~p", [Ref]),
+    Locks = lists:keydelete(Ref, 2, State#state.locks),
+    State#state{locks=Locks}.
+
+-spec maybe_clear_exchange(reference(), term(), state()) -> state().
+maybe_clear_exchange(Ref, Status, State) ->
+    case lists:keytake(Ref, 2, State#state.exchanges) of
+        false ->
+            State;
+        {value, {Idx,Ref,_Pid}, Exchanges} ->
+            lager:debug("Untracking exchange: ~p :: ~p", [Idx, Status]),
+            State#state{exchanges=Exchanges}
+    end.
+
+-spec maybe_clear_registered_tree(pid(), state()) -> state().
+maybe_clear_registered_tree(Pid, State) when is_pid(Pid) ->
+    Trees = lists:keydelete(Pid, 2, State#state.trees),
+    State#state{trees=Trees};
+maybe_clear_registered_tree(_, State) ->
+    State.
+
+-spec next_tree(state()) -> {pid(), state()}.
+next_tree(#state{trees=[]}) ->
+    throw(no_trees_registered);
+next_tree(State=#state{tree_queue=[], trees=Trees}) ->
+    State2 = State#state{tree_queue=Trees},
+    next_tree(State2);
+next_tree(State=#state{tree_queue=Queue}) ->
+    [{_Index,Pid}|Rest] = Queue,
+    State2 = State#state{tree_queue=Rest},
+    {Pid, State2}.
+
+-spec schedule_tick(Service::atom()) -> ok.
+schedule_tick(Service) ->
+    %% Perform tick every 15 seconds
+    DefaultTick = 15000,
+    Tick = app_helper:get_env(riak_core,
+                              anti_entropy_tick,
+                              DefaultTick),
+    erlang:send_after(Tick, Service, tick),
+    ok.
+
+-spec maybe_tick(state()) -> state().
+maybe_tick(State) ->
+    case enabled() of
+        true ->
+            case riak_core_capability:get({State#state.service, anti_entropy}, disabled) of
+                disabled ->
+                    lager:debug("Ticks disabled for: ~p", [State#state.service]),
+                    NextState = State;
+                enabled_v1 ->
+                    NextState = tick(State)
+            end;
+        false ->
+            %% Ensure we do not have any running index_hashtrees, which can
+            %% happen when disabling anti-entropy on a live system.
+            [riak_core_index_hashtree:stop(T) || {_,T} <- State#state.trees],
+            NextState = State
+    end,
+    schedule_tick(gen_name(State#state.service)),
+    NextState.
+
+-spec tick(state()) -> state().
+tick(State) ->
+    lager:debug("Tick tick."),
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    State2 = maybe_reload_hashtrees(Ring, State),
+    State3 = lists:foldl(fun(_,S) ->
+                                 maybe_poke_tree(S)
+                         end, State2, lists:seq(1,10)),
+    State4 = maybe_exchange(Ring, State3),
+    State4.
+
+-spec maybe_poke_tree(state()) -> state().
+maybe_poke_tree(State=#state{trees=[]}) ->
+    State;
+maybe_poke_tree(State) ->
+    {Tree, State2} = next_tree(State),
+    lager:debug("Poking ~p", [Tree]),
+    riak_core_index_hashtree:poke(Tree),
+    State2.
+
+%%%===================================================================
+%%% Exchanging
+%%%===================================================================
+
+-spec do_exchange_status(pid(), vnode(), vnode(), index_n(), any(), state()) -> state().
+do_exchange_status(_Pid, LocalVN, RemoteVN, IndexN, Reply, State) ->
+    {LocalIdx, _} = LocalVN,
+    {RemoteIdx, RemoteNode} = RemoteVN,
+    case Reply of
+        ok ->
+            State;
+        {remote, anti_entropy_disabled} ->
+            lager:warning("Active anti-entropy is disabled on ~p", [RemoteNode]),
+            State;
+        _ ->
+            State2 = requeue_exchange(LocalIdx, RemoteIdx, IndexN, State),
+            State2
+    end.
+
+-spec enqueue_exchange(index() |
+                       {index(), index_n()} |
+                       {index(), index(), index_n()}, state()) -> state().
+enqueue_exchange(E={Index, _RemoteIdx, _IndexN}, State) ->
+    %% Verify that the exchange is valid
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    Exchanges = all_pairwise_exchanges(Index, Ring),
+    case lists:member(E, Exchanges) of
+        true ->
+            enqueue_exchanges([E], State);
+        false ->
+            State
+    end;
+enqueue_exchange({Index, IndexN}, State) ->
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    Exchanges = all_pairwise_exchanges(Index, Ring),
+    Exchanges2 = [Exchange || Exchange={_, _, IdxN} <- Exchanges,
+                              IdxN =:= IndexN],
+    enqueue_exchanges(Exchanges2, State);
+enqueue_exchange(Index, State) ->
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    Exchanges = all_pairwise_exchanges(Index, Ring),
+    enqueue_exchanges(Exchanges, State).
+
+-spec enqueue_exchanges([exchange()], state()) -> state().
+enqueue_exchanges(Exchanges, State) ->
+    EQ = prune_exchanges(State#state.exchange_queue ++ Exchanges),
+    State#state{exchange_queue=EQ}.
+
+-spec start_exchange(vnode(),
+                     {index(), index_n()},
+                     riak_core_ring(),
+                     state()) -> {any(), state()}.
+start_exchange(LocalVN, {RemoteIdx, IndexN}, Ring, State) ->
+    %% in rare cases, when the ring is resized, there may be an
+    %% exchange enqueued for an index that no longer exists. catch
+    %% the case here and move on
+    try riak_core_ring:index_owner(Ring, RemoteIdx) of
+        Owner ->
+            Nodes = lists:usort([node(), Owner]),
+            DownNodes = Nodes -- riak_core_node_watcher:nodes(State#state.service),
+            case DownNodes of
+                [] ->
+                    RemoteVN = {RemoteIdx, Owner},
+                    start_exchange(LocalVN, RemoteVN, IndexN, Ring, State);
+                _ ->
+                    {{down, State#state.service, DownNodes}, State}
+            end
+    catch
+        error:{badmatch,_} ->
+            lager:warning("ignoring exchange to non-existent index: ~p", [RemoteIdx]),
+            {ok, State}
+    end.
+
+start_exchange(LocalVN, RemoteVN, IndexN, Ring, State) ->
+    {LocalIdx, _} = LocalVN,
+    {RemoteIdx, _} = RemoteVN,
+    case riak_core_ring:vnode_type(Ring, LocalIdx) of
+        primary ->
+            VNode = State#state.vnode,
+            case orddict:find(LocalIdx, State#state.trees) of
+                error ->
+                    %% The local vnode has not yet registered it's
+                    %% index_hashtree. Likewise, the vnode may not even
+                    %% be running (eg. after a crash).  Send request to
+                    %% the vnode to trigger on-demand start and requeue
+                    %% exchange.
+                    VNode:request_hashtree_pid(LocalIdx),
+                    State2 = requeue_exchange(LocalIdx, RemoteIdx, IndexN, State),
+                    {not_built, State2};
+                {ok, Tree} ->
+                    case riak_core_exchange_fsm:start(State#state.service,
+                                                      LocalVN, RemoteVN,
+                                                      IndexN, Tree, self(),
+                                                      VNode) of
+                        {ok, FsmPid} ->
+                            Ref = monitor(process, FsmPid),
+                            Exchanges = State#state.exchanges,
+                            Exchanges2 = [{LocalIdx, Ref, FsmPid} | Exchanges],
+                            {ok, State#state{exchanges=Exchanges2}};
+                        {error, Reason} ->
+                            {Reason, State}
+                    end
+            end;
+        _ ->
+            %% No longer owner of this partition or partition is
+            %% part or larger future ring, ignore exchange
+            {not_responsible, State}
+    end.
+
+-spec all_pairwise_exchanges(index(), riak_core_ring())
+                            -> [exchange()].
+all_pairwise_exchanges(Index, Ring) ->
+    LocalIndexN = riak_core_util2:responsible_preflists(Index, Ring),
+    Sibs = riak_core_util2:preflist_siblings(Index),
+    lists:flatmap(
+      fun(RemoteIdx) ->
+              RemoteIndexN = riak_core_util2:responsible_preflists(RemoteIdx, Ring),
+              SharedIndexN = ordsets:intersection(ordsets:from_list(LocalIndexN),
+                                                  ordsets:from_list(RemoteIndexN)),
+              [{Index, RemoteIdx, IndexN} || IndexN <- SharedIndexN]
+      end, Sibs).
+
+-spec all_exchanges(node(), riak_core_ring(), state())
+                   -> [exchange()].
+all_exchanges(_Node, Ring, #state{trees=Trees}) ->
+    Indices = orddict:fetch_keys(Trees),
+    lists:flatmap(fun(Index) ->
+                          all_pairwise_exchanges(Index, Ring)
+                  end, Indices).
+
+-spec add_index_exchanges(index(), state()) -> state().
+add_index_exchanges(_Index, State) when State#state.mode == manual ->
+    State;
+add_index_exchanges(Index, State) ->
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    Exchanges = all_pairwise_exchanges(Index, Ring),
+    EQ = State#state.exchange_queue ++ Exchanges,
+    EQ2 = prune_exchanges(EQ),
+    State#state{exchange_queue=EQ2}.
+
+-spec prune_exchanges([exchange()])
+                     -> [exchange()].
+prune_exchanges(Exchanges) ->
+    L = [if A < B ->
+                 {A, B, IndexN};
+            true ->
+                 {B, A, IndexN}
+         end || {A, B, IndexN} <- Exchanges],
+    lists:usort(L).
+
+-spec already_exchanging(index() ,state()) -> boolean().
+already_exchanging(Index, #state{exchanges=E}) ->
+    case lists:keyfind(Index, 1, E) of
+        false ->
+            false;
+        {Index,_,_} ->
+            true
+    end.
+
+-spec maybe_exchange(riak_core_ring(), state()) -> state().
+maybe_exchange(Ring, State) ->
+    case next_exchange(Ring, State) of
+        {none, State2} ->
+            State2;
+        {NextExchange, State2} ->
+            {LocalIdx, RemoteIdx, IndexN} = NextExchange,
+            case already_exchanging(LocalIdx, State) of
+                true ->
+                    requeue_exchange(LocalIdx, RemoteIdx, IndexN, State2);
+                false ->
+                    LocalVN = {LocalIdx, node()},
+                    case start_exchange(LocalVN, {RemoteIdx, IndexN}, Ring, State2) of
+                        {ok, State3} ->
+                            State3;
+                        {_Reason, State3} ->
+                            State3
+                    end
+            end
+    end.
+
+-spec next_exchange(riak_core_ring(), state()) -> {'none' | exchange(), state()}.
+next_exchange(_Ring, State=#state{exchange_queue=[], trees=[]}) ->
+    {none, State};
+next_exchange(_Ring, State=#state{exchange_queue=[],
+                                  mode=Mode}) when Mode == manual ->
+    {none, State};
+next_exchange(Ring, State=#state{exchange_queue=[]}) ->
+    case prune_exchanges(all_exchanges(node(), Ring, State)) of
+        [] ->
+            {none, State};
+        [Exchange|Rest] ->
+            State2 = State#state{exchange_queue=Rest},
+            {Exchange, State2}
+    end;
+next_exchange(_Ring, State=#state{exchange_queue=Exchanges}) ->
+    [Exchange|Rest] = Exchanges,
+    State2 = State#state{exchange_queue=Rest},
+    {Exchange, State2}.
+
+-spec requeue_poke_int(index(), state()) -> state().
+requeue_poke_int(Index, State=#state{trees=Trees}) ->
+    case orddict:find(Index, Trees) of
+        {ok, Tree} ->
+            Queue = State#state.tree_queue ++ [{Index,Tree}],
+            State#state{tree_queue=Queue};
+        _ ->
+            State
+    end.
+
+-spec requeue_exchange(index(), index(), index_n(), state()) -> state().
+requeue_exchange(LocalIdx, RemoteIdx, IndexN, State) ->
+    Exchange = {LocalIdx, RemoteIdx, IndexN},
+    case lists:member(Exchange, State#state.exchange_queue) of
+        true ->
+            State;
+        false ->
+            lager:debug("Requeue: ~p", [{LocalIdx, RemoteIdx, IndexN}]),
+            Exchanges = State#state.exchange_queue ++ [Exchange],
+            State#state{exchange_queue=Exchanges}
+    end.

--- a/src/riak_core_entropy_manager.erl
+++ b/src/riak_core_entropy_manager.erl
@@ -37,7 +37,8 @@
          get_lock/3,
          requeue_poke/2,
          start_exchange_remote/4,
-         exchange_status/5]).
+         exchange_status/5,
+         supervisor_spec/2]).
 -export([all_pairwise_exchanges/2]).
 
 %% gen_server callbacks
@@ -64,9 +65,20 @@
 -type state() :: #state{}.
 
 -define(DEFAULT_CONCURRENCY, 2).
--define(DEFAULT_BUILD_LIMIT, {1, 36000}). %% Once per hour
-%%-define(DEFAULT_BUILD_LIMIT, {1, 3600000}). %% Once per hour
+-define(DEFAULT_BUILD_LIMIT, {1, 3600000}). %% Once per hour
 
+
+-spec supervisor_spec(Service::atom(), VNode::atom()) ->
+                             {atom(),
+                              {riak_core_entropy_manager, start_link,
+                               [atom()]},
+                              permanent, 30000, worker, [riak_core_entropy_manager]}.
+
+supervisor_spec(Service, VNode) ->
+    {gen_name(Service),
+     {riak_core_entropy_manager, start_link,
+      [Service, VNode]},
+     permanent, 30000, worker, [riak_core_entropy_manager]}.
 
 gen_name(Service) ->
     list_to_atom(atom_to_list(Service) ++ "_entropy_manager").

--- a/src/riak_core_entropy_manager.erl
+++ b/src/riak_core_entropy_manager.erl
@@ -605,11 +605,11 @@ start_exchange(LocalVN, RemoteVN, IndexN, Ring, State) ->
 -spec all_pairwise_exchanges(index(), riak_core_ring())
                             -> [exchange()].
 all_pairwise_exchanges(Index, Ring) ->
-    LocalIndexN = riak_core_util2:responsible_preflists(Index, Ring),
-    Sibs = riak_core_util2:preflist_siblings(Index),
+    LocalIndexN = riak_core_util:responsible_preflists(Index, Ring),
+    Sibs = riak_core_util:preflist_siblings(Index),
     lists:flatmap(
       fun(RemoteIdx) ->
-              RemoteIndexN = riak_core_util2:responsible_preflists(RemoteIdx, Ring),
+              RemoteIndexN = riak_core_util:responsible_preflists(RemoteIdx, Ring),
               SharedIndexN = ordsets:intersection(ordsets:from_list(LocalIndexN),
                                                   ordsets:from_list(RemoteIndexN)),
               [{Index, RemoteIdx, IndexN} || IndexN <- SharedIndexN]

--- a/src/riak_core_entropy_manager.erl
+++ b/src/riak_core_entropy_manager.erl
@@ -369,7 +369,8 @@ reload_hashtrees(Ring, State=#state{trees=Trees}) ->
     MissingIdx = [Idx || Idx <- Indices,
                          not dict:is_key(Idx, Existing)],
     VNode = State#state.vnode,
-    [VNode:request_hashtree_pid(Idx) || Idx <- MissingIdx],
+    Master = VNode:master(),
+    [riak_core_aae_vnode:request_hashtree_pid(Master, Idx) || Idx <- MissingIdx],
     State.
 
 add_hashtree_pid(Index, Pid, State) ->
@@ -591,7 +592,7 @@ start_exchange(LocalVN, RemoteVN, IndexN, Ring, State) ->
                     %% be running (eg. after a crash).  Send request to
                     %% the vnode to trigger on-demand start and requeue
                     %% exchange.
-                    VNode:request_hashtree_pid(LocalIdx),
+                    riak_core_aae_vnode:request_hashtree_pid(VNode:master(), LocalIdx),
                     State2 = requeue_exchange(LocalIdx, RemoteIdx, IndexN, State),
                     {not_built, State2};
                 {ok, Tree} ->

--- a/src/riak_core_entropy_manager.erl
+++ b/src/riak_core_entropy_manager.erl
@@ -122,14 +122,14 @@ start_exchange_remote(Service, _VNode={Index, Node}, IndexN, FsmPid) ->
                     {start_exchange_remote, FsmPid, Index, IndexN},
                     infinity).
 
-%% @doc Used by {@link riak_kv_index_hashtree} to requeue a poke on
+%% @doc Used by {@link riak_core_index_hashtree} to requeue a poke on
 %%      build failure.
 -spec requeue_poke(atom(), index()) -> ok.
 requeue_poke(Service, Index) ->
     Name = gen_name(Service),
     gen_server:cast(Name, {requeue_poke, Index}).
 
-%% @doc Used by {@link riak_kv_exchange_fsm} to inform the entropy
+%% @doc Used by {@link riak_core_exchange_fsm} to inform the entropy
 %%      manager about the status of an exchange (ie. completed without
 %%      issue, failed, etc)
 -spec exchange_status(atom(), vnode(), vnode(), index_n(), any()) -> ok.

--- a/src/riak_core_exchange_fsm.erl
+++ b/src/riak_core_exchange_fsm.erl
@@ -1,0 +1,416 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_core_exchange_fsm).
+-behaviour(gen_fsm).
+
+%% API
+-export([start/7]).
+
+%% FSM states
+-export([prepare_exchange/2,
+         update_trees/2,
+         key_exchange/2]).
+
+%% gen_fsm callbacks
+-export([init/1, handle_event/3, handle_sync_event/4, handle_info/3,
+         terminate/3, code_change/4]).
+
+-type index() :: non_neg_integer().
+-type index_n() :: {index(), pos_integer()}.
+-type vnode() :: {index(), node()}.
+
+-record(state, {local       :: vnode(),
+                remote      :: vnode(),
+                index_n     :: index_n(),
+                local_tree  :: pid(),
+                remote_tree :: pid(),
+                built       :: non_neg_integer(),
+                timeout     :: pos_integer(),
+                vnode       :: atom(),
+                service     :: atom()
+               }).
+
+%% Per state transition timeout used by certain transitions
+-define(DEFAULT_ACTION_TIMEOUT, 300000). %% 5 minutes
+
+%% Use occasional calls to disk_log:log() for some backpressure periodically
+-define(LOG_BATCH_SIZE, 5000).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+start(Service, LocalVN, RemoteVN, IndexN, Tree, Manager, VNode) ->
+    gen_fsm:start(?MODULE, [Service, LocalVN, RemoteVN, IndexN, Tree, Manager, VNode], []).
+
+%%%===================================================================
+%%% gen_fsm callbacks
+%%%===================================================================
+
+init([Service, LocalVN, RemoteVN, IndexN, LocalTree, Manager, VNode]) ->
+    Timeout = app_helper:get_env(riak_core,
+                                 anti_entropy_timeout,
+                                 ?DEFAULT_ACTION_TIMEOUT),
+    monitor(process, Manager),
+    monitor(process, LocalTree),
+    State = #state{local=LocalVN,
+                   remote=RemoteVN,
+                   index_n=IndexN,
+                   local_tree=LocalTree,
+                   timeout=Timeout,
+                   built=0,
+                   vnode=VNode,
+                   service=Service},
+    gen_fsm:send_event(self(), start_exchange),
+    lager:debug("Starting exchange: ~p", [LocalVN]),
+    {ok, prepare_exchange, State}.
+
+handle_event(_Event, StateName, State) ->
+    {next_state, StateName, State}.
+
+handle_sync_event(_Event, _From, StateName, State) ->
+    {reply, ok, StateName, State}.
+
+handle_info({'DOWN', _, _, _, _}, _StateName, State) ->
+    %% Either the entropy manager, local hashtree, or remote hashtree has
+    %% exited. Stop exchange.
+    {stop, normal, State};
+handle_info(_Info, StateName, State) ->
+    {next_state, StateName, State}.
+
+terminate(_Reason, _StateName, _State) ->
+    ok.
+
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.
+
+%%%===================================================================
+%%% gen_fsm states
+%%%===================================================================
+
+%% @doc Initial state. Attempt to acquire all necessary exchange locks.
+%%      In order, acquire local concurrency lock, local tree lock,
+%%      remote concurrency lock, and remote tree lock. Exchange will
+%%      timeout if locks cannot be acquired in a timely manner.
+prepare_exchange(start_exchange, State=#state{remote=RemoteVN,
+                                              index_n=IndexN,
+                                              service=Service}) ->
+    case riak_core_entropy_manager:get_lock(Service, exchange) of
+        ok ->
+            case riak_core_index_hashtree:get_lock(State#state.local_tree,
+                                                   local_fsm) of
+                ok ->
+                    remote_exchange_request(Service, RemoteVN, IndexN),
+                    next_state_with_timeout(prepare_exchange, State);
+                _ ->
+                    send_exchange_status(already_locked, State),
+                    {stop, normal, State}
+            end;
+        Error ->
+            send_exchange_status(Error, State),
+            {stop, normal, State}
+    end;
+prepare_exchange(timeout, State) ->
+    do_timeout(State);
+prepare_exchange({remote_exchange, Pid}, State) when is_pid(Pid) ->
+    monitor(process, Pid),
+    State2 = State#state{remote_tree=Pid},
+    update_trees(start_exchange, State2);
+prepare_exchange({remote_exchange, Error}, State) ->
+    send_exchange_status({remote, Error}, State),
+    {stop, normal, State}.
+
+%% @doc Now that locks have been acquired, ask both the local and remote
+%%      hashtrees to perform a tree update. If updates do not occur within
+%%      a timely manner, the exchange will timeout. Since the trees will
+%%      continue to finish the update even after the exchange times out,
+%%      a future exchange should eventually make progress.
+update_trees(start_exchange, State=#state{local=LocalVN,
+                                          remote=RemoteVN,
+                                          local_tree=LocalTree,
+                                          remote_tree=RemoteTree,
+                                          index_n=IndexN}) ->
+    lager:debug("Sending to ~p", [LocalVN]),
+    lager:debug("Sending to ~p", [RemoteVN]),
+
+    update_request(LocalTree, LocalVN, IndexN),
+    update_request(RemoteTree, RemoteVN, IndexN),
+    {next_state, update_trees, State};
+
+update_trees({not_responsible, VNodeIdx, IndexN}, State) ->
+    lager:debug("VNode ~p does not cover preflist ~p", [VNodeIdx, IndexN]),
+    send_exchange_status({not_responsible, VNodeIdx, IndexN}, State),
+    {stop, normal, State};
+update_trees({tree_built, _, _}, State) ->
+    Built = State#state.built + 1,
+    case Built of
+        2 ->
+            lager:debug("Moving to key exchange"),
+            {next_state, key_exchange, State, 0};
+        _ ->
+            {next_state, update_trees, State#state{built=Built}}
+    end.
+
+%% @doc Now that locks have been acquired and both hashtrees have been updated,
+%%      perform a key exchange and trigger read repair for any divergent keys.
+key_exchange(timeout, State=#state{local=LocalVN,
+                                   remote=RemoteVN,
+                                   local_tree=LocalTree,
+                                   remote_tree=RemoteTree,
+                                   index_n=IndexN,
+                                   vnode=VNode,
+                                   service=Service}) ->
+    lager:debug("Starting key exchange between ~p and ~p", [LocalVN, RemoteVN]),
+    lager:debug("Exchanging hashes for preflist ~p", [IndexN]),
+
+    TmpDir = app_helper:get_env(riak_core, platform_data_dir, "/tmp"),
+    {NA, NB, NC} = Now = WriteLog = now(),
+    LogFile1 = lists:flatten(io_lib:format("~s/~s/in.~p.~p.~p",
+                                           [TmpDir, ?MODULE, NA, NB, NC])),
+    ok = filelib:ensure_dir(LogFile1),
+    LogFile2 = lists:flatten(io_lib:format("~s/~s/out.~p.~p.~p",
+                                           [TmpDir, ?MODULE, NA, NB, NC])),
+    ok = filelib:ensure_dir(LogFile2),
+    Remote = fun(get_bucket, {L, B}) ->
+                     exchange_bucket(RemoteTree, IndexN, L, B);
+                (key_hashes, Segment) ->
+                     exchange_segment(RemoteTree, IndexN, Segment);
+                (init, _Y) ->
+                     %% Our return value is ignored, so we can't return
+                     %% the disk log handle here.  However, disk_log is
+                     %% magically stateful, so we don't need to change
+                     %% the exchange API to accomodate us.
+                     {ok, _} = open_disk_log(Now, LogFile1, read_write),
+                     ok;
+                (final, _Y) ->
+                     ok = disk_log:sync(Now),
+                     ok = disk_log:close(Now),
+                     ok;
+                (_X, _Y) ->
+                     lager:error("~s LINE ~p: ~p ~p", [?MODULE, ?LINE, _X, _Y]),
+                     ok
+             end,
+
+    %% Unclear if we should allow exchange to run indefinitely or enforce
+    %% a timeout. The problem is that depending on the number of keys and
+    %% key differences, exchange can take arbitrarily long. For now, go with
+    %% unbounded exchange, with the ability to cancel exchanges through the
+    %% entropy manager if needed.
+    AccFun = fun(KeyDiff, Acc) ->
+                     lists:foldl(fun({DiffReason, BKeyBin}, Count) ->
+                                         {B, K} = binary_to_term(BKeyBin),
+                                         T = {B, K, DiffReason},
+                                         if Count rem ?LOG_BATCH_SIZE == 0 ->
+                                                 ok = disk_log:log(WriteLog, T);
+                                            true ->
+                                                 ok = disk_log:alog(WriteLog, T)
+                                         end,
+                                         Count+1
+                                 end, Acc, KeyDiff)
+             end,
+    %% TODO: Add stats for AAE
+    Count = riak_core_index_hashtree:compare(IndexN, Remote, AccFun, 0,
+                                             LocalTree),
+    if Count == 0 ->
+            ok;
+       true ->
+            %% Sort the keys.  For vnodes that use backends that preserve
+            %% lexicographic sort order for BKeys, this is a big
+            %% improvement.  For backends that do not, e.g. Bitcask, sorting
+            %% by BKey is unlikely to be any worse.  For Riak CS's use
+            %% pattern, sorting may have some benefit since block N is
+            %% likely to be nearby on disk of block N+1.
+            StartTime = now(),
+            ok = sort_disk_log(LogFile1, LogFile2),
+            lager:debug("~s:key_exchange: sorting time = ~p seconds\n",
+                        [?MODULE, timer:now_diff(now(), StartTime) / 1000000]),
+            {ok, ReadLog} = open_disk_log(Now, LogFile2, read_only),
+            FoldRes =
+                fold_disk_log(fun(Diff, Acc) ->
+                                      read_repair_keydiff(VNode, LocalVN, RemoteVN,
+                                                          Diff),
+                                      Acc + 1
+                              end, 0, ReadLog),
+            disk_log:close(ReadLog),
+            if Count == FoldRes ->
+                    ok;
+               true ->
+                    lager:error("~s:key_exchange: Count ~p /= FoldRes ~p\n",
+                                [?MODULE, Count, FoldRes])
+            end,
+            lager:info("Repaired ~b keys during active anti-entropy exchange "
+                       "of ~p between ~p and ~p",
+                       [Count, IndexN, LocalVN, RemoteVN])
+    end,
+    exchange_complete(LocalVN, RemoteVN, IndexN, Count, Service),
+    _ = file:delete(LogFile1),
+    _ = file:delete(LogFile2),
+    {stop, normal, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+%% @private
+exchange_bucket(Tree, IndexN, Level, Bucket) ->
+    riak_core_index_hashtree:exchange_bucket(IndexN, Level, Bucket, Tree).
+
+%% @private
+exchange_segment(Tree, IndexN, Segment) ->
+    riak_core_index_hashtree:exchange_segment(IndexN, Segment, Tree).
+
+%% @private
+read_repair_keydiff(VNode, LocalVN, RemoteVN, {Bucket, Key, _Reason}) ->
+    %% TODO: Even though this is at debug level, it's still extremely
+    %%       spammy. Should this just be removed? We can always use
+    %%       redbug to trace read_repair_keydiff when needed. Of course,
+    %%       users can't do that.
+    %% lager:debug("Anti-entropy forced read repair: ~p/~p", [Bucket, Key]),
+    VNode:aae_repair(Bucket, Key),
+    %% Force vnodes to update AAE tree in case read repair wasn't triggered
+    VNode:rehash([LocalVN, RemoteVN], Bucket, Key),
+    ok.
+
+%% @private
+update_request(Tree, {Index, _}, IndexN) ->
+    as_event(fun() ->
+                     case riak_core_index_hashtree:update(IndexN, Tree) of
+                         ok ->
+                             {tree_built, Index, IndexN};
+                         not_responsible ->
+                             {not_responsible, Index, IndexN}
+                     end
+             end).
+
+remote_exchange_request(Service, RemoteVN, IndexN) ->
+    FsmPid = self(),
+    as_event(fun() ->
+                     riak_core_entropy_manager:start_exchange_remote(Service,
+                                                                     RemoteVN,
+                                                                     IndexN,
+                                                                     FsmPid)
+             end).
+
+%% @private
+as_event(F) ->
+    Self = self(),
+    spawn_link(fun() ->
+                       Result = F(),
+                       gen_fsm:send_event(Self, Result)
+               end),
+    ok.
+
+%% @private
+do_timeout(State=#state{local=LocalVN,
+                        remote=RemoteVN,
+                        index_n=IndexN}) ->
+    lager:info("Timeout during exchange between (local) ~p and (remote) ~p, "
+               "(preflist) ~p", [LocalVN, RemoteVN, IndexN]),
+    send_exchange_status({timeout, RemoteVN, IndexN}, State),
+    {stop, normal, State}.
+
+%% @private
+send_exchange_status(Status, #state{local=LocalVN,
+                                    remote=RemoteVN,
+                                    index_n=IndexN,
+                                    service=Service}) ->
+    riak_core_entropy_manager:exchange_status(Service, LocalVN, RemoteVN, IndexN, Status).
+
+%% @private
+next_state_with_timeout(StateName, State) ->
+    next_state_with_timeout(StateName, State, State#state.timeout).
+next_state_with_timeout(StateName, State, Timeout) ->
+    {next_state, StateName, State, Timeout}.
+
+exchange_complete({LocalIdx, _}, {RemoteIdx, RemoteNode}, IndexN, Repaired, Service) ->
+    riak_core_entropy_info:exchange_complete(Service, LocalIdx, RemoteIdx, IndexN, Repaired),
+    rpc:call(RemoteNode, riak_core_entropy_info, exchange_complete,
+             [RemoteIdx, LocalIdx, IndexN, Repaired]).
+
+open_disk_log(Name, Path, RWorRO) ->
+    open_disk_log(Name, Path, RWorRO, [{type, halt}, {format, internal}]).
+
+open_disk_log(Name, Path, RWorRO, OtherOpts) ->
+    disk_log:open([{name, Name}, {file, Path}, {mode, RWorRO}|OtherOpts]).
+
+sort_disk_log(InputFile, OutputFile) ->
+    {ok, ReadLog} = open_disk_log(now(), InputFile, read_only),
+    _ = file:delete(OutputFile),
+    {ok, WriteLog} = open_disk_log(now(), OutputFile, read_write),
+    Input = sort_disk_log_input(ReadLog),
+    Output = sort_disk_log_output(WriteLog),
+    try
+        file_sorter:sort(Input, Output, {format, term})
+    after
+        ok = disk_log:close(ReadLog),
+        ok = disk_log:close(WriteLog)
+    end.
+
+sort_disk_log_input(ReadLog) ->
+    sort_disk_log_input(ReadLog, start).
+
+sort_disk_log_input(ReadLog, Cont) ->
+    fun(close) ->
+            ok;
+       (read) ->
+            case disk_log:chunk(ReadLog, Cont) of
+                {error, Reason} ->
+                    {error, Reason};
+                {Cont2, Terms} ->
+                    {Terms, sort_disk_log_input(ReadLog, Cont2)};
+                {Cont2, Terms, _Badbytes} ->
+                    {Terms, sort_disk_log_input(ReadLog, Cont2)};
+                eof ->
+                    end_of_input
+            end
+    end.
+
+sort_disk_log_output(WriteLog) ->
+    sort_disk_log_output(WriteLog, 1).
+
+sort_disk_log_output(WriteLog, Count) ->
+    fun(close) ->
+            ok;
+       (Terms) ->
+            %% Typical length of terms is on the order of 1-1500
+            %% e.g. [{Bucket1, Key1, missing|remote_missing|different}, ...]
+            if Count rem 100 == 0 ->
+                    disk_log:log_terms(WriteLog, Terms);
+               true ->
+                    disk_log:alog_terms(WriteLog, Terms)
+            end,
+            sort_disk_log_output(WriteLog, Count + 1)
+    end.
+
+fold_disk_log(Fun, Acc, DiskLog) ->
+    fold_disk_log(disk_log:chunk(DiskLog, start), Fun, Acc, DiskLog).
+
+fold_disk_log(eof, _Fun, Acc, _DiskLog) ->
+    Acc;
+fold_disk_log({Cont, Terms}, Fun, Acc, DiskLog) ->
+    Acc2 = try
+               lists:foldl(Fun, Acc, Terms)
+           catch X:Y ->
+                   lager:error("~s:fold_disk_log: caught ~p ~p @ ~p\n",
+                               [?MODULE, X, Y, erlang:get_stacktrace()]),
+                   Acc
+           end,
+    fold_disk_log(disk_log:chunk(DiskLog, Cont), Fun, Acc2, DiskLog).

--- a/src/riak_core_exchange_fsm.erl
+++ b/src/riak_core_exchange_fsm.erl
@@ -286,7 +286,7 @@ read_repair_keydiff(VNode, LocalVN, RemoteVN, {Bucket, Key, _Reason}) ->
     %% lager:debug("Anti-entropy forced read repair: ~p/~p", [Bucket, Key]),
     VNode:aae_repair(Bucket, Key),
     %% Force vnodes to update AAE tree in case read repair wasn't triggered
-    VNode:rehash([LocalVN, RemoteVN], Bucket, Key),
+    riak_core_aae_vnode:rehash(VNode:master(), [LocalVN, RemoteVN], Bucket, Key),
     ok.
 
 %% @private

--- a/src/riak_core_index_hashtree.erl
+++ b/src/riak_core_index_hashtree.erl
@@ -1,0 +1,700 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% This is a direct copy of:
+%% https://github.com/basho/riak_kv/blob/develop/src/riak_kv_index_hashtree.erl
+%% -------------------------------------------------------------------
+
+%% @doc
+%% This module implements a gen_server process that manages a set of hashtrees
+%% (see {@link hashtree}) containing key/hash pairs for all data owned by a
+%% given partition. Each riak_kv vnode spawns its own index_hashtree. These
+%% hashtrees are used for active anti-entropy exchange between vnodes.
+
+-module(riak_core_index_hashtree).
+-behaviour(gen_server).
+
+%% API
+-export([start/5, start_link/4]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-export([get_lock/2,
+         compare/3,
+         compare/4,
+         compare/5,
+         exchange_bucket/4,
+         exchange_segment/3,
+         update/2,
+         start_exchange_remote/4,
+         delete/2,
+         insert/4,
+         insert/5,
+         insert_object/3,
+         async_insert_object/3,
+         stop/1,
+         destroy/1]).
+
+-export([poke/1,
+         get_build_time/1]).
+
+-type index() :: non_neg_integer().
+-type index_n() :: {index(), pos_integer()}.
+-type orddict() :: orddict:orddict().
+-type proplist() :: proplists:proplist().
+-type riak_object_t2b() :: binary().
+-type hashtree() :: hashtree:hashtree().
+
+-record(state, {index,
+                vnode_pid,
+                vnode,
+                built,
+                lock :: undefined | reference(),
+                path,
+                build_time,
+                service,
+                trees}).
+
+-type state() :: #state{}.
+
+%% Time from build to expiration of tree, in millseconds
+-define(DEFAULT_EXPIRE, 604800000). %% 1 week
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%% @doc Spawn an index_hashtree process that manages the hashtrees (one
+%%      for each `index_n') for the specified partition index.
+-spec start(atom(), index(), nonempty_list(index_n()), pid(), atom()) -> {ok, pid()} |
+                                                                 {error, term()}.
+start(Service, Index, IndexNs=[_|_], VNPid, VNode) ->
+    gen_server:start(?MODULE, [Service, Index, IndexNs, VNPid, VNode], []).
+
+%% @doc Spawn an index_hashtree process that manages the hashtrees (one
+%%      for each `index_n') for the specified partition index.
+-spec start_link(atom(), index(), nonempty_list(index_n()), pid()) -> {ok, pid()} |
+                                                              {error, term()}.
+start_link(Service, Index, IndexNs=[_|_], VNPid) ->
+    gen_server:start_link(?MODULE, [Service, Index, IndexNs, VNPid], []).
+
+%% @doc Add a key/hash pair to the tree identified by the given tree id
+%%      that is managed by the provided index_hashtree pid.
+-spec insert(index_n(), binary(), binary(), pid()) -> ok.
+insert(Id, Key, Hash, Tree) ->
+    insert(Id, Key, Hash, Tree, []).
+
+%% @doc A variant of {@link insert/4} that accepts a list of options.
+%%      Valid options:
+%%       ``if_missing'' :: Only insert the key/hash pair if the key does not
+%%                         already exist in the hashtree.
+-spec insert(index_n(), binary(), binary(), pid(), proplist()) -> ok.
+insert(_Id, _Key, _Hash, undefined, _Options) ->
+    ok;
+insert(Id, Key, Hash, Tree, Options) ->
+    catch gen_server:call(Tree, {insert, Id, Key, Hash, Options}, infinity).
+
+%% @doc Add an encoded (binary) riak_object associated with a given
+%%      bucket/key to the appropriate hashtree managed by the provided
+%%      index_hashtree pid. The hash value is generated using
+%%      {@link hash_object/2}. Any encoding version is supported. The encoding
+%%      will be changed to the appropriate version before hashing the object.
+-spec insert_object({binary(), binary()}, riak_object_t2b(), pid()) -> ok.
+insert_object(_BKey, _RObj, undefined) ->
+    ok;
+insert_object(BKey, RObj, Tree) ->
+    catch gen_server:call(Tree, {insert_object, BKey, RObj}, infinity).
+
+%% @doc Asynchronous version of {@link insert_object/3}.
+async_insert_object(BKey, RObj, Tree) ->
+    gen_server:cast(Tree, {insert_object, BKey, RObj}).
+
+%% @doc Remove the key/hash pair associated with a given bucket/key from the
+%%      appropriate hashtree managed by the provided index_hashtree pid.
+-spec delete({binary(), binary()}, pid()) -> ok.
+delete(_BKey, undefined) ->
+    ok;
+delete(BKey, Tree) ->
+    catch gen_server:call(Tree, {delete, BKey}, infinity).
+
+%% @doc Called by the entropy manager to finish the process used to acquire
+%%      remote vnode locks when starting an exchange. For more details,
+%%      see {@link riak_kv_entropy_manager:start_exchange_remote/3}
+-spec start_exchange_remote(pid(), term(), index_n(), pid()) -> ok.
+start_exchange_remote(FsmPid, From, IndexN, Tree) ->
+    gen_server:cast(Tree, {start_exchange_remote, FsmPid, From, IndexN}).
+
+%% @doc Update all hashtrees managed by the provided index_hashtree pid.
+-spec update(index_n(), pid()) -> ok | not_responsible.
+update(Id, Tree) ->
+    gen_server:call(Tree, {update_tree, Id}, infinity).
+
+%% @doc Return a hash bucket from the tree identified by the given tree id
+%%      that is managed by the provided index_hashtree.
+-spec exchange_bucket(index_n(), integer(), integer(), pid()) -> orddict().
+exchange_bucket(Id, Level, Bucket, Tree) ->
+    gen_server:call(Tree, {exchange_bucket, Id, Level, Bucket}, infinity).
+
+%% @doc Return a segment from the tree identified by the given tree id that
+%%      is managed by the provided index_hashtree.
+-spec exchange_segment(index_n(), integer(), pid()) -> orddict().
+exchange_segment(Id, Segment, Tree) ->
+    gen_server:call(Tree, {exchange_segment, Id, Segment}, infinity).
+
+%% @doc Start the key exchange between a given tree managed by the
+%%      provided index_hashtree and a remote tree accessed through the
+%%      provided remote function.
+-spec compare(index_n(), hashtree:remote_fun(), pid()) -> [hashtree:keydiff()].
+compare(Id, Remote, Tree) ->
+    compare(Id, Remote, undefined, Tree).
+
+%% @doc A variant of {@link compare/3} that takes a key difference accumulator
+%%      function as an additional parameter.
+-spec compare(index_n(), hashtree:remote_fun(),
+              undefined | hashtree:acc_fun(T), pid()) -> T.
+compare(Id, Remote, AccFun, Tree) ->
+    compare(Id, Remote, AccFun, [], Tree).
+
+%% @doc A variant of {@link compare/3} that takes a key difference accumulator
+%%      function as an additional parameter.
+-spec compare(index_n(), hashtree:remote_fun(),
+              undefined | hashtree:acc_fun(T), any(), pid()) -> T.
+compare(Id, Remote, AccFun, Acc, Tree) ->
+    gen_server:call(Tree, {compare, Id, Remote, AccFun, Acc}, infinity).
+
+%% @doc Acquire the lock for the specified index_hashtree if not already
+%%      locked, and associate the lock with the calling process.
+-spec get_lock(pid(), any()) -> ok | not_built | already_locked.
+get_lock(Tree, Type) ->
+    get_lock(Tree, Type, self()).
+
+%% @doc Acquire the lock for the specified index_hashtree if not already
+%%      locked, and associate the lock with the provided pid.
+-spec get_lock(pid(), any(), pid()) -> ok | not_built | already_locked.
+get_lock(Tree, Type, Pid) ->
+    gen_server:call(Tree, {get_lock, Type, Pid}, infinity).
+
+%% @doc Poke the specified index_hashtree to ensure the tree is
+%%      built/rebuilt as needed. This is periodically called by the
+%%      {@link riak_kv_entropy_manager}.
+-spec poke(pid()) -> ok.
+poke(Tree) ->
+    gen_server:cast(Tree, poke).
+
+%% @doc Terminate the specified index_hashtree.
+stop(Tree) ->
+    gen_server:cast(Tree, stop).
+
+%% @doc Destroy the specified index_hashtree, which will destroy all
+%%      associated hashtrees and terminate.
+-spec destroy(pid()) -> ok.
+destroy(Tree) ->
+    gen_server:call(Tree, destroy, infinity).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([Service, Index, IndexNs, VNPid, VNode]) ->
+    case determine_data_root() of
+        undefined ->
+            case riak_core_entropy_manager:enabled() of
+                true ->
+                    lager:warning("Neither riak_kv/anti_entropy_data_dir or "
+                                  "riak_core/platform_data_dir are defined. "
+                                  "Disabling active anti-entropy."),
+                    riak_core_entropy_manager:disable(Service);
+                false ->
+                    ok
+            end,
+            ignore;
+        Root ->
+            Path = filename:join(Root, integer_to_list(Index)),
+            monitor(process, VNPid),
+
+            State = #state{index=Index,
+                           vnode_pid=VNPid,
+                           trees=orddict:new(),
+                           built=false,
+                           vnode=VNode,
+                           service=Service,
+                           path=Path},
+            State2 = init_trees(IndexNs, State),
+            {ok, State2}
+    end.
+
+handle_call({new_tree, Id}, _From, State) ->
+    State2 = do_new_tree(Id, State),
+    {reply, ok, State2};
+
+handle_call({get_lock, Type, Pid}, _From, State) ->
+    {Reply, State2} = do_get_lock(Type, Pid, State),
+    {reply, Reply, State2};
+
+handle_call({insert, Id, Key, Hash, Options}, _From, State) ->
+    State2 = do_insert(Id, Key, Hash, Options, State),
+    {reply, ok, State2};
+handle_call({insert_object, BKey, RObj}, _From, State) ->
+    VNode = State#state.vnode,
+    IndexN = riak_core_util2:get_index_n(BKey),
+    State2 = do_insert(IndexN, term_to_binary(BKey), VNode:hash_object(BKey, RObj), [], State),
+    {reply, ok, State2};
+handle_call({delete, BKey}, _From, State) ->
+    IndexN = riak_core_util2:get_index_n(BKey),
+    State2 = do_delete(IndexN, term_to_binary(BKey), State),
+    {reply, ok, State2};
+
+handle_call({update_tree, Id}, From, State) ->
+    lager:debug("Updating tree: (vnode)=~p (preflist)=~p", [State#state.index, Id]),
+    apply_tree(Id,
+               fun(Tree) ->
+                       {SnapTree, Tree2} = hashtree:update_snapshot(Tree),
+                       spawn_link(fun() ->
+                                          hashtree:update_perform(SnapTree),
+                                          gen_server:reply(From, ok)
+                                  end),
+                       {noreply, Tree2}
+               end,
+               State);
+
+handle_call({exchange_bucket, Id, Level, Bucket}, _From, State) ->
+    apply_tree(Id,
+               fun(Tree) ->
+                       Result = hashtree:get_bucket(Level, Bucket, Tree),
+                       {Result, Tree}
+               end,
+               State);
+
+handle_call({exchange_segment, Id, Segment}, _From, State) ->
+    apply_tree(Id,
+               fun(Tree) ->
+                       [{_, Result}] = hashtree:key_hashes(Tree, Segment),
+                       {Result, Tree}
+               end,
+               State);
+
+handle_call({compare, Id, Remote, AccFun, Acc}, From, State) ->
+    do_compare(Id, Remote, AccFun, Acc, From, State),
+    {noreply, State};
+
+handle_call(destroy, _From, State) ->
+    State2 = destroy_trees(State),
+    {stop, normal, ok, State2};
+
+handle_call(_Request, _From, State) ->
+    Reply = ok,
+    {reply, Reply, State}.
+
+handle_cast(poke, State) ->
+    State2 = do_poke(State),
+    {noreply, State2};
+
+handle_cast(stop, State) ->
+    close_trees(State),
+    {stop, normal, State};
+
+handle_cast({insert_object, BKey, RObj}, State) ->
+    VNode = State#state.vnode,
+    IndexN = riak_core_util2:get_index_n(BKey),
+    State2 = do_insert(IndexN, term_to_binary(BKey), VNode:hash_object(BKey, RObj), [], State),
+    {noreply, State2};
+
+handle_cast(build_failed, State) ->
+    riak_core_entropy_manager:requeue_poke(State#state.service,
+                                           State#state.index),
+    State2 = State#state{built=false},
+    {noreply, State2};
+handle_cast(build_finished, State) ->
+    State2 = do_build_finished(State),
+    {noreply, State2};
+
+handle_cast({start_exchange_remote, FsmPid, From, _IndexN}, State) ->
+    %% Concurrency lock already acquired, try to acquire tree lock.
+    case do_get_lock(remote_fsm, FsmPid, State) of
+        {ok, State2} ->
+            gen_server:reply(From, {remote_exchange, self()}),
+            {noreply, State2};
+        {Reply, State2} ->
+            gen_server:reply(From, {remote_exchange, Reply}),
+            {noreply, State2}
+    end;
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({'DOWN', _, _, Pid, _}, State) when Pid == State#state.vnode_pid ->
+    %% vnode has terminated, exit as well
+    close_trees(State),
+    {stop, normal, State};
+handle_info({'DOWN', Ref, _, _, _}, State) ->
+    State2 = maybe_release_lock(Ref, State),
+    {noreply, State2};
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+determine_data_root() ->
+    case application:get_env(riak_core, anti_entropy_data_dir) of
+        {ok, EntropyRoot} ->
+            EntropyRoot;
+        undefined ->
+            case application:get_env(riak_core, platform_data_dir) of
+                {ok, PlatformRoot} ->
+                    Root = filename:join(PlatformRoot, "anti_entropy"),
+                    lager:warning("Config riak_kv/anti_entropy_data_dir is "
+                                  "missing. Defaulting to: ~p", [Root]),
+                    application:set_env(riak_core, anti_entropy_data_dir, Root),
+                    Root;
+                undefined ->
+                    undefined
+            end
+    end.
+
+-spec init_trees([index_n()], state()) -> state().
+init_trees(IndexNs, State) ->
+    State2 = lists:foldl(fun(Id, StateAcc) ->
+                                 do_new_tree(Id, StateAcc)
+                         end, State, IndexNs),
+    State2#state{built=false}.
+
+-spec load_built(state()) -> boolean().
+load_built(#state{trees=Trees}) ->
+    {_,Tree0} = hd(Trees),
+    case hashtree:read_meta(<<"built">>, Tree0) of
+        {ok, <<1>>} ->
+            true;
+        _ ->
+            false
+    end.
+
+%% Fold over a given vnode's data, inserting each object into the appropriate
+%% hashtree. Use the `if_missing' option to only insert the key/hash pair if
+%% the key does not already exist in the tree. This allows real-time updates
+%% to the hashtree to occur concurrently with the fold. For example, if an
+%% incoming write triggers a real-time insert of a key/hash pair for an object
+%% before the fold reaches the now out-of-date version of the object, the old
+%% key/hash pair will be ignored.
+-spec fold_keys(index(), pid(), atom()) -> ok.
+fold_keys(Partition, Tree, VNode) ->
+    Req = riak_core_util:make_fold_req(
+            fun(BKey={Bucket,Key}, RObj, _) ->
+                    IndexN = riak_core_util2:get_index_n({Bucket, Key}),
+                    insert(IndexN, term_to_binary(BKey), VNode:hash_object(BKey, RObj),
+                           Tree, [if_missing]),
+                    ok
+            end,
+            ok, false, [aae_reconstruction]),
+    riak_core_vnode_master:sync_command({Partition, node()},
+                                        Req,
+                                        VNode:master(), infinity),
+    ok.
+
+%% Generate a new {@link hashtree} for the specified `index_n'. If this is
+%% the first hashtree created by this index_hashtree, then open/create a new
+%% on-disk store at `segment_path'. Otherwise, re-use the store from the first
+%% tree. In other words, all hashtrees for a given index_hashtree are stored in
+%% the same on-disk store.
+-spec do_new_tree(index_n(), state()) -> state().
+do_new_tree(Id, State=#state{trees=Trees, path=Path}) ->
+    Index = State#state.index,
+    IdBin = tree_id(Id),
+    NewTree = case Trees of
+                  [] ->
+                      hashtree:new({Index,IdBin}, [{segment_path, Path}]);
+                  [{_,Other}|_] ->
+                      hashtree:new({Index,IdBin}, Other)
+              end,
+    Trees2 = orddict:store(Id, NewTree, Trees),
+    State#state{trees=Trees2}.
+
+-spec do_get_lock(any(), pid(), state()) -> {not_built | ok | already_locked, state()}.
+do_get_lock(_, _, State) when State#state.built /= true ->
+    lager:debug("Not built: ~p :: ~p", [State#state.index, State#state.built]),
+    {not_built, State};
+do_get_lock(_Type, Pid, State=#state{lock=undefined}) ->
+    Ref = monitor(process, Pid),
+    State2 = State#state{lock=Ref},
+    {ok, State2};
+do_get_lock(_, _, State) ->
+    lager:debug("Already locked: ~p", [State#state.index]),
+    {already_locked, State}.
+
+-spec maybe_release_lock(reference(), state()) -> state().
+maybe_release_lock(Ref, State) ->
+    case State#state.lock of
+        Ref ->
+            State#state{lock=undefined};
+        _ ->
+            State
+    end.
+
+%% Utility function for passing a specific hashtree into a provided function
+%% and storing the possibly-modified hashtree back in the index_hashtree state.
+-spec apply_tree(index_n(),
+                 fun((hashtree()) -> {'noreply' | any(), hashtree()}),
+                 state())
+                -> {'reply', 'not_responsible', state()} |
+                   {'reply', any(), state()} |
+                   {'noreply', state()}.
+apply_tree(Id, Fun, State=#state{trees=Trees}) ->
+    case orddict:find(Id, Trees) of
+        error ->
+            {reply, not_responsible, State};
+        {ok, Tree} ->
+            {Result, Tree2} = Fun(Tree),
+            Trees2 = orddict:store(Id, Tree2, Trees),
+            State2 = State#state{trees=Trees2},
+            case Result of
+                noreply ->
+                    {noreply, State2};
+                _ ->
+                    {reply, Result, State2}
+            end
+    end.
+
+-spec do_build_finished(state()) -> state().
+do_build_finished(State=#state{index=Index, built=_Pid, service=Service}) ->
+    lager:debug("Finished build (b): ~p", [Index]),
+    {_,Tree0} = hd(State#state.trees),
+    BuildTime = get_build_time(Tree0),
+    hashtree:write_meta(<<"built">>, <<1>>, Tree0),
+    hashtree:write_meta(<<"build_time">>, term_to_binary(BuildTime), Tree0),
+    riak_core_entropy_info:tree_built(Service, Index, BuildTime),
+    State#state{built=true, build_time=BuildTime}.
+
+%% Determine the build time for all trees associated with this
+%% index. The build time is stored as metadata in the on-disk file. If
+%% the tree was rehashed after a restart, this function should return
+%% the original build time. If this is a newly created tree (or if the
+%% on-disk time is invalid), the function returns the current time.
+-spec get_build_time(hashtree()) -> calendar:t_now().
+get_build_time(Tree) ->
+    Time = case hashtree:read_meta(<<"build_time">>, Tree) of
+               {ok, TimeBin} ->
+                   binary_to_term(TimeBin);
+               _ ->
+                   undefined
+           end,
+    case valid_time(Time) of
+        true ->
+            Time;
+        false ->
+            os:timestamp()
+    end.
+
+valid_time({X,Y,Z}) when is_integer(X) and is_integer(Y) and is_integer(Z) ->
+    true;
+valid_time(_) ->
+    false.
+
+-spec do_insert(index_n(), binary(), binary(), proplist(), state()) -> state().
+do_insert(Id, Key, Hash, Opts, State=#state{trees=Trees}) ->
+    case orddict:find(Id, Trees) of
+        {ok, Tree} ->
+            Tree2 = hashtree:insert(Key, Hash, Tree, Opts),
+            Trees2 = orddict:store(Id, Tree2, Trees),
+            State#state{trees=Trees2};
+        _ ->
+            State2 = handle_unexpected_key(Id, Key, State),
+            State2
+    end.
+
+-spec do_delete(index_n(), binary(), state()) -> state().
+do_delete(Id, Key, State=#state{trees=Trees}) ->
+    case orddict:find(Id, Trees) of
+        {ok, Tree} ->
+            Tree2 = hashtree:delete(Key, Tree),
+            Trees2 = orddict:store(Id, Tree2, Trees),
+            State#state{trees=Trees2};
+        _ ->
+            State2 = handle_unexpected_key(Id, Key, State),
+            State2
+    end.
+
+-spec handle_unexpected_key(index_n(), binary(), state()) -> state().
+handle_unexpected_key(Id, Key, State=#state{index=Partition}) ->
+    RP = riak_core_util2:responsible_preflists(Partition),
+    case lists:member(Id, RP) of
+        false ->
+            %% The encountered object does not belong to any preflists thata
+            %% this partition is associated with. Under normal Riak operation,
+            %% this should only happen when the `n_val' for an object is
+            %% reduced. For example, write an object with N=3, then change N to
+            %% 2. There will be an extra replica of the object that is no
+            %% longer needed. We should probably just delete these objects, but
+            %% to be safe rather than sorry, the first version of AAE simply
+            %% ignores these objects.
+            %%
+            %% TODO: We should probably remove these warnings before final
+            %%       release, as reducing N will result in a ton of log/console
+            %%       spam.
+            %% lager:warning("Object ~p encountered during fold over partition "
+            %%               "~p, but key does not hash to an index handled by "
+            %%               "this partition", [Key, Partition]),
+            State;
+        true ->
+            %% The encountered object belongs to a preflist that is currently
+            %% associated with this partition, but was not when the
+            %% index_hashtree process was created. This occurs when increasing
+            %% the `n_val' for an object. For example, write an object with N=3
+            %% and it will map to the index/n preflist `{<index>, 3}'. Increase
+            %% N to 4, and the object now maps to preflist '{<index>, 4}' which
+            %% may not have an existing hashtree if there were previously no
+            %% objects with N=4.
+            lager:info("Partition/tree ~p/~p does not exist to hold object ~p",
+                       [Partition, Id, Key]),
+            case State#state.built of
+                true ->
+                    %% If the tree is already built, clear the tree to trigger
+                    %% a rebuild that will re-distribute objects into the
+                    %% proper hashtrees based on current N values.
+                    lager:info("Clearing tree to trigger future rebuild"),
+                    clear_tree(State);
+                _ ->
+                    %% Initialize a new index_n tree to prevent future errors.
+                    %% The various hashtrees will likely be inconsistent, with
+                    %% some trees containing key/hash pairs that should be in
+                    %% other trees (eg. due to a change in N value). This will
+                    %% be resolved whenever trees are eventually rebuilt, either
+                    %% after normal expiration or after a future unexpected value
+                    %% triggers the alternate case clause above.
+                    State2 = do_new_tree(Id, State),
+                    State2
+            end
+    end.
+
+-spec tree_id(index_n()) -> hashtree:tree_id_bin().
+tree_id({Index, N}) ->
+    %% hashtree is hardcoded for 22-byte (176-bit) tree id
+    <<Index:160/integer,N:16/integer>>;
+tree_id(_) ->
+    erlang:error(badarg).
+
+-spec do_compare(index_n(), hashtree:remote_fun(), hashtree:acc_fun(any()),
+                 any(), term(), state()) -> ok.
+do_compare(Id, Remote, AccFun, Acc, From, State) ->
+    case orddict:find(Id, State#state.trees) of
+        error ->
+            %% This case shouldn't happen, but might as well safely handle it.
+            lager:warning("Tried to compare nonexistent tree "
+                          "(vnode)=~p (preflist)=~p", [State#state.index, Id]),
+            gen_server:reply(From, []);
+        {ok, Tree} ->
+            spawn_link(fun() ->
+                               Remote(init, self()),
+                               Result = hashtree:compare(Tree, Remote,
+                                                         AccFun, Acc),
+                               Remote(final, self()),
+                               gen_server:reply(From, Result)
+                       end)
+    end,
+    ok.
+
+-spec do_poke(state()) -> state().
+do_poke(State) ->
+    lager:debug("[~p] Poked!", [self()]),
+    State1 = maybe_clear(State),
+    State2 = maybe_build(State1),
+    State2.
+
+%% If past expiration, clear all hashtrees.
+-spec maybe_clear(state()) -> state().
+maybe_clear(State=#state{lock=undefined, built=true}) ->
+    Diff = timer:now_diff(os:timestamp(), State#state.build_time),
+    Expire = app_helper:get_env(riak_core,
+                                anti_entropy_expire,
+                                ?DEFAULT_EXPIRE),
+    %% Need to convert from millsec to microsec
+    case Diff > (Expire * 1000) of
+        true ->
+            clear_tree(State);
+        false ->
+            State
+    end;
+maybe_clear(State) ->
+    State.
+
+-spec clear_tree(state()) -> state().
+clear_tree(State=#state{index=Index}) ->
+    lager:debug("Clearing tree ~p", [State#state.index]),
+    State2 = destroy_trees(State),
+    IndexNs = riak_core_util2:responsible_preflists(Index),
+    State3 = init_trees(IndexNs, State2#state{trees=orddict:new()}),
+    State3#state{built=false}.
+
+destroy_trees(State) ->
+    State2 = close_trees(State),
+    {_,Tree0} = hd(State2#state.trees),
+    hashtree:destroy(Tree0),
+    State2.
+
+-spec maybe_build(state()) -> state().
+maybe_build(State=#state{built=false}) ->
+    Self = self(),
+    Pid = spawn_link(fun() ->
+                             build_or_rehash(Self, State)
+                     end),
+    State#state{built=Pid};
+maybe_build(State) ->
+    %% Already built or build in progress
+    State.
+
+%% If the on-disk data is not marked as previously being built, then trigger
+%% a fold/build. Otherwise, trigger a rehash to ensure the hashtrees match the
+%% current on-disk segments.
+-spec build_or_rehash(pid(), state()) -> ok.
+build_or_rehash(Self, State=#state{index=Index, trees=Trees,
+                                   service=Service}) ->
+    Type = case load_built(State) of
+               false -> build;
+               true  -> rehash
+           end,
+    lager:debug("We're build or rehashing data so we figured we will: ~p",
+                [Type]),
+    Lock = riak_core_entropy_manager:get_lock(Service, Type),
+    case {Lock, Type} of
+        {ok, build} ->
+            lager:debug("Starting build: ~p", [Index]),
+            fold_keys(Index, Self, State#state.vnode),
+            lager:debug("Finished build (a): ~p", [Index]),
+            gen_server:cast(Self, build_finished);
+        {ok, rehash} ->
+            lager:debug("Starting rehash: ~p", [Index]),
+            [hashtree:rehash_tree(T) || {_,T} <- Trees],
+            lager:debug("Finished rehash (a): ~p", [Index]),
+            gen_server:cast(Self, build_finished);
+        {Error, E} ->
+            lager:debug("Build failed(~p): ~p/~p", [Index, Error, E]),
+            gen_server:cast(Self, build_failed)
+    end.
+
+close_trees(State=#state{trees=Trees}) ->
+    Trees2 = [{IdxN, hashtree:close(Tree)} || {IdxN, Tree} <- Trees],
+    State#state{trees=Trees2}.

--- a/src/riak_core_index_hashtree.erl
+++ b/src/riak_core_index_hashtree.erl
@@ -23,7 +23,7 @@
 %% @doc
 %% This module implements a gen_server process that manages a set of hashtrees
 %% (see {@link hashtree}) containing key/hash pairs for all data owned by a
-%% given partition. Each riak_kv vnode spawns its own index_hashtree. These
+%% given partition. Each riak_core vnode spawns its own index_hashtree. These
 %% hashtrees are used for active anti-entropy exchange between vnodes.
 
 -module(riak_core_index_hashtree).
@@ -136,7 +136,7 @@ delete(BKey, Tree) ->
 
 %% @doc Called by the entropy manager to finish the process used to acquire
 %%      remote vnode locks when starting an exchange. For more details,
-%%      see {@link riak_kv_entropy_manager:start_exchange_remote/3}
+%%      see {@link riak_core_entropy_manager:start_exchange_remote/3}
 -spec start_exchange_remote(pid(), term(), index_n(), pid()) -> ok.
 start_exchange_remote(FsmPid, From, IndexN, Tree) ->
     gen_server:cast(Tree, {start_exchange_remote, FsmPid, From, IndexN}).
@@ -193,7 +193,7 @@ get_lock(Tree, Type, Pid) ->
 
 %% @doc Poke the specified index_hashtree to ensure the tree is
 %%      built/rebuilt as needed. This is periodically called by the
-%%      {@link riak_kv_entropy_manager}.
+%%      {@link riak_core_entropy_manager}.
 -spec poke(pid()) -> ok.
 poke(Tree) ->
     gen_server:cast(Tree, poke).
@@ -217,7 +217,7 @@ init([Service, Index, IndexNs, VNPid, VNode]) ->
         undefined ->
             case riak_core_entropy_manager:enabled() of
                 true ->
-                    lager:warning("Neither riak_kv/anti_entropy_data_dir or "
+                    lager:warning("Neither riak_core/anti_entropy_data_dir or "
                                   "riak_core/platform_data_dir are defined. "
                                   "Disabling active anti-entropy."),
                     riak_core_entropy_manager:disable(Service);
@@ -368,7 +368,7 @@ determine_data_root() ->
             case application:get_env(riak_core, platform_data_dir) of
                 {ok, PlatformRoot} ->
                     Root = filename:join(PlatformRoot, "anti_entropy"),
-                    lager:warning("Config riak_kv/anti_entropy_data_dir is "
+                    lager:warning("Config riak_core/anti_entropy_data_dir is "
                                   "missing. Defaulting to: ~p", [Root]),
                     application:set_env(riak_core, anti_entropy_data_dir, Root),
                     Root;

--- a/src/riak_core_index_hashtree.erl
+++ b/src/riak_core_index_hashtree.erl
@@ -253,11 +253,11 @@ handle_call({insert, Id, Key, Hash, Options}, _From, State) ->
     {reply, ok, State2};
 handle_call({insert_object, BKey, RObj}, _From, State) ->
     VNode = State#state.vnode,
-    IndexN = riak_core_util2:get_index_n(BKey),
+    IndexN = riak_core_util:get_index_n(BKey),
     State2 = do_insert(IndexN, term_to_binary(BKey), VNode:hash_object(BKey, RObj), [], State),
     {reply, ok, State2};
 handle_call({delete, BKey}, _From, State) ->
-    IndexN = riak_core_util2:get_index_n(BKey),
+    IndexN = riak_core_util:get_index_n(BKey),
     State2 = do_delete(IndexN, term_to_binary(BKey), State),
     {reply, ok, State2};
 
@@ -312,7 +312,7 @@ handle_cast(stop, State) ->
 
 handle_cast({insert_object, BKey, RObj}, State) ->
     VNode = State#state.vnode,
-    IndexN = riak_core_util2:get_index_n(BKey),
+    IndexN = riak_core_util:get_index_n(BKey),
     State2 = do_insert(IndexN, term_to_binary(BKey), VNode:hash_object(BKey, RObj), [], State),
     {noreply, State2};
 
@@ -405,7 +405,7 @@ load_built(#state{trees=Trees}) ->
 fold_keys(Partition, Tree, VNode) ->
     Req = riak_core_util:make_fold_req(
             fun(BKey={Bucket,Key}, RObj, _) ->
-                    IndexN = riak_core_util2:get_index_n({Bucket, Key}),
+                    IndexN = riak_core_util:get_index_n({Bucket, Key}),
                     insert(IndexN, term_to_binary(BKey), VNode:hash_object(BKey, RObj),
                            Tree, [if_missing]),
                     ok
@@ -540,7 +540,7 @@ do_delete(Id, Key, State=#state{trees=Trees}) ->
 
 -spec handle_unexpected_key(index_n(), binary(), state()) -> state().
 handle_unexpected_key(Id, Key, State=#state{index=Partition}) ->
-    RP = riak_core_util2:responsible_preflists(Partition),
+    RP = riak_core_util:responsible_preflists(Partition),
     case lists:member(Id, RP) of
         false ->
             %% The encountered object does not belong to any preflists thata
@@ -645,7 +645,7 @@ maybe_clear(State) ->
 clear_tree(State=#state{index=Index}) ->
     lager:debug("Clearing tree ~p", [State#state.index]),
     State2 = destroy_trees(State),
-    IndexNs = riak_core_util2:responsible_preflists(Index),
+    IndexNs = riak_core_util:responsible_preflists(Index),
     State3 = init_trees(IndexNs, State2#state{trees=orddict:new()}),
     State3#state{built=false}.
 

--- a/src/riak_core_index_hashtree.erl
+++ b/src/riak_core_index_hashtree.erl
@@ -422,12 +422,15 @@ fold_keys(Partition, Tree, VNode) ->
 %% tree. In other words, all hashtrees for a given index_hashtree are stored in
 %% the same on-disk store.
 -spec do_new_tree(index_n(), state()) -> state().
-do_new_tree(Id, State=#state{trees=Trees, path=Path}) ->
+do_new_tree(Id, State=#state{trees=Trees, path=Path, service=Service}) ->
     Index = State#state.index,
     IdBin = tree_id(Id),
     NewTree = case Trees of
                   [] ->
-                      hashtree:new({Index,IdBin}, [{segment_path, Path}]);
+                      hashtree:new(
+                        {Index,IdBin},
+                        [{segment_path,
+                          filename:join(Path, atom_to_list(Service))}]);
                   [{_,Other}|_] ->
                       hashtree:new({Index,IdBin}, Other)
               end,

--- a/src/riak_core_index_hashtree.erl
+++ b/src/riak_core_index_hashtree.erl
@@ -17,7 +17,7 @@
 %% under the License.
 %%
 %% This is a direct copy of:
-%% https://github.com/basho/riak_kv/blob/develop/src/riak_kv_index_hashtree.erl
+%% https://github.com/basho/riak_kv/blob/develop/src/riak_kvgi_index_hashtree.erl
 %% -------------------------------------------------------------------
 
 %% @doc


### PR DESCRIPTION
So,
I've started moving AAE from riak_kv to riak_core. It misses documentation and is not too well tested but it seems to work in first tests.

It changes the interface to the AAE code slightly by adding two more options that get passed:
- The ring serivce (formerly riak_kv)
- The responsible vnode module

This allows to run AAE for services other then _kv and also for multiple services on the same ring.

There is a riak_core_aae_vnode behavior that includes the functions the vnode needs to implement. And there still needs to move some code in there that is fairly general.

So please don't merge yet it's mostly to track progress and collect comments on the effort (and hopefully fine some people giving it a test :P)
