### PR TITLE
Stop doing implicit role manipulation

### DIFF
--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -682,7 +682,7 @@ accumulate_grants([], Seen, Acc) ->
     {Acc, Seen};
 accumulate_grants([Role|Roles], Seen, Acc) ->
     Options = riak_core_metadata:get({<<"security">>, <<"roles">>}, Role),
-    NestedRoles = [R || R <- lookup("roles", Options),
+    NestedRoles = [R || R <- lookup("roles", Options, []),
                         not lists:member(R,Seen),
                         user_exists(R)],
     {NewAcc, NewSeen} = accumulate_grants(NestedRoles, [Role|Seen], Acc),
@@ -760,7 +760,7 @@ validate_options(Options) ->
 validate_role_option(Options) ->
     case lookup("roles", Options) of
         undefined ->
-            {ok, stash("roles", {"roles", []}, Options)};
+            {ok, Options};
         RoleStr ->
             Roles= [list_to_binary(R) || R <-
                                          string:tokens(RoleStr, ",")],


### PR DESCRIPTION
Per #522, when invoking `riak-admin security alter-user` the code loses all existing roles if only a password is provided.

The option parsing code creates `{"roles", []}` as a tuple when `riak-admin security alter-user <user> role=` is invoked (which is the only way to remove all roles), but `riak_core_security:validate_role_option/1` also added `{"roles", []}` as a tuple when no roles information was passed at all, hence the bug.

This patch instructs `validate_role_option/1` to simply return the options without adding the unnecessary tuple. It also handles the one case in the code where (I believe) an absence of such a tuple might cause problems by adding a default value of `[]` to a roles `lookup`.

/cc @Vagabond 
