### PR TITLE
Cuttlefish schema for background manager global kill/enable switch

### DIFF
--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -152,8 +152,8 @@
 %% background tasks. To disable background coordination entirely, set this parameter
 %% to false. Specific subsystems may also have their own controls over use of the
 %% background manager. Riak 2.0+.
-{mapping, "use_bg_manager", "riak_core.use_background_manager", [
-    {datatype, {enum, [true, false]}},
+{mapping, "background_manager", "riak_core.use_background_manager", [
+    {datatype, flag},
     {level, advanced},
-    {default, true}
+    {default, on}
 ]}.

--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -146,12 +146,12 @@
   {commented, on}
 ]}.
 
-%% @doc Enable or skip use of the background manager. When enabled, participating
-%% Riak subsystems will coordinate access to shared resources. This will help
-%% to prevent system response degradation under times of heavy load from multiple
-%% background tasks. To disable background coordination entirely, set this parameter
-%% to false. Specific subsystems may also have their own controls over use of the
-%% background manager. Riak 2.0+.
+%% @doc Whether to enable the background manager globally. When
+%% enabled, participating Riak subsystems will coordinate access to
+%% shared resources. This will help to prevent system response
+%% degradation under times of heavy load from multiple background
+%% tasks. Specific subsystems may also have their own controls over
+%% use of the background manager.
 {mapping, "background_manager", "riak_core.use_background_manager", [
     {datatype, flag},
     {level, advanced},

--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -154,6 +154,6 @@
 %% use of the background manager.
 {mapping, "background_manager", "riak_core.use_background_manager", [
     {datatype, flag},
-    {level, advanced},
-    {default, on}
+    {default, on},
+    hidden
 ]}.

--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -145,3 +145,15 @@
   {default, off},
   {commented, on}
 ]}.
+
+%% @doc Enable or skip use of the background manager. When enabled, participating
+%% Riak subsystems will coordinate access to shared resources. This will help
+%% to prevent system response degradation under times of heavy load from multiple
+%% background tasks. To disable background coordination entirely, set this parameter
+%% to false. Specific subsystems may also have their own controls over use of the
+%% background manager. Riak 2.0+.
+{mapping, "use_bg_manager", "riak_core.use_background_manager", [
+    {datatype, {enum, [true, false]}},
+    {level, advanced},
+    {default, true}
+]}.

--- a/test/riak_core_schema_tests.erl
+++ b/test/riak_core_schema_tests.erl
@@ -27,6 +27,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_core.platform_lib_dir", "./lib"),
     cuttlefish_unit:assert_config(Config, "riak_core.platform_log_dir", "./log"),
     cuttlefish_unit:assert_config(Config, "riak_core.enable_consensus", false),
+    cuttlefish_unit:assert_config(Config, "riak_core.use_background_manager", true),
     ok.
 
 default_bucket_properties_test() ->
@@ -61,7 +62,8 @@ override_schema_test() ->
         {["platform_etc_dir"], "/absolute/etc"},
         {["platform_lib_dir"], "/absolute/lib"},
         {["platform_log_dir"], "/absolute/log"},
-        {["strong_consistency"], on}
+        {["strong_consistency"], on},
+        {["background_manager"], off}
     ],
 
     Config = cuttlefish_unit:generate_templated_config("../priv/riak_core.schema", Conf, context()),
@@ -83,6 +85,7 @@ override_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_core.platform_lib_dir", "/absolute/lib"),
     cuttlefish_unit:assert_config(Config, "riak_core.platform_log_dir", "/absolute/log"),
     cuttlefish_unit:assert_config(Config, "riak_core.enable_consensus", true),
+    cuttlefish_unit:assert_config(Config, "riak_core.use_background_manager", false),
     ok.
 
 %% this context() represents the substitution variables that rebar


### PR DESCRIPTION
Add cuttlefish schema for the global background manager kill/enable switch.
- On by default
- Advanced mode setting means it doesn't get generated into the config file "riak.config"
- Look for it in "dev/devN/data/generated.configs" where N=1..6 after `make devrel`

I examined the `generated.configs` file to confirm it was present and had the correct default value… you should see this:

```
{riak_core,
     [{use_background_manager,true},
      {enable_consensus,false},
     …
```
