### PR TITLE
Add EQC statem property for vclock. [rebased]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ ebin/*
 include/*_pb.hrl
 *~
 doc/*
+/.eqc-info
+/current_counterexample.eqc

--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -31,9 +31,19 @@
 
 -module(vclock).
 
--export([fresh/0,descends/2,merge/1,get_counter/2,get_timestamp/2,
-	increment/2,increment/3,all_nodes/1,equal/2,prune/3,timestamp/0]).
--export([fresh/2]).
+-export([fresh/0,
+         fresh/2,
+         descends/2,
+         dominates/2,
+         merge/1,
+         get_counter/2,
+         get_timestamp/2,
+         increment/2,
+         increment/3,
+         all_nodes/1,
+         equal/2,
+         prune/3,
+         timestamp/0]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -72,6 +82,10 @@ descends(Va, Vb) ->
         {_, {CtrA, _TSA}} ->
             (CtrA >= CtrB) andalso descends(Va,RestB)
         end.
+
+-spec dominates(vclock(), vclock()) -> boolean().
+dominates(A, B) ->
+    descends(A, B) andalso not descends(B, A).
 
 % @doc Combine all VClocks in the input list into their least possible
 %      common descendant.

--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -85,7 +85,7 @@ descends(Va, Vb) ->
 
 -spec dominates(vclock(), vclock()) -> boolean().
 dominates(A, B) ->
-    (not equal(A, B)) andalso descends(A, B).
+    descends(A, B) andalso not equal(A, B).
 
 % @doc Combine all VClocks in the input list into their least possible
 %      common descendant.

--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -85,7 +85,7 @@ descends(Va, Vb) ->
 
 -spec dominates(vclock(), vclock()) -> boolean().
 dominates(A, B) ->
-    descends(A, B) andalso not descends(B, A).
+    (not equal(A, B)) andalso descends(A, B).
 
 % @doc Combine all VClocks in the input list into their least possible
 %      common descendant.

--- a/test/vclock_qc.erl
+++ b/test/vclock_qc.erl
@@ -1,0 +1,81 @@
+-module(vclock_qc).
+
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eqc/include/eqc_statem.hrl").
+-define(ACTOR_IDS, [a,b,c,d,e]).
+-compile(export_all).
+
+-record(state,{vclock, model}).
+
+%% Initialize the state
+initial_state() ->
+    #state{vclock=vclock:fresh(),
+           model=orddict:from_list([{ID, 0} || ID <- ?ACTOR_IDS])
+          }.
+
+%% Command generator, S is the state
+command(S) ->
+    oneof([
+           {call, vclock, increment, [gen_actor_id(), S#state.vclock]},
+           {call, vclock, get_counter, [gen_actor_id(), S#state.vclock]},
+           {call, vclock, merge, [[gen_vclock(), S#state.vclock]]}
+          ]).
+
+%% Next state transformation, S is the current state
+next_state(S,V,{call,vclock,increment,[ActorId, _]}) ->
+    S#state{vclock=V,
+            model=orddict:update_counter(ActorId, 1, S#state.model)};
+next_state(S,_V,{call,vclock,get_counter,[_, _]}) ->
+    S;
+next_state(S,V,{call,vclock,merge,[[Other,_VClock]]}) ->
+    S#state{vclock=V, model=model_merge(S#state.model, Other)};
+next_state(S,_V,{call,_,_,_}) ->
+    S.
+
+%% Precondition, checked before command is added to the command sequence
+precondition(_S,{call,_,_,_}) ->
+    true.
+
+%% Postcondition, checked after command has been evaluated
+%% OBS: S is the state before next_state(S,_,<command>)
+postcondition(#state{model=M},{call,vclock,increment,[ActorId, Vclock]},Res) ->
+    %% Partial ordering property (descends)
+    vclock:descends(Res,Vclock) andalso
+    %% Counter has been incremented
+        vclock:get_counter(ActorId, Res) == orddict:fetch(ActorId,M) + 1;
+postcondition(#state{model=M}, {call,vclock,get_counter,[ActorId, _]}, Res) ->
+    %% The counter for a given actor is the same as the model
+    Res == orddict:fetch(ActorId, M);
+postcondition(#state{model=M}, {call,vclock,merge,[[Other,VClock]]}, Res) ->
+    %% The counter for a given actor is the same as the model
+    Merged = model_merge(M,Other),
+    lists:all(fun(A) -> orddict:fetch(A,Merged) == vclock:get_counter(A,Res) end, 
+              ?ACTOR_IDS) andalso
+        vclock:descends(Res, Other) andalso vclock:descends(Res, VClock);
+postcondition(_S, _C, _Res) ->
+    true.
+
+
+prop_vclock() ->
+    ?FORALL(Cmds,commands(?MODULE),
+            begin
+                {H,S,Res} = run_commands(?MODULE,Cmds),
+                aggregate(command_names(Cmds),
+                          pretty_commands(?MODULE,Cmds, {H,S,Res}, Res == ok))
+            end).
+
+gen_actor_id() ->
+    elements(?ACTOR_IDS).
+
+gen_vclock() ->
+    frequency([
+               {1, vclock:fresh()},
+               {3, ?LAZY(?LET({Actor, Vc},
+                              {gen_actor_id(), gen_vclock()},
+                              vclock:increment(Actor, Vc)))}
+              ]).
+
+model_merge(M, V) ->
+    orddict:map(fun(A,C) ->
+                        erlang:max(C,vclock:get_counter(A, V)) 
+                end, M).

--- a/test/vclock_qc.erl
+++ b/test/vclock_qc.erl
@@ -13,10 +13,18 @@
 
 -record(state, {vclocks = []}).
 
+-define(TEST_TIME, 20).
+
 eqc_test_() ->
     {timeout,
      60,
-     ?_assert(quickcheck(eqc:testing_time(20, more_commands(10,?QC_OUT(prop_vclock())))))}.
+     ?_assert(quickcheck(eqc:testing_time(?TEST_TIME, more_commands(10,?QC_OUT(prop_vclock())))))}.
+
+test() ->
+    quickcheck(eqc:testing_time(?TEST_TIME, more_commands(10, prop_vclock()))).
+
+test(Time) ->
+    quickcheck(eqc:testing_time(Time, more_commands(10, prop_vclock()))).
 
 
 %% Initialize the state

--- a/test/vclock_qc.erl
+++ b/test/vclock_qc.erl
@@ -1,11 +1,21 @@
 -module(vclock_qc).
 
+-ifdef(EQC).
+
 -include_lib("eqc/include/eqc.hrl").
 -include_lib("eqc/include/eqc_statem.hrl").
--define(ACTOR_IDS, [a,b,c,d,e]).
+-include_lib("eunit/include/eunit.hrl").
 -compile(export_all).
 
+-define(ACTOR_IDS, [a,b,c,d,e]).
+-define(QC_OUT(P),
+        eqc:on_output(fun(Str, Args) -> io:format(user, Str, Args) end, P)).
+
 -record(state,{vclock, model}).
+
+eqc_test_() ->
+    ?_assert(eqc:quickcheck(?QC_OUT(prop_vclock()))).
+
 
 %% Initialize the state
 initial_state() ->
@@ -79,3 +89,4 @@ model_merge(M, V) ->
     orddict:map(fun(A,C) ->
                         erlang:max(C,vclock:get_counter(A, V)) 
                 end, M).
+-endif.

--- a/test/vclock_qc.erl
+++ b/test/vclock_qc.erl
@@ -20,7 +20,7 @@ eqc_test_() ->
 %% Initialize the state
 initial_state() ->
     #state{vclock=vclock:fresh(),
-           model=orddict:from_list([{ID, 0} || ID <- ?ACTOR_IDS])
+           model=new_model()
           }.
 
 %% Command generator, S is the state
@@ -28,7 +28,7 @@ command(S) ->
     oneof([
            {call, vclock, increment, [gen_actor_id(), S#state.vclock]},
            {call, vclock, get_counter, [gen_actor_id(), S#state.vclock]},
-           {call, vclock, merge, [[gen_vclock(), S#state.vclock]]}
+           {call, ?MODULE, merge, [gen_vclock(), S#state.vclock]}
           ]).
 
 %% Next state transformation, S is the current state
@@ -37,8 +37,8 @@ next_state(S,V,{call,vclock,increment,[ActorId, _]}) ->
             model=orddict:update_counter(ActorId, 1, S#state.model)};
 next_state(S,_V,{call,vclock,get_counter,[_, _]}) ->
     S;
-next_state(S,V,{call,vclock,merge,[[Other,_VClock]]}) ->
-    S#state{vclock=V, model=model_merge(S#state.model, Other)};
+next_state(S,V,{call,_,merge,[{O,_}, _VClock]}) ->
+    S#state{vclock=V, model=model_merge(S#state.model, O)};
 next_state(S,_V,{call,_,_,_}) ->
     S.
 
@@ -56,11 +56,12 @@ postcondition(#state{model=M},{call,vclock,increment,[ActorId, Vclock]},Res) ->
 postcondition(#state{model=M}, {call,vclock,get_counter,[ActorId, _]}, Res) ->
     %% The counter for a given actor is the same as the model
     Res == orddict:fetch(ActorId, M);
-postcondition(#state{model=M}, {call,vclock,merge,[[Other,VClock]]}, Res) ->
-    %% The counter for a given actor is the same as the model
-    Merged = model_merge(M,Other),
+postcondition(#state{model=M}, {call,_,merge,[{OM,Other},VClock]}, Res) ->
+    Merged = model_merge(M, OM),
+    %% The merged state has all the same actor counts
     lists:all(fun(A) -> orddict:fetch(A,Merged) == vclock:get_counter(A,Res) end, 
               ?ACTOR_IDS) andalso
+        %% The merged vector clock descends from both inputs
         vclock:descends(Res, Other) andalso vclock:descends(Res, VClock);
 postcondition(_S, _C, _Res) ->
     true.
@@ -79,14 +80,21 @@ gen_actor_id() ->
 
 gen_vclock() ->
     frequency([
-               {1, vclock:fresh()},
-               {3, ?LAZY(?LET({Actor, Vc},
-                              {gen_actor_id(), gen_vclock()},
-                              vclock:increment(Actor, Vc)))}
+               {1, {new_model(), vclock:fresh()}},
+               {3, ?LAZY(gen_incr_vclock())}
               ]).
 
-model_merge(M, V) ->
-    orddict:map(fun(A,C) ->
-                        erlang:max(C,vclock:get_counter(A, V)) 
-                end, M).
+gen_incr_vclock() ->
+    ?LET({Actor, {M,Vc}},
+         {gen_actor_id(), gen_vclock()},
+         {orddict:update_counter(Actor, 1, M), vclock:increment(Actor, Vc)}).
+
+merge({_,O}, V) ->
+    vclock:merge([O,V]).
+
+model_merge(M,OM) ->
+    orddict:merge(fun(_K,A,B) -> erlang:max(A,B) end, M, OM).
+
+new_model() ->
+    orddict:from_list([{ID, 0} || ID <- ?ACTOR_IDS]).
 -endif.

--- a/test/vclock_qc.erl
+++ b/test/vclock_qc.erl
@@ -26,14 +26,17 @@ command(#state{vclocks=Vs}) ->
     oneof([{call, ?MODULE, fresh, []}] ++
           [{call, ?MODULE, increment, [gen_actor_id(), elements(Vs)]} || length(Vs) > 0] ++
           [{call, ?MODULE, get_counter, [gen_actor_id(), elements(Vs)]} || length(Vs) > 0] ++
-          [{call, ?MODULE, merge, [list(elements(Vs))]} || length(Vs) > 0] ++ 
-          [{call, ?MODULE, descends, [elements(Vs), elements(Vs)]} || length(Vs) > 0]
+          [{call, ?MODULE, merge, [list(elements(Vs))]} || length(Vs) > 0] ++
+          [{call, ?MODULE, descends, [elements(Vs), elements(Vs)]} || length(Vs) > 0] ++
+          [{call, ?MODULE, dominates, [elements(Vs), elements(Vs)]} || length(Vs) > 0]
           ).
 
 %% Next state transformation, S is the current state
 next_state(S,_V,{call,_,get_counter,[_, _]}) ->
     S;
 next_state(S,_V,{call,_,descends,[_, _]}) ->
+    S;
+next_state(S,_V,{call,_,dominates,[_, _]}) ->
     S;
 next_state(#state{vclocks=Vs}=S,V,{call,_,_,_}) ->
     S#state{vclocks=Vs ++ [V]}.
@@ -48,8 +51,10 @@ postcondition(_S, {call, _, get_counter, _}, {MRes, Res}) ->
     MRes == Res;
 postcondition(_S, {call, _, descends, _}, {MRes, Res}) ->
     MRes == Res;
+postcondition(_S, {call, _, dominates, _}, {MRes, Res}) ->
+    MRes == Res;
 postcondition(_S, {call, _, merge, [Items]}, {MRes, Res}) ->
-    model_compare(MRes, Res) andalso 
+    model_compare(MRes, Res) andalso
         lists:all(fun({_, V}) ->
                           vclock:descends(Res, V)
                   end, Items);
@@ -64,7 +69,8 @@ prop_vclock() ->
             begin
                 {H,S,Res} = run_commands(?MODULE,Cmds),
                 aggregate(command_names(Cmds),
-                          pretty_commands(?MODULE,Cmds, {H,S,Res}, Res == ok))
+                          collect({num_vclocks, length(S#state.vclocks) div 10},
+                                  pretty_commands(?MODULE,Cmds, {H,S,Res}, Res == ok)))
             end).
 
 gen_actor_id() ->
@@ -74,7 +80,7 @@ gen_vclock() ->
     ?SIZED(Size, gen_vclock(Size)).
 
 gen_vclock(Size) ->
-    ?LAZY(frequency([{1, {new_model(), vclock:fresh()}} ] ++ 
+    ?LAZY(frequency([{1, {new_model(), vclock:fresh()}} ] ++
               [ {3, gen_incr_vclock(Size - 1)} || Size > 0] ++
               [ {1, gen_merged_vclock(Size div 2)} || Size > 0 ])).
 
@@ -91,11 +97,12 @@ gen_incr_vclock(Size) ->
 fresh() ->
     {new_model(), vclock:fresh()}.
 
+dominates({AM, AV}, {BM, BV}) ->
+    {model_descends(AM, BM) andalso AM =/= BM,
+     vclock:dominates(AV, BV)}.
+
 descends({AM, AV}, {BM, BV}) ->
-    {lists:all(fun({Actor, Count}) ->
-                       Count >= orddict:fetch(Actor, BM)
-               end, 
-               AM),
+    {model_descends(AM, BM),
      vclock:descends(AV, BV)}.
 
 get_counter(A, {M, V}) ->
@@ -116,9 +123,15 @@ new_model() ->
     orddict:from_list([{ID, 0} || ID <- ?ACTOR_IDS]).
 
 model_compare(M, V) ->
-    lists:all(fun(A) -> 
-                      orddict:fetch(A,M) == vclock:get_counter(A,V) 
-              end, 
+    lists:all(fun(A) ->
+                      orddict:fetch(A,M) == vclock:get_counter(A,V)
+              end,
               ?ACTOR_IDS).
+
+model_descends(AM, BM) ->
+   lists:all(fun({Actor, Count}) ->
+                     Count >= orddict:fetch(Actor, BM)
+             end,
+             AM).
 
 -endif.


### PR DESCRIPTION
This is a QuickCheck property for vclock. The property was created so that the `dominates/2` could be added, with confidence that other parts of the API are solid as well. `dominates/2` essentially implements the `>` relation (strict-order) where `descends/2` implements the `>=` relation (partial-order). This could be used in various parts of `riak_kv` where vclocks are compared.

(h/t @joedevivo and @Quviq for their help on this)

/cc @russelldb 
