### PR TITLE
Don't discard config options that are not validated

### DIFF
--- a/src/riak_core_ssl_util.erl
+++ b/src/riak_core_ssl_util.erl
@@ -111,8 +111,8 @@ validate_ssl_config([{cacertdir, CACertDir}|Rest], Acc) ->
         Certs when is_list(Certs) ->
             validate_ssl_config(Rest, [{cacerts, Certs}|Acc])
     end;
-validate_ssl_config([_|Rest], Acc) ->
-    validate_ssl_config(Rest, Acc).
+validate_ssl_config([E|Rest], Acc) ->
+    validate_ssl_config(Rest, [E|Acc]).
 
 upgrade_client_to_ssl(Socket, App) ->
     case maybe_use_ssl(App) of


### PR DESCRIPTION
This was a change made as part of the security work that breaks SSL replication.
