### PR TITLE
Dominates should take timestamp into account.

### DIFF
--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -102,7 +102,7 @@ descends_dot(Vclock, Dot) ->
 
 -spec dominates(vclock(), vclock()) -> boolean().
 dominates(A, B) ->
-    descends(A, B) andalso not equal(A, B).
+    descends(A, B) andalso not descends(B, A).
 
 % @doc Combine all VClocks in the input list into their least possible
 %      common descendant.
@@ -377,5 +377,11 @@ valid_entry_test() ->
     ?assertNot(valid_entry(undefined)),
     ?assertNot(valid_entry("huffle-puff")),
     ?assertNot(valid_entry([])).
+
+dominates_test() ->
+    A1 = vclock:increment(a, vclock:fresh()),
+    timer:sleep(1000), %% Sleep 1, to alter timestamp for same actor.
+    A2 = vclock:increment(a, vclock:fresh()),
+    ?assertEqual(false, vclock:dominates(A1, A2)).
 
 -endif.

--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -100,10 +100,13 @@ descends(Va, Vb) ->
 descends_dot(Vclock, Dot) ->
     descends(Vclock, [Dot]).
 
-%% @doc true if `A' strictly dominates `B'. Note: uses timestamp
-%% information as well as causal information. In Riak it is possible
-%% to have vclocks that are identical except for timestamps. See
-%% source comment for more details.
+%% @doc true if `A' strictly dominates `B'. Note: ignores
+%% timestamps. In Riak it is possible to have vclocks that are
+%% identical except for timestamps. When two vclocks descend each
+%% other, but are not equal, they are concurrent. See source comment
+%% for more details. (Actually you can have indentical clocks
+%% including timestamps, that represent different events, but let's
+%% not go there.)
 %%
 
 -spec dominates(vclock(), vclock()) -> boolean().
@@ -115,7 +118,7 @@ dominates(A, B) ->
     %% check descends both ways rather than checking descends(A, B)
     %% and not equal(A, B). Do not "optimise" this to dodge the second
     %% descends call! I know that the laws of causality say that each
-    %% actor must act serially, but Riak breaks that, so timestamps.
+    %% actor must act serially, but Riak breaks that.
     descends(A, B) andalso not descends(B, A).
 
 % @doc Combine all VClocks in the input list into their least possible

--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -392,10 +392,4 @@ valid_entry_test() ->
     ?assertNot(valid_entry("huffle-puff")),
     ?assertNot(valid_entry([])).
 
-dominates_test() ->
-    A1 = vclock:increment(a, vclock:fresh()),
-    timer:sleep(1000), %% Sleep 1, to alter timestamp for same actor.
-    A2 = vclock:increment(a, vclock:fresh()),
-    ?assertEqual(false, vclock:dominates(A1, A2)).
-
 -endif.

--- a/test/vclock_qc.erl
+++ b/test/vclock_qc.erl
@@ -117,7 +117,7 @@ fresh() ->
     {new_model(), vclock:fresh()}.
 
 dominates({AM, AV}, {BM, BV}) ->
-    {model_descends(AM, BM) andalso AM =/= BM,
+    {model_descends(AM, BM) andalso not model_descends(BM, AM),
      vclock:dominates(AV, BV)}.
 
 descends({AM, AV}, {BM, BV}) ->


### PR DESCRIPTION
Ensure that dominates takes into account the timestamp; two concurrent
puts happening one second apart should not be considered related.
