### PR TITLE
fix make test

### DIFF
--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -244,7 +244,7 @@ do_write_ringfile(Ring, FN) ->
             lager:error("Unable to write ring to \"~s\" - ~p\n", [FN, Err]),
             {error,Err}
     end.
-    
+
 
 %% @spec find_latest_ringfile() -> string()
 find_latest_ringfile() ->
@@ -286,7 +286,7 @@ prune_ringfiles() ->
                     {error, Reason};
                 {ok, []} -> ok;
                 {ok, Filenames} ->
-                    Timestamps = [TS || {"riak_core_ring", C1, TS} <- 
+                    Timestamps = [TS || {"riak_core_ring", C1, TS} <-
                      [list_to_tuple(string:tokens(FN, ".")) || FN <- Filenames],
                                         C1 =:= Cluster],
                     if Timestamps /= [] ->
@@ -300,8 +300,8 @@ prune_ringfiles() ->
                                          io_lib:format(
                                            "~B~2.10.0B~2.10.0B~2.10.0B~2.10.0B~2.10.0B",K))
                                        || K <- Keep],
-                            DelFNs = [Dir ++ "/" ++ FN || FN <- Filenames, 
-                                                          lists:all(fun(TS) -> 
+                            DelFNs = [Dir ++ "/" ++ FN || FN <- Filenames,
+                                                          lists:all(fun(TS) ->
                                                                             string:str(FN,TS)=:=0
                                                                     end, KeepTSs)],
                             [file:delete(DelFN) || DelFN <- DelFNs],
@@ -399,7 +399,7 @@ handle_call({ring_trans, Fun, Args}, _From, State=#state{raw_ring=Ring}) ->
         {ignore, Reason} ->
             {reply, {not_changed, Reason}, State};
         Other ->
-            lager:error("ring_trans: invalid return value: ~p", 
+            lager:error("ring_trans: invalid return value: ~p",
                                    [Other]),
             {reply, not_changed, State}
     end;
@@ -644,7 +644,7 @@ back_test() ->
     ?assertEqual([[7,8,9]], back(1, X, List2)),
     ?assertEqual([], back(1, X, List3)),
     ?assertEqual([[7,8,3]], back(2, X, List1)),
-    ?assertEqual([[11,12,13]], back(3, X, List1)).    
+    ?assertEqual([[11,12,13]], back(3, X, List1)).
 
 prune_list_test() ->
     TSList1 = [[2011,2,28,16,32,16],[2011,2,28,16,32,36],[2011,2,28,16,30,27],[2011,2,28,16,32,16],[2011,2,28,16,32,36]],
@@ -652,7 +652,7 @@ prune_list_test() ->
     PrunedList1 = [[2011,2,28,16,30,27],[2011,2,28,16,32,16]],
     PrunedList2 = [[2011,2,28,16,31,16],[2011,2,28,16,32,36]],
     ?assertEqual(PrunedList1, prune_list(TSList1)),
-    ?assertEqual(PrunedList2, prune_list(TSList2)).    
+    ?assertEqual(PrunedList2, prune_list(TSList2)).
 
 set_ring_global_test() ->
     setup_ets(test),
@@ -673,6 +673,7 @@ set_my_ring_test() ->
     cleanup_ets(test).
 
 refresh_my_ring_test() ->
+    setup_ets(test),
     Core_Settings = [{ring_creation_size, 4},
                      {ring_state_dir, "/tmp"},
                      {cluster_name, "test"}],
@@ -703,22 +704,22 @@ do_write_ringfile_test() ->
     file:delete(?TMP_RINGFILE),
     file:change_mode(?TEST_RINGFILE, 8#00644),
     file:delete(?TEST_RINGFILE),
-    
+
     %% Check happy path
     GenR = fun(Name) -> riak_core_ring:fresh(64, Name) end,
     ?assertEqual(ok, do_write_ringfile(GenR(happy), ?TEST_RINGFILE)),
-    
+
     %% Check write fails (create .tmp file with no write perms)
     ok = file:write_file(?TMP_RINGFILE, <<"no write for you">>),
     ok = file:change_mode(?TMP_RINGFILE, 8#00444),
     ?assertMatch({error,_}, do_write_ringfile(GenR(tmp_perms), ?TEST_RINGFILE)),
     ok = file:change_mode(?TMP_RINGFILE, 8#00644),
     ok = file:delete(?TMP_RINGFILE),
-    
+
     %% Check rename fails
     ok = file:change_mode(?TEST_RINGDIR, 8#00444),
     ?assertMatch({error,_}, do_write_ringfile(GenR(ring_perms), ?TEST_RINGFILE)),
     ok = file:change_mode(?TEST_RINGDIR, 8#00755).
-    
+
 -endif.
 

--- a/test/mock_vnode.erl
+++ b/test/mock_vnode.erl
@@ -34,7 +34,7 @@
          asyncnoreply/2,
          asyncreply/2,
          asynccrash/2,
-         crash/1, 
+         crash/1,
          spawn_error/2,
          sync_error/2,
          get_crash_reason/1,
@@ -77,7 +77,7 @@ latereply(Preflist) ->
 
 asyncnoreply(Preflist, AsyncDonePid) ->
     Ref = {asyncnoreply, make_ref()},
-    riak_core_vnode_master:command(Preflist, {asyncnoreply, AsyncDonePid}, 
+    riak_core_vnode_master:command(Preflist, {asyncnoreply, AsyncDonePid},
                                    {raw, Ref, AsyncDonePid}, ?MASTER),
     {ok, Ref}.
 
@@ -88,7 +88,7 @@ asyncreply(Preflist, AsyncDonePid) ->
     {ok, Ref}.
 
 asynccrash(Preflist, AsyncDonePid) ->
-    Ref = {asyncreply, make_ref()},
+    Ref = {asynccrash, make_ref()},
     riak_core_vnode_master:command(Preflist, {asynccrash, AsyncDonePid},
                                    {raw, Ref, AsyncDonePid}, ?MASTER),
     {ok, Ref}.
@@ -119,7 +119,7 @@ init([Index]) ->
             {ok, S, [{pool, ?MODULE, PoolSize, myargs}]};
         _ ->
             {ok, S}
-    end.    
+    end.
 
 handle_command(get_index, _Sender, State) ->
     {reply, {ok, State#state.index}, State};
@@ -142,7 +142,7 @@ handle_command(crash, _Sender, State) ->
     spawn_link(fun() -> exit(State#state.index) end),
     {reply, ok, State};
 handle_command(stop, Sender, State = #state{counter=Counter}) ->
-    %% Send reply here as vnode_master:sync_command does a call 
+    %% Send reply here as vnode_master:sync_command does a call
     %% which is cast on to the vnode process.  Returning {stop,...}
     %% does not provide for returning a response.
     riak_core_vnode:reply(Sender, stopped),
@@ -152,7 +152,7 @@ handle_command(neverreply, _Sender, State = #state{counter=Counter}) ->
 handle_command(returnreply, _Sender, State = #state{counter=Counter}) ->
     {reply, returnreply, State#state{counter = Counter + 1}};
 handle_command(latereply, Sender, State = #state{counter=Counter}) ->
-    spawn(fun() -> 
+    spawn(fun() ->
                   timer:sleep(100),
                   riak_core_vnode:reply(Sender, latereply)
           end),
@@ -186,8 +186,11 @@ handle_work({reply, DonePid},  {raw, Ref, _EqcPid} = _Sender, State = #wstate{in
     timer:sleep(100), % slow things down enough to cause issue on stops
     DonePid ! {I, {ok, Ref}},
     {reply, asyncreply, State};
-handle_work({crash, _DonePid},  {raw, _Ref, _EqcPid} = _Sender, _State = #wstate{index=_I}) ->
+handle_work({crash, DonePid},
+        {raw, Ref, _EqcPid} = _Sender, _State = #wstate{index=I}) ->
     timer:sleep(100), % slow things down enough to cause issue on stops
-    %DonePid ! {I, {ok, Ref}},
+    %% This msg needs to get sent, since it's counted in core_vnode_eqc work tracking
+    %% in next_state_data/5
+    DonePid ! {I, {ok, Ref}},
     throw(deliberate_async_crash).
 


### PR DESCRIPTION
Fix 2 failing tests
- `refresh_my_ring_test` was failing due to an ETS table not being setup properly.
- `core_vnode_eqc` was failing in multiple places
  - shutdown had to be changed to kill so that processes didn't hang during testing
  - an asyncwork response wasn't being counted for asynccrash calls so that needed to be added back in (it was commented out)
  - With worker pools of 1, if an asyncrash call was followed by another async call that calls work wouldn't be counted because the message was dropped. I changed the possible pool sizes from [0,1,10] to [0,4,10] to make this issue extremely unlikely to happen. You'd need 4 worker crashes then another async call before any of them were restarted. Since they all have 100ms delays before crashing on purpose in mock_vnode that seems highly unlikely.
