### PR TITLE
Wildcard security sources overlapping with regular user sources causes issues

### DIFF
--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -860,8 +860,21 @@ group_sources(Sources) ->
         end, dict:new(), Sources),
     R1 = [{Users, CIDR, Source, Options} || {{CIDR, Source, Options}, Users} <-
                                        dict:to_list(D)],
+    %% Split any entries where the user list contains 'all' so that 'all' has
+    %% its own entry. We could actually elide any user sources that overlap
+    %% with an 'all' source, but that may be more confusing because deleting
+    %% the all source would then 'ressurrect' the user sources.
+    R2 = lists:foldl(fun({Users, CIDR, Source, Options}=E, Acc) ->
+                    case lists:member(all, Users) of
+                        true ->
+                            [{[all], CIDR, Source, Options},
+                             {Users -- [all], CIDR, Source, Options}|Acc];
+                        false ->
+                            [E|Acc]
+                    end
+            end, [], R1),
     %% sort the result by the same criteria that sort_sources uses
-    R2 = lists:sort(fun({UserA, _, _, _}, {UserB, _, _, _}) ->
+    R3 = lists:sort(fun({UserA, _, _, _}, {UserB, _, _, _}) ->
                     case {UserA, UserB} of
                         {[all], [all]} ->
                             true;
@@ -873,10 +886,10 @@ group_sources(Sources) ->
                         {_, _} ->
                             true
                     end
-            end, R1),
+            end, R2),
     lists:sort(fun({_, {_, MaskA}, _, _}, {_, {_, MaskB}, _, _}) ->
                 MaskA > MaskB
-        end, R2).
+        end, R3).
 
 group_grants(Grants) ->
     D = lists:foldl(fun({{_User, Bucket}, G}, Acc) ->


### PR DESCRIPTION
```
./rel/riak/bin/riak-admin security add-user andrew
./rel/riak/bin/riak-admin security add-source andrew 127.0.0.1/32 trust
./rel/riak/bin/riak-admin security add-source all 127.0.0.1/32 trust
./rel/riak/bin/riak-admin security print-sources
RPC to 'riak@127.0.0.1' failed: {'EXIT',
                                 {badarg,
                                  [{erlang,binary_to_list,[all],[]},
                                   {riak_core_security,
                                    '-prettyprint_users/2-lc$^0/1-0-',1,
                                    [{file,"src/riak_core_security.erl"},
                                     {line,70}]},
                                   {riak_core_security,
                                    '-prettyprint_users/2-lc$^0/1-0-',1,
                                    [{file,"src/riak_core_security.erl"},
                                     {line,70}]},
                                   {riak_core_security,prettyprint_users,2,
                                    [{file,"src/riak_core_security.erl"},
                                     {line,70}]},
                                   {riak_core_security,
                                    '-print_sources/1-lc$^0/1-0-',1,
                                    [{file,"src/riak_core_security.erl"},
                                     {line,85}]},
                                   {riak_core_security,print_sources,1,
                                    [{file,"src/riak_core_security.erl"},
                                     {line,85}]},
                                   {rpc,'-handle_call_call/6-fun-0-',5,
                                    [{file,"rpc.erl"},{line,205}]}]}}
```

Sources that overlap with an 'all' source need to be handled better, somehow.

See also #451 
