### PR TITLE
Create role-specific namespace for grants

### DIFF
--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -975,7 +975,12 @@ revoke([Grants, "ON", "ANY", "FROM", Users]) ->
         Other2 ->
             Other2
     end,
-    riak_core_security:add_revoke(Unames, any, Permissions);
+    case riak_core_security:add_revoke(Unames, any, Permissions) of
+        ok -> ok;
+        Error ->
+            io:format("~p~n", [Error]),
+            Error
+    end;
 revoke([Grants, "ON", Type, Bucket, "FROM", Users]) ->
     revoke([Grants, "ON", {list_to_binary(Type), list_to_binary(Bucket)},
             "FROM",
@@ -995,7 +1000,12 @@ revoke([Grants, "ON", Bucket, "FROM", Users]) ->
         Other2 ->
             Other2
     end,
-    riak_core_security:add_revoke(Unames, Bucket, Permissions);
+    case riak_core_security:add_revoke(Unames, Bucket, Permissions) of
+        ok -> ok;
+        Error ->
+            io:format("~p~n", [Error]),
+            Error
+    end;
 revoke(_) ->
     io:format("Usage: revoke <permissions> ON <type> [bucket] FROM <users>"),
     error.


### PR DESCRIPTION
This is an exclusive-or of the `jrd-security-role-uniqueness` branch, which attempted to constrain users and groups to have distinct names. This branch enables operators to define names that overlap by creating distinct places in core metadata for grants for users vs groups.

`riak-admin` will (for grant/revoke only, although that list of commands could be extended trivially) support `user/<user>` and `group/<group>` syntax to disambiguate grants or revokes when names are not unique. The tool will mandate the use of that syntax when name conflicts occur, although at the moment the tools have not been updated to illustrate the syntax or to explicitly ask for it.

The `user/` or `group/` prefixes have also been used internally when generating a list of permissions so that the `print-user` command can identify which permissions apply to the user vs any group by the same name.

/cc @Vagabond 
