### PR TITLE
Changing how pathing is determined:

### DIFF
--- a/src/riak_core.app.src
+++ b/src/riak_core.app.src
@@ -25,8 +25,8 @@
          %% Cluster name
          {cluster_name, "default"},
 
-         %% Default location of ringstate
-         {ring_state_dir, "data/ring"},
+         %% Default location for ring, cluster and other data files
+         {platform_data_dir, "data"},
 
          %% Default ring creation size.  Make sure it is a power of 2,
          %% e.g. 16, 32, 64, 128, 256, 512 etc

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -224,14 +224,14 @@ force_update() ->
     ok.
 
 do_write_ringfile(Ring) ->
-    case app_helper:get_env(riak_core, ring_state_dir) of
+    case ring_dir() of
         "<nostore>" -> nop;
         Dir ->
             {{Year, Month, Day},{Hour, Minute, Second}} = calendar:universal_time(),
             TS = io_lib:format(".~B~2.10.0B~2.10.0B~2.10.0B~2.10.0B~2.10.0B",
                                [Year, Month, Day, Hour, Minute, Second]),
             Cluster = app_helper:get_env(riak_core, cluster_name),
-            FN = Dir ++ "/riak_core_ring." ++ Cluster ++ TS,
+            FN = Dir ++ "/ring/riak_core_ring." ++ Cluster ++ TS,
             do_write_ringfile(Ring, FN)
     end.
 
@@ -248,7 +248,7 @@ do_write_ringfile(Ring, FN) ->
 
 %% @spec find_latest_ringfile() -> string()
 find_latest_ringfile() ->
-    Dir = app_helper:get_env(riak_core, ring_state_dir),
+    Dir = ring_dir(),
     case file:list_dir(Dir) of
         {ok, Filenames} ->
             Cluster = app_helper:get_env(riak_core, cluster_name),
@@ -276,7 +276,7 @@ read_ringfile(RingFile) ->
 
 %% @spec prune_ringfiles() -> ok | {error, Reason}
 prune_ringfiles() ->
-    case app_helper:get_env(riak_core, ring_state_dir) of
+    case ring_dir() of
         "<nostore>" -> ok;
         Dir ->
             Cluster = app_helper:get_env(riak_core, cluster_name),
@@ -462,6 +462,15 @@ code_change(_OldVsn, State, _Extra) ->
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
+
+ring_dir() ->
+    Dir = case app_helper:get_env(riak_core, ring_state_dir) of
+        undefined ->
+            app_helper:get_env(riak_core, platform_data_dir, "data");
+        D ->
+            D
+    end,
+    filename:join(Dir, "ring").
 
 prune_list([X|Rest]) ->
     lists:usort(lists:append([[X],back(1,X,Rest),back(2,X,Rest),

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -231,7 +231,7 @@ do_write_ringfile(Ring) ->
             TS = io_lib:format(".~B~2.10.0B~2.10.0B~2.10.0B~2.10.0B~2.10.0B",
                                [Year, Month, Day, Hour, Minute, Second]),
             Cluster = app_helper:get_env(riak_core, cluster_name),
-            FN = Dir ++ "/ring/riak_core_ring." ++ Cluster ++ TS,
+            FN = Dir ++ "/riak_core_ring." ++ Cluster ++ TS,
             do_write_ringfile(Ring, FN)
     end.
 

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -464,13 +464,12 @@ code_change(_OldVsn, State, _Extra) ->
 %% ===================================================================
 
 ring_dir() ->
-    Dir = case app_helper:get_env(riak_core, ring_state_dir) of
+    case app_helper:get_env(riak_core, ring_state_dir) of
         undefined ->
-            app_helper:get_env(riak_core, platform_data_dir, "data");
+            filename:join(app_helper:get_env(riak_core, platform_data_dir, "data"), "ring");
         D ->
             D
-    end,
-    filename:join(Dir, "ring").
+    end.
 
 prune_list([X|Rest]) ->
     lists:usort(lists:append([[X],back(1,X,Rest),back(2,X,Rest),


### PR DESCRIPTION
- Adding new property to riak_core.app.src called platform_data_dir
- Removed ring_state_dir from riak_core.app.src
- Adding function to riak_core_ring_manager named ring_dir() to build a path for the ring file using either platform_data_dir or ring_state_dir

These changes where originally submitted under PR464.
