### PR TITLE
Treat users and groups as distinct concepts (extended)

### DIFF
--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -24,8 +24,10 @@
          stage_force_replace/1, print_staged/1, commit_staged/1,
          clear_staged/1, transfer_limit/1, pending_claim_percentage/2,
          transfers/1, add_user/1, alter_user/1, del_user/1,
+         add_group/1, alter_group/1, del_group/1,
          add_source/1, del_source/1, grant/1, revoke/1,
          print_users/1, print_user/1, print_sources/1,
+         print_groups/1, print_group/1,
          security_enable/1, security_disable/1, security_status/1, ciphers/1]).
 
 %% @doc Return for a given ring and node, percentage currently owned and
@@ -825,8 +827,13 @@ check_limit(Str) ->
     end.
 
 add_user([Username|Options]) ->
-    try riak_core_security:add_user(list_to_binary(Username),
-                                     parse_options(Options)) of
+    add_role(Username, Options, fun riak_core_security:add_user/2).
+
+add_group([Groupname|Options]) ->
+    add_role(Groupname, Options, fun riak_core_security:add_group/2).
+
+add_role(Name, Options, Fun) ->
+    try Fun(list_to_binary(Name), parse_options(Options)) of
         ok -> ok;
         Error ->
             io:format("~p~n", [Error]),
@@ -839,8 +846,13 @@ add_user([Username|Options]) ->
     end.
 
 alter_user([Username|Options]) ->
-    try riak_core_security:alter_user(list_to_binary(Username),
-                                       parse_options(Options)) of
+    alter_role(Username, Options, fun riak_core_security:alter_user/2).
+
+alter_group([Groupname|Options]) ->
+    alter_role(Groupname, Options, fun riak_core_security:alter_group/2).
+
+alter_role(Name, Options, Fun) ->
+    try Fun(list_to_binary(Name), parse_options(Options)) of
         ok -> ok;
         Error ->
             io:format("~p~n", [Error]),
@@ -853,7 +865,13 @@ alter_user([Username|Options]) ->
     end.
 
 del_user([Username]) ->
-    case riak_core_security:del_user(list_to_binary(Username)) of
+    del_role(Username, fun riak_core_security:del_user/1).
+
+del_group([Groupname]) ->
+    del_role(Groupname, fun riak_core_security:del_group/1).
+
+del_role(Name, Fun) ->
+    case Fun(list_to_binary(Name)) of
         ok -> ok;
         Error ->
             io:format("~p~n", [Error]),
@@ -957,7 +975,12 @@ revoke([Grants, "ON", "ANY", "FROM", Users]) ->
         Other2 ->
             Other2
     end,
-    riak_core_security:add_revoke(Unames, any, Permissions);
+    case riak_core_security:add_revoke(Unames, any, Permissions) of
+        ok -> ok;
+        Error ->
+            io:format("~p~n", [Error]),
+            Error
+    end;
 revoke([Grants, "ON", Type, Bucket, "FROM", Users]) ->
     revoke([Grants, "ON", {list_to_binary(Type), list_to_binary(Bucket)},
             "FROM",
@@ -977,7 +1000,12 @@ revoke([Grants, "ON", Bucket, "FROM", Users]) ->
         Other2 ->
             Other2
     end,
-    riak_core_security:add_revoke(Unames, Bucket, Permissions);
+    case riak_core_security:add_revoke(Unames, Bucket, Permissions) of
+        ok -> ok;
+        Error ->
+            io:format("~p~n", [Error]),
+            Error
+    end;
 revoke(_) ->
     io:format("Usage: revoke <permissions> ON <type> [bucket] FROM <users>"),
     error.
@@ -988,6 +1016,12 @@ print_users([]) ->
 
 print_user([User]) ->
     riak_core_security:print_user(list_to_binary(User)).
+
+print_groups([]) ->
+    riak_core_security:print_groups().
+
+print_group([Group]) ->
+    riak_core_security:print_group(list_to_binary(Group)).
 
 print_sources([]) ->
     riak_core_security:print_sources().


### PR DESCRIPTION
(This consolidates #529 and #533.)

To make it easier to reason about and document the new security behavior, this PR splits roles into users and groups.
- Users (but not groups) can be given authentication information (sources).
- Groups (but not users) can be used to cascade privileges to other groups and users.

Where the code does not or cannot distinguish between users and groups, I continue to refer to roles, but the user interface is constrained to users and groups.

There are 3 projects impacted by this change:
- riak (branch `jrd-security-role-bifurcation`) basho/riak#489
- riak_core (branch `jrd-security-grant-namespace`)
- riak_test (branch `jrd-security-role-bifurcation`) basho/riak_test#538

All should be merged at the same time.

/cc @Vagabond 
