### PR TITLE
address unmatched_returns in cluster metadata code

### DIFF
--- a/src/hashtree_tree.erl
+++ b/src/hashtree_tree.erl
@@ -340,7 +340,7 @@ insert_hash(Key, Hash, Opts, NodeName, Tree) ->
 insert_hash(Key, Hash, Opts, NodeName, Node, Tree=#hashtree_tree{dirty=Dirty}) ->
     Node2 = hashtree:insert(Key, Hash, Node, Opts),
     Dirty2 = gb_sets:add_element(NodeName, Dirty),
-    set_node(NodeName, Node2, Tree),
+    _ = set_node(NodeName, Node2, Tree),
     Tree#hashtree_tree{dirty=Dirty2}.
 
 %% @private
@@ -357,7 +357,7 @@ update_dirty_parents(DirtyParents, Tree) ->
                                   DirtyNode = lookup_node(DirtyParent, Tree),
                                   {DirtySnap, DirtyNode2} = hashtree:update_snapshot(DirtyNode),
                                   NextDirty = update_dirty(DirtyParent, DirtySnap, DirtyAcc, Tree),
-                                  set_node(DirtyParent, DirtyNode2, Tree),
+                                  _ = set_node(DirtyParent, DirtyNode2, Tree),
                                   NextDirty
                           end, gb_sets:new(), DirtyParents),
             update_dirty_parents(NextDirty, Tree)
@@ -365,15 +365,16 @@ update_dirty_parents(DirtyParents, Tree) ->
 
 %% @private
 update_dirty(DirtyName, DirtyNode, NextDirty, Tree) ->
-    hashtree:update_perform(DirtyNode),
+    %% ignore returned tree b/c we are tracking dirty nodes in this fold seperately
+    _ = hashtree:update_perform(DirtyNode),
     case parent_node(DirtyName, Tree) of
         undefined ->
             NextDirty;
         {ParentName, ParentNode} ->
             TopHash = extract_top_hash(hashtree:top_hash(DirtyNode)),
             ParentKey = to_parent_key(DirtyName),
-            %% ignore returned tree b/c we are tracking dirty in this fold seperately
-            insert_hash(ParentKey, TopHash, [], ParentName, ParentNode, Tree),
+            %% ignore returned tree b/c we are tracking dirty nodes in this fold seperately
+            _ = insert_hash(ParentKey, TopHash, [], ParentName, ParentNode, Tree),
             gb_sets:add_element(ParentName, NextDirty)
     end.
 

