### PR TITLE
Add get dot and dot type for dvv style causality

### DIFF
--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -139,7 +139,7 @@ get_timestamp(Node, VClock) ->
 -spec get_entry(Node :: vclock_node(), VClock :: vclock()) -> {ok, dot()} | undefined.
 get_entry(Node, VClock) ->
     case lists:keyfind(Node, 1, VClock) of
-	false -> undefined;
+        false -> undefined;
         Entry -> {ok, Entry}
     end.
 
@@ -348,8 +348,8 @@ merge_same_id_test() ->
 
 get_entry_test() ->
     VC = vclock:fresh(),
-    VC1 = increment(c, increment(b, increment(a, VC))),
-    ?assertMatch({ok, {a, {1, _}}}, get_entry(a, VC1)),
+    VC1 = increment(a, increment(c, increment(b, increment(a, VC)))),
+    ?assertMatch({ok, {a, {2, _}}}, get_entry(a, VC1)),
     ?assertMatch({ok, {b, {1, _}}}, get_entry(b, VC1)),
     ?assertMatch({ok, {c, {1, _}}}, get_entry(c, VC1)),
     ?assertEqual(undefined, get_entry(d, VC1)).

--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -35,6 +35,7 @@
          fresh/2,
          descends/2,
          dominates/2,
+         descends_dot/2,
          merge/1,
          get_counter/2,
          get_timestamp/2,
@@ -86,6 +87,18 @@ descends(Va, Vb) ->
         {_, {CtrA, _TSA}} ->
             (CtrA >= CtrB) andalso descends(Va,RestB)
         end.
+
+%% @doc does the given `vclock()' descend from the given `dot()'. The
+%% `dot()' can be any vclock entry returned from
+%% `get_entry/2'. returns `true' if the `vclock()' has an entry for
+%% the `actor' in the `dot()', and that the counter for that entry is
+%% at least that of the given `dot()'. False otherwise. Call with a
+%% valid entry or you'll get an error.
+%%
+%% @see descends/2, get_entry/3, dominates/2
+-spec descends_dot(vclock(), dot()) -> boolean().
+descends_dot(Vclock, Dot) ->
+    descends(Vclock, [Dot]).
 
 -spec dominates(vclock(), vclock()) -> boolean().
 dominates(A, B) ->

--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -38,6 +38,7 @@
          merge/1,
          get_counter/2,
          get_timestamp/2,
+         get_entry/2,
          increment/2,
          increment/3,
          all_nodes/1,
@@ -49,9 +50,11 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--export_type([vclock/0, timestamp/0, vclock_node/0]).
+-export_type([vclock/0, timestamp/0, vclock_node/0, dot/0]).
 
 -opaque vclock() :: [vc_entry()].
+-opaque dot() :: vc_entry().
+
 % The timestamp is present but not used, in case a client wishes to inspect it.
 -type vc_entry() :: {vclock_node(), {counter(), timestamp()}}.
 
@@ -129,6 +132,14 @@ get_timestamp(Node, VClock) ->
     case lists:keyfind(Node, 1, VClock) of
 	{_, {_Ctr, TS}} -> TS;
 	false           -> undefined
+    end.
+
+% @doc Get the {counter, timestamp} entry value in a VClock set from Node.
+-spec get_entry(Node :: vclock_node(), VClock :: vclock()) -> dot() | undefined.
+get_entry(Node, VClock) ->
+    case lists:keyfind(Node, 1, VClock) of
+	false -> undefined;
+        Entry -> Entry
     end.
 
 % @doc Increment VClock at Node.

--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -135,7 +135,7 @@ get_timestamp(Node, VClock) ->
 	false           -> undefined
     end.
 
-% @doc Get the {counter, timestamp} entry value in a VClock set from Node.
+% @doc Get the entry `dot()' for `vclock_node()' from `vclock()'.
 -spec get_entry(Node :: vclock_node(), VClock :: vclock()) -> {ok, dot()} | undefined.
 get_entry(Node, VClock) ->
     case lists:keyfind(Node, 1, VClock) of
@@ -145,7 +145,7 @@ get_entry(Node, VClock) ->
 
 %% @doc is the given argument a valid dot, or entry?
 -spec valid_entry(dot()) -> boolean().
-valid_entry({_, {_, _}}) ->
+valid_entry({_, {Cnt, TS}}) when is_integer(Cnt), is_integer(TS) ->
     true;
 valid_entry(_) ->
     false.


### PR DESCRIPTION
Add's `get_entry/2` to the API, this returns the `{Actor, {Counter, TS}}` entry for the given actor and clock. It is used by riak_kv for finer grained causal tracking.
