### PR TITLE
Numerous AAE improvements

### DIFF
--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -111,6 +111,7 @@
          update_snapshot/1,
          update_perform/1,
          rehash_tree/1,
+         flush_buffer/1,
          close/1,
          destroy/1,
          read_meta/2,

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -516,7 +516,8 @@ new_segment_store(Opts, State) ->
     Config3 = orddict:erase(write_buffer_size_min, Config2),
     Config4 = orddict:erase(write_buffer_size_max, Config3),
     Config5 = orddict:store(is_internal_db, true, Config4),
-    Options = orddict:store(create_if_missing, true, Config5),
+    Config6 = orddict:store(use_bloomfilter, true, Config5),
+    Options = orddict:store(create_if_missing, true, Config6),
 
     filelib:ensure_dir(DataDir),
     {ok, Ref} = eleveldb:open(DataDir, Options),


### PR DESCRIPTION
This pull request enables bloom filters for the LevelDB instances used by AAE. The use of bloom filters was assumed in the design of AAE, but the proper setting was mistakenly overlooked. This fixes that.

Also, this change exports the `hashtree:flush_buffer/1` function that is used by the sibling K/V pull request: basho/riak_kv#765