--- a/src/riak_core_broadcast.erl
+++ b/src/riak_core_broadcast.erl
@@ -298,7 +298,7 @@ handle_cast({ring_update, Ring}, State=#state{all_members=BroadcastMembers}) ->
                                        {stop, term(), #state{}}.
 handle_info(lazy_tick, State) ->
     schedule_lazy_tick(),
-    send_lazy(State),
+    _ = send_lazy(State),
     {noreply, State};
 handle_info(exchange_tick, State) ->
     schedule_exchange_tick(),
@@ -323,7 +323,7 @@ code_change(_OldVsn, State, _Extra) ->
 %%%===================================================================
 handle_broadcast(false, _MessageId, _Message, _Mod, _Round, Root, From, State) -> %% stale msg
     State1 = add_lazy(From, Root, State),
-    send({prune, Root, node()}, From),
+    _ = send({prune, Root, node()}, From),
     State1;
 handle_broadcast(true, MessageId, Message, Mod, Round, Root, From, State) -> %% valid msg
     State1 = add_eager(From, Root, State),
@@ -331,11 +331,11 @@ handle_broadcast(true, MessageId, Message, Mod, Round, Root, From, State) -> %% 
     schedule_lazy_push(MessageId, Mod, Round+1, Root, From, State2).
 
 handle_ihave(true, MessageId, Mod, Round, Root, From, State) -> %% stale i_have
-    send({ignored_i_have, MessageId, Mod, Round, Root, node()}, From),
+    _ = send({ignored_i_have, MessageId, Mod, Round, Root, node()}, From),
     State;
 handle_ihave(false, MessageId, Mod, Round, Root, From, State) -> %% valid i_have
     %% TODO: don't graft immediately
-    send({graft, MessageId, Mod, Round, Root, node()}, From),
+    _ = send({graft, MessageId, Mod, Round, Root, node()}, From),
     add_eager(From, Root, State).
 
 handle_graft(stale, MessageId, Mod, Round, Root, From, State) ->
@@ -348,7 +348,7 @@ handle_graft({ok, Message}, MessageId, Mod, Round, Root, From, State) ->
     %% instead we will allow the i_have to be sent once more and let the subsequent
     %% ignore serve as the ack.
     State1 = add_eager(From, Root, State),
-    send({broadcast, MessageId, Message, Mod, Round, Root, node()}, From),
+    _ = send({broadcast, MessageId, Message, Mod, Round, Root, node()}, From),
     State1;
 handle_graft({error, Reason}, _MessageId, Mod, _Round, _Root, _From, State) ->
     lager:error("unable to graft message from ~p. reason: ~p", [Mod, Reason]),
@@ -380,7 +380,7 @@ eager_push(MessageId, Message, Mod, State) ->
 
 eager_push(MessageId, Message, Mod, Round, Root, From, State) ->
     Peers = eager_peers(Root, From, State),
-    send({broadcast, MessageId, Message, Mod, Round, Root, node()}, Peers),
+    _ = send({broadcast, MessageId, Message, Mod, Round, Root, node()}, Peers),
     State.
 
 schedule_lazy_push(MessageId, Mod, State) ->
@@ -449,7 +449,7 @@ cancel_exchanges(Which, Exchanges) ->
     kill_exchanges(ToCancel).
 
 kill_exchanges(Exchanges) ->
-    [kill_exchange(Exchange) || Exchange <- Exchanges],
+    _ = [kill_exchange(Exchange) || Exchange <- Exchanges],
     Exchanges.
 
 kill_exchange({_, _, _, ExchangePid}) ->

--- a/src/riak_core_metadata_exchange_fsm.erl
+++ b/src/riak_core_metadata_exchange_fsm.erl
@@ -181,7 +181,7 @@ exchange(_Event, _From, State) ->
 repair(Peer, {missing_prefix, Type, Prefix}) ->
     repair_prefix(Peer, Type, Prefix);
 repair(Peer, {key_diffs, Prefix, Diffs}) ->
-    [repair_keys(Peer, Prefix, Diff) || Diff <- Diffs],
+    _ = [repair_keys(Peer, Prefix, Diff) || Diff <- Diffs],
     ok.
 
 %% @private


### PR DESCRIPTION
the following dialyzer errors no longer appear with this commit:

```
hashtree_tree.erl:343:
Expression produces a value of type hashtree:hashtree(), but this value is unmatched

hashtree_tree.erl:360:
Expression produces a value of type hashtree:hashtree(), but this value is unmatched

hashtree_tree.erl:368:
Expression produces a value of type hashtree:hashtree(), but this value is unmatched

hashtree_tree.erl:376:
Expression produces a value of type hashtree_tree:tree(), but this value is unmatched

riak_core_broadcast.erl:301:
Expression produces a value of type [['ok' | [any()]]], but this value is unmatched

riak_core_broadcast.erl:326:
Expression produces a value of type 'ok' | ['ok' | ['ok' | [any()]]], but this value is unmatched

riak_core_broadcast.erl:334:
Expression produces a value of type 'ok' | ['ok' | ['ok' | [any()]]], but this value is unmatched

riak_core_broadcast.erl:338:
Expression produces a value of type 'ok' | ['ok' | ['ok' | [any()]]], but this value is unmatched

riak_core_broadcast.erl:351:
Expression produces a value of type 'ok' | ['ok' | ['ok' | [any()]]], but this value is unmatched

riak_core_broadcast.erl:383:
Expression produces a value of type 'ok' | ['ok' | ['ok' | [any()]]], but this value is unmatched

riak_core_broadcast.erl:452:
Expression produces a value of type ['true'], but this value is unmatched

riak_core_metadata_exchange_fsm.erl:184:
Expression produces a value of type ['ok'], but this value is unmatched

riak_core_metadata_manager.erl:332:
Expression produces a value of type atom() | tid(), but this value is unmatched

riak_core_metadata_manager.erl:337:
Expression produces a value of type {'ok','cluster_meta_manifest'}, but this value is unmatched

riak_core_metadata_manager.erl:402:
Expression produces a value of type 'ok' | {'error',_}, but this value is unmatched

riak_core_metadata_manager.erl:560:
Expression produces a value of type atom() | tid(), but this value is unmatched

riak_core_metadata_manager.erl:599:
Expression produces a value of type atom() | {'error',_} | tid(), but this value is unmatched
```

Review:
- [x] verify riak_test `cluster_meta_basic` still passes (NOTE: there is known, unrelated intermittent failure)
- [x] verify dialyzer errors above are gone
- [x] verify there were no missed dialyzer errors in cluster metadata files

A useful grep pattern for review: `"\(riak_core_\(broadcast\|metadata\)\|hashtree_tree\)"`
