### PR TITLE
Add logging and pretty printing of log file to background manager.

### DIFF
--- a/src/riak_core_bg_manager.erl
+++ b/src/riak_core_bg_manager.erl
@@ -1032,14 +1032,14 @@ maybe_log(_Op, _Args, _Status, _State) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% @private
-%% @doc Format the timestamp into human readable date string.
+%% @doc Format the timestamp into a human readable date string. Timezone depends
+%% on the value of the app env var 'sasl/utc_log' which is true or false. If true,
+%% then universal time is returned, otherwise local time prevails.
+%% @link https://github.com/basho/lager/blob/master/src/lager_stdlib.erl#L80
 format_utc_timestamp(TS) ->
-    {{Year,Month,Day},{Hour,Minute,Second}} = 
-	calendar:now_to_universal_time(TS),
-    Mstr = element(Month,{"Jan","Feb","Mar","Apr","May","Jun","Jul",
-			  "Aug","Sep","Oct","Nov","Dec"}),
-    io_lib:format("~w/~s/~w:~w:~w:~w",
-		  [Day,Mstr,Year,Hour,Minute,Second]).
+    DateTimeMsecs = lager_util:localtime_ms(TS),
+    {D,T} = lager_util:format_time(lager_util:maybe_utc(DateTimeMsecs)),
+    lists:flatten([D,$ ,T]).
 
 %% @private
 %% @doc

--- a/src/riak_core_bg_manager.erl
+++ b/src/riak_core_bg_manager.erl
@@ -133,7 +133,7 @@
 
 -define(NOT_TRANSFERED(S), S#state.info_table == undefined orelse S#state.entry_table == undefined).
 
--define(MAX_LOG_BYTES, 1000000).    %% maximum size of a single logfile
+-define(MAX_LOG_BYTES, 100 * 1024). %% maximum size of a single logfile
 -define(MAX_LOG_FILES, 5).          %% maximum number of logfiles in the wrap rotation
 
 %%%===================================================================

--- a/src/riak_core_bg_manager.erl
+++ b/src/riak_core_bg_manager.erl
@@ -435,7 +435,7 @@ init([]) ->
                    entry_table=undefined, %% resolved in the ETS-TRANSFER handler
                    enabled=true,
                    bypassed=false,
-                   loglevel=app_helper:get_env(riak_core, background_manager_loglevel, debug),
+                   loglevel=app_helper:get_env(riak_core, background_manager_loglevel, on),
                    log=Log
                   },
     {ok, State}.

--- a/test/bg_manager_eqc.erl
+++ b/test/bg_manager_eqc.erl
@@ -783,6 +783,12 @@ wait_for_pid(Pid) ->
     Mref = erlang:monitor(process, Pid),
     receive
         {'DOWN', Mref, process, _, _} ->
+            %% listing all resources is no longer in the gen_server, so
+            %% we need to let the DOWN handler have a chance to complete
+            %% and delete the entry from the table. It's now a race to
+            %% see who notices the dead pid. Maybe bg-mgr should verify
+            %% that a process is still alive when doing the query.
+            timer:sleep(10),
             ok
     after
         5000 ->


### PR DESCRIPTION
The background manager already contains functions to view the current set of locks and tokens, but lacks any historical view of how subsystems have interacted. It would be highly useful to examine past get_lock/get_token patterns in the event of performance problems around the participating subsystems that use the background manager, especially on nodes with extreme overload or crashed nodes.

This PR adds logging to disk, which will persist after a crashed node. All writes are done using Erlang's disk_log module and are asynchronous so that normal operations are not blocked by slow disk writes. Losing a little data from the disk_log cash is preferable to blocking a caller of the background manager.

Three logging levels are provided, with `on` being the default of the config variable `background_manager_loglevel`:
- `off` - no logging is done
- `on` - logs only the get_lock, get_token, enable/disable, and bypass calls as events.
- `debug` - logs all operations

Logfile entries are in disk_log's "internal" format under `riak_core_bg_manager/events.xxx` in the data directory of each node. Writing is fast and the log files are repairable when read. The logs are `wrap` logs and thus will occupy a fixed maximum space on disk (and memory for the disk_log write buffer). The total size of the logs are controlled by `background_manager_log_size` application configuration variable, and default to 5 files of 1MB each, so the maximum disk space used is 5 MB, which should give days of logged events for postmortem analysis.

Testing was done using both the `bg_manager_eqc.erl` EQC test as a driver (find log files in /tmp/riak_core_bg_manager/events.xxx) , and with `riak_test -t rtee replication2` (find log files in devN/data/riak_core_bg_manager/events.xxx). After running the replication2 test, we see entries like the following:

```
6/Jan/2014:18:29:0 get_lock {vnode_lock, 685078892498860742907977265335757665463718379520} [{task, handoff}] ok
6/Jan/2014:18:29:0 get_lock {vnode_lock, 685078892498860742907977265335757665463718379520} [{task,  repl_fullsync}] max_concurrency
6/Jan/2014:18:29:0 get_lock {vnode_lock, 68507889249886074290797726533575766546371837952} [{task,  repl_fullsync}] ok
```
