### PR TITLE
plumb through coverage queries during overload

### DIFF
--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -259,8 +259,7 @@ waiting_results({{ReqId, VNode}, Results},
                     {next_state, waiting_results, UpdStateData, Timeout}
             end;
         Error ->
-            Mod:finish(Error, ModState),
-            {stop, Error, StateData}
+            Mod:finish(Error, ModState)
     end;
 waiting_results({timeout, _, _}, #state{mod=Mod, mod_state=ModState}) ->
     Mod:finish({error, timeout}, ModState);

--- a/src/riak_core_vnode_proxy.erl
+++ b/src/riak_core_vnode_proxy.erl
@@ -276,6 +276,8 @@ handle_overload(Msg, #state{mod=Mod, index=Index}) ->
     case Msg of
         {'$gen_event', ?VNODE_REQ{sender=Sender, request=Request}} ->
             catch(Mod:handle_overload_command(Request, Sender, Index));
+        {'$gen_event', ?COVERAGE_REQ{sender=Sender, request=Request}} ->
+            catch(Mod:handle_overload_command(Request, Sender, Index));
         _ ->
             ok
     end.


### PR DESCRIPTION
Send back overload responses during coverage queries. 

Part of a fix for https://github.com/basho/riak_kv/issues/753
