### PR TITLE
Fixes

### DIFF
--- a/src/riak_core.app.src
+++ b/src/riak_core.app.src
@@ -27,6 +27,7 @@
 
          %% Default location of ringstate
          {ring_state_dir, "data/ring"},
+         {platform_data_dir, "data"},
 
          %% Default ring creation size.  Make sure it is a power of 2,
          %% e.g. 16, 32, 64, 128, 256, 512 etc

--- a/src/riak_core.app.src
+++ b/src/riak_core.app.src
@@ -25,8 +25,7 @@
          %% Cluster name
          {cluster_name, "default"},
 
-         %% Default location of ringstate
-         {ring_state_dir, "data/ring"},
+         %% Default location for ring, cluster and other data files
          {platform_data_dir, "data"},
 
          %% Default ring creation size.  Make sure it is a power of 2,

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -466,7 +466,7 @@ code_change(_OldVsn, State, _Extra) ->
 ring_dir() ->
     case app_helper:get_env(riak_core, ring_state_dir) of
         undefined ->
-            app_helper:get_env(riak_core, platform_data_dir, "data");
+            filename:join(app_helper:get_env(riak_core, platform_data_dir, "data"), "ring");
         Dir ->
             Dir
     end.

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -225,7 +225,6 @@ force_update() ->
 
 do_write_ringfile(Ring) ->
     case ring_dir() of
-        undefined ->
         "<nostore>" -> nop;
         Dir ->
             {{Year, Month, Day},{Hour, Minute, Second}} = calendar:universal_time(),

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -224,14 +224,14 @@ force_update() ->
     ok.
 
 do_write_ringfile(Ring) ->
-    case app_helper:get_env(riak_core, ring_state_dir) of
+    case app_helper:get_env(riak_core, platform_data_dir) of
         "<nostore>" -> nop;
         Dir ->
             {{Year, Month, Day},{Hour, Minute, Second}} = calendar:universal_time(),
             TS = io_lib:format(".~B~2.10.0B~2.10.0B~2.10.0B~2.10.0B~2.10.0B",
                                [Year, Month, Day, Hour, Minute, Second]),
             Cluster = app_helper:get_env(riak_core, cluster_name),
-            FN = Dir ++ "/riak_core_ring." ++ Cluster ++ TS,
+            FN = Dir ++ "/ring/riak_core_ring." ++ Cluster ++ TS,
             do_write_ringfile(Ring, FN)
     end.
 

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -266,14 +266,6 @@ find_latest_ringfile() ->
             {error, Reason}
     end.
 
-ring_dir() ->
-    case app_helper:get_env(riak_core, ring_state_dir) of
-        Dir ->
-            Dir;
-        undefined ->
-            app_helper:get_env(riak_core, platform_data_dir, "data")
-    end.
-
 %% @spec read_ringfile(string()) -> riak_core_ring:riak_core_ring() | {error, any()}
 read_ringfile(RingFile) ->
     case file:read_file(RingFile) of
@@ -473,10 +465,10 @@ code_change(_OldVsn, State, _Extra) ->
 
 ring_dir() ->
     case app_helper:get_env(riak_core, ring_state_dir) of
-        Dir ->
-            Dir;
         undefined ->
-            app_helper:get_env(riak_core, platform_data_dir, "data")
+            app_helper:get_env(riak_core, platform_data_dir, "data");
+        Dir ->
+            Dir
     end.
 
 prune_list([X|Rest]) ->

--- a/src/riak_core_sup.erl
+++ b/src/riak_core_sup.erl
@@ -49,7 +49,7 @@ start_link() ->
 init([]) ->
     DistMonEnabled = app_helper:get_env(riak_core, enable_dist_mon,
                                         true),
-    {ok, Root} = application:get_env(riak_core, platform_data_dir),
+    Root = application:get_env(riak_core, platform_data_dir),
 
     EnsembleSup = {riak_ensemble_sup,
                    {riak_ensemble_sup, start_link, [Root]},

--- a/src/riak_core_sup.erl
+++ b/src/riak_core_sup.erl
@@ -49,7 +49,7 @@ start_link() ->
 init([]) ->
     DistMonEnabled = app_helper:get_env(riak_core, enable_dist_mon,
                                         true),
-    Root = application:get_env(riak_core, platform_data_dir),
+    {ok, Root} = application:get_env(riak_core, platform_data_dir),
 
     EnsembleSup = {riak_ensemble_sup,
                    {riak_ensemble_sup, start_link, [Root]},


### PR DESCRIPTION
This pull request has fixes for a few problems that I have been experiencing when trying to get up and running with riak_core.

Steps to reproduce:
1) Install the templates from rebar_riak_core
2) Create the application from the provided templates
3) Update the version of riak_core to the latest and greatest
4) make rel
5) rel/<<appid>>/bin/<<appid>> console

This will generate a series of exceptions.
a) riak_core_sup attempts calls to application:get_env to find platform_data_dir
    1) application:get_env returns a given value, not {ok, Value} which is leading to a bad_match exception
b) When (a) is fixed, riak_core_metadata_manager doesn't start, returning a no_data_dir reason
    1) riak_core_metadata_manager is looking for platform_data_dir, which is not provided in the app.src

While I was digging around, I noticed that riak_core_ring_manager had it's own, independent setting.  That didn't make much sense to me, so I changed it to use platform_data_dir and build the path from there.  You can consider this optional and I don't have a problem resubmitting the pull request without that changeset.
