### PR TITLE
Cuttlefish RHS Substitutions

### DIFF
--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -46,7 +46,8 @@
 %% @doc Default location of ringstate
 {mapping, "ring.state_dir", "riak_core.ring_state_dir", [
   {datatype, directory},
-  {default, "#(platform_data_dir)/ring"}
+  {default, "#(platform_data_dir)/ring"},
+  {level, advanced}
 ]}.
 
 %% @doc Default cert location for https can be overridden

--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -46,28 +46,28 @@
 %% @doc Default location of ringstate
 {mapping, "ring.state_dir", "riak_core.ring_state_dir", [
   {datatype, directory},
-  {default, "{{ring_state_dir}}"}
+  {default, "#(platform_data_dir)/ring"}
 ]}.
 
 %% @doc Default cert location for https can be overridden
 %% with the ssl config variable, for example:
 {mapping, "ssl.certfile", "riak_core.ssl.certfile", [
   {datatype, file},
-  {commented, "{{platform_etc_dir}}/cert.pem"}
+  {commented, "#(platform_etc_dir)/cert.pem"}
 ]}.
 
 %% @doc Default key location for https can be overridden with the ssl
 %% config variable, for example:
 {mapping, "ssl.keyfile", "riak_core.ssl.keyfile", [
   {datatype, file},
-  {commented, "{{platform_etc_dir}}/key.pem"}
+  {commented, "#(platform_etc_dir)/key.pem"}
 ]}.
 
 %% @doc Default signing authority location for https can be overridden
 %% with the ssl config variable, for example:
 {mapping, "ssl.cacertfile", "riak_core.ssl.cacertfile", [
   {datatype, file},
-  {commented, "{{platform_etc_dir}}/cacertfile.pem"}
+  {commented, "#(platform_etc_dir)/cacertfile.pem"}
 ]}.
 
 %% @doc handoff.port is the TCP port that Riak uses for

--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -7,7 +7,7 @@
 {mapping, "buckets.default.n_val", "riak_core.default_bucket_props.n_val", [
   {datatype, integer},
   {default, 3},
-  {level, advanced}
+  hidden
 ]}.
 
 %% @doc Number of partitions in the cluster (only valid when first
@@ -47,7 +47,7 @@
 {mapping, "ring.state_dir", "riak_core.ring_state_dir", [
   {datatype, directory},
   {default, "#(platform_data_dir)/ring"},
-  {level, advanced}
+  hidden
 ]}.
 
 %% @doc Default cert location for https can be overridden
@@ -76,7 +76,7 @@
 {mapping, "handoff.port", "riak_core.handoff_port", [
   {default, {{handoff_port}} },
   {datatype, integer},
-  {level, advanced}
+  hidden
 ]}.
 
 %% @doc To encrypt riak_core intra-cluster data handoff traffic,
@@ -86,13 +86,13 @@
 {mapping, "handoff.ssl.certfile", "riak_core.handoff_ssl_options.certfile", [
 %%  {commented, "/tmp/erlserver.pem"},
   {datatype, file},
-  {level, advanced}
+  hidden
 ]}.
 
 %% @doc if you need a seperate keyfile for handoff
 {mapping, "handoff.ssl.keyfile", "riak_core.handoff_ssl_options.keyfile", [
   {datatype, file},
-  {level, advanced}
+  hidden
 ]}.
 
 %% @doc DTrace support Do not enable 'dtrace' unless your Erlang/OTP
@@ -107,35 +107,30 @@
 %% @doc Platform-specific installation paths (substituted by rebar)
 {mapping, "platform_bin_dir", "riak_core.platform_bin_dir", [
   {datatype, directory},
-  {level, basic},
   {default, "{{platform_bin_dir}}"}
 ]}.
 
 %% @see platform_bin_dir
 {mapping, "platform_data_dir", "riak_core.platform_data_dir", [
   {datatype, directory},
-  {level, basic},
   {default, "{{platform_data_dir}}"}
 ]}.
 
 %% @see platform_bin_dir
 {mapping, "platform_etc_dir", "riak_core.platform_etc_dir", [
   {datatype, directory},
-  {level, basic},
   {default, "{{platform_etc_dir}}"}
 ]}.
 
 %% @see platform_bin_dir
 {mapping, "platform_lib_dir", "riak_core.platform_lib_dir", [
   {datatype, directory},
-  {level, basic},
   {default, "{{platform_lib_dir}}"}
 ]}.
 
 %% @see platform_bin_dir
 {mapping, "platform_log_dir", "riak_core.platform_log_dir", [
   {datatype, directory},
-  {level, basic},
   {default, "{{platform_log_dir}}"}
 ]}.
 

--- a/test/riak_core_schema_tests.erl
+++ b/test/riak_core_schema_tests.erl
@@ -14,7 +14,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.n_val", 3),
     cuttlefish_unit:assert_config(Config, "riak_core.ring_creation_size", 64),
     cuttlefish_unit:assert_config(Config, "riak_core.handoff_concurrency", 2),
-    cuttlefish_unit:assert_config(Config, "riak_core.ring_state_dir", "./ring"),
+    cuttlefish_unit:assert_config(Config, "riak_core.ring_state_dir", "./data/ring"),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.ssl.certfile"),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.ssl.keyfile"),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.ssl.cacertfile"),
@@ -94,7 +94,6 @@ override_schema_test() ->
 context() ->
     [
         {handoff_port, "8099"},
-        {ring_state_dir , "./ring"},
         {platform_bin_dir , "./bin"},
         {platform_data_dir, "./data"},
         {platform_etc_dir , "./etc"},


### PR DESCRIPTION
This is the first "in the wild" use of Cuttlefish's new Right Hand Side Substitutions.

Check out the change to `ring.state_dir` for an idea of how it's changed, but basically, instead of using `{{platform_data_dir}}` at build time to determine the default, you can now reference `#(platform_data_dir)` which will be evaluated at runtime.
- [x] CSE love
- [x] ProdMgmt love
- [x] Eng love
