### PR TITLE
riak_core_net_ticktime should be guarded by capability

### DIFF
--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -98,8 +98,8 @@ start(_StartType, _StartArgs) ->
                                           [true, false],
                                           false),
             riak_core_capability:register({riak_core, net_ticktime},
-                                          [supported, unsupported],
-                                          unsupported),
+                                          [true, false],
+                                          false),
 
             {ok, Pid};
         {error, Reason} ->

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -97,6 +97,9 @@ start(_StartType, _StartArgs) ->
             riak_core_capability:register({riak_core, bucket_types},
                                           [true, false],
                                           false),
+            riak_core_capability:register({riak_core, net_ticktime},
+                                          [supported, unsupported],
+                                          unsupported),
 
             {ok, Pid};
         {error, Reason} ->

--- a/src/riak_core_net_ticktime.erl
+++ b/src/riak_core_net_ticktime.erl
@@ -36,14 +36,12 @@ enable() ->
                                   false).
 
 start_set_net_ticktime_daemon(Node, Time) ->
-    Capability = riak_core_capability:get({riak_core, net_ticktime}),
-    start_set_net_ticktime_daemon(Node, Time, Capability).
+    start_set_net_ticktime_daemon(Node, Time, net_ticktime_active()).
 
 start_set_net_ticktime_daemon(Node, Time, true) ->
     EbinDir = filename:dirname(code:which(?MODULE)),
     try
         Dirs = rpc:call(Node, code, get_path, []),
-        lager:info("Node: ~p EbinDir: ~p Member? ~p", [Node, EbinDir, lists:member(EbinDir, Dirs)]),
         case lists:member(EbinDir, Dirs) of
             false ->
                 lager:info("start_set_net_ticktime_daemon: adding to code path "
@@ -142,4 +140,13 @@ set_net_ticktime(Time) ->
             Status;
         A when is_atom(A) ->
             A
+    end.
+
+-spec net_ticktime_active() -> boolean().
+net_ticktime_active() ->
+    case catch riak_core_capability:get({riak_core, net_ticktime}) of
+        true ->
+            true;
+        _ ->
+            false
     end.


### PR DESCRIPTION
To prevent case where a user has not yet loaded the module on a pre-2.0 node.

Quick sketch:
- Capability has two modes, supported & unsupported.
- On startup, if module is available register the capability w/ supported as the preferred mode, otherwise unsupported
- Since `start_set_net_ticktime_daemon` runs first on a riak node, guard it by a check for the currently preferred mode across the cluster and only proceed if it is supported. If it fails, this indicates to the user that one or more nodes does not have the module
- User loads module on node (add its to basho-patches) and calls new function `riak_core_net_ticktime:enable/0`. This re-registers the capability on the node w/ supported as the preferred mode
- Once done on all nodes that did not have the module and ring has converged user can safely call `start_set_net_ticktime_daemon` and since the capability prefers supported it will proceed
