### PR TITLE
Attempt to enforce role name uniqueness

### DIFF
--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -374,13 +374,18 @@ authenticate(Username, Password, ConnInfo) ->
 add_user(Username, Options) ->
     case user_exists(Username) of
         false ->
-            case validate_options(Options) of
-                {ok, NewOptions} ->
-                    riak_core_metadata:put({<<"security">>, <<"users">>},
-                                           Username, NewOptions),
-                    ok;
-                Error ->
-                    Error
+            case group_exists(Username) of
+                false ->
+                    case validate_options(Options) of
+                        {ok, NewOptions} ->
+                            riak_core_metadata:put({<<"security">>, <<"users">>},
+                                                   Username, NewOptions),
+                            ok;
+                        Error ->
+                            Error
+                    end;
+                true ->
+                    {error, group_exists_with_same_name}
             end;
         true ->
             {error, user_exists}
@@ -389,13 +394,18 @@ add_user(Username, Options) ->
 add_group(Groupname, Options) ->
     case group_exists(Groupname) of
         false ->
-            case validate_groups_option(Options) of
-                {ok, NewOptions} ->
-                    riak_core_metadata:put({<<"security">>, <<"groups">>},
-                                           Groupname, NewOptions),
-                    ok;
-                Error ->
-                    Error
+            case user_exists(Groupname) of
+                false ->
+                    case validate_groups_option(Options) of
+                        {ok, NewOptions} ->
+                            riak_core_metadata:put({<<"security">>, <<"groups">>},
+                                                   Groupname, NewOptions),
+                            ok;
+                        Error ->
+                            Error
+                    end;
+                true ->
+                    {error, user_exists_with_same_name}
             end;
         true ->
             {error, group_exists}


### PR DESCRIPTION
One proposal for coping with naming conflicts between groups and users for purposes of granting permissions: don't allow conflicts (so far as we can determine).

When strong consistency comes to cluster metadata, we can enforce this more strongly, but for now we can supplement this by adding documentation instructing ops not to create groups and users by the same name.

/cc @Vagabond 
