### PR TITLE
Cleanup for permissions assigned to 'all'

### DIFF
--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -541,7 +541,7 @@ del_group(Groupname) ->
             ok
     end.
 
--spec add_grant(userlist(), bucket(), [string()]) -> ok | {error, term()}.
+-spec add_grant(userlist(), bucket() | any, [string()]) -> ok | {error, term()}.
 add_grant(all, Bucket, Grants) ->
     %% all is always valid
     case validate_permissions(Grants) of
@@ -584,7 +584,7 @@ add_grant(Role, Bucket, Grants) ->
     add_grant([Role], Bucket, Grants).
 
 
--spec add_revoke(userlist(), bucket(), [string()]) -> ok | {error, term()}.
+-spec add_revoke(userlist(), bucket() | any, [string()]) -> ok | {error, term()}.
 add_revoke(all, Bucket, Revokes) ->
     %% all is always valid
     case validate_permissions(Revokes) of
@@ -628,7 +628,7 @@ add_revoke(User, Bucket, Revokes) ->
 
 
 -spec add_source(Users :: all | binary() | [binary()], CIDR ::
-                 {inet:ip_address(), non_neg_integer()}, Source :: string(),
+                 {inet:ip_address(), non_neg_integer()}, Source :: atom(),
                  Options :: [{string(), term()}]) -> ok | {error, term()}.
 add_source(all, CIDR, Source, Options) ->
     %% all is always valid

--- a/test/riak_core_security_tests.erl
+++ b/test/riak_core_security_tests.erl
@@ -1,0 +1,182 @@
+-module(riak_core_security_tests).
+-compile(export_all).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+start_manager(Node) ->
+    Dir = atom_to_list(Node),
+    case length(Dir) of
+        0 -> exit(no_dir); %% make sure we don't do something stupid below
+        _ -> ok
+    end,
+    os:cmd("mkdir " ++ Dir),
+    os:cmd("rm -rf " ++ Dir ++ "/"),
+    {ok, Mgr} = riak_core_metadata_manager:start_link([{data_dir, Dir},
+                                     {node_name, Node}]),
+    TreeDir = Dir ++ "/trees",
+    {ok, Tree} = riak_core_metadata_hashtree:start_link(TreeDir),
+    {ok, Bcst} = riak_core_broadcast:start_link([node()], [], [], []),
+    unlink(Bcst),
+    unlink(Tree),
+    unlink(Mgr),
+
+    application:set_env(riak_core, permissions, [{riak_kv,[get,put]}]),
+    {Mgr, Tree, Bcst}.
+
+stop_manager({Mgr, Tree, Bcst}) ->
+    catch exit(Mgr, kill),
+    catch exit(Tree, kill),
+    catch exit(Bcst, kill),
+    ok.
+
+sync_test_() ->
+    {foreach,
+     fun() ->
+             start_manager(node())
+     end,
+     fun(S) ->
+             stop_manager(S)
+     end,
+     [ {"trust auth works",
+        fun() ->
+                ?assertMatch({error, _}, riak_core_security:authenticate(<<"user">>, <<"password">>,
+                                                [{ip, {127, 0, 0, 1}}])),
+                ?assertEqual(ok, riak_core_security:add_user(<<"user">>,
+                                            [{"password","password"}])),
+                ?assertMatch({error, _}, riak_core_security:authenticate(<<"user">>, <<"password">>,
+                                                [{ip, {127, 0, 0, 1}}])),
+                ?assertEqual(ok, riak_core_security:add_source(all, {{127, 0, 0, 1}, 32}, trust, [])),
+                ?assertMatch({ok, _}, riak_core_security:authenticate(<<"user">>, <<"password">>,
+                                                [{ip, {127, 0, 0, 1}}])),
+                %% make sure these don't crash, at least
+                ?assertEqual(ok, riak_core_security:print_users()),
+                ?assertEqual(ok, riak_core_security:print_sources()),
+                ?assertEqual(ok, riak_core_security:print_user(<<"user">>)),
+                ok
+        end},
+       { "password auth works",
+        fun() ->
+                ?assertMatch({error, _}, riak_core_security:authenticate(<<"user">>, <<"password">>,
+                                                [{ip, {127, 0, 0, 1}}])),
+                ?assertEqual(ok, riak_core_security:add_user(<<"user">>,
+                                            [])),
+                ?assertMatch({error, _}, riak_core_security:authenticate(<<"user">>, <<"password">>,
+                                                [{ip, {127, 0, 0, 1}}])),
+                ?assertEqual(ok, riak_core_security:add_source(all, {{127, 0, 0, 1}, 32}, password, [])),
+                ?assertMatch({error, _}, riak_core_security:authenticate(<<"user">>, <<"badpassword">>,
+                                                [{ip, {127, 0, 0, 1}}])),
+                ?assertEqual({error, missing_password}, riak_core_security:authenticate(<<"user">>, <<"password">>,
+                                                [{ip, {127, 0, 0, 1}}])),
+                ?assertEqual(ok, riak_core_security:alter_user(<<"user">>, [{"password", "password"}])),
+                ?assertMatch({error, _}, riak_core_security:authenticate(<<"user">>, <<"badpassword">>,
+                                                [{ip, {127, 0, 0, 1}}])),
+                ?assertMatch({ok, _}, riak_core_security:authenticate(<<"user">>, <<"password">>,
+                                                [{ip, {127, 0, 0, 1}}])),
+                %% make sure these don't crash, at least
+                ?assertEqual(ok, riak_core_security:print_users()),
+                ?assertEqual(ok, riak_core_security:print_sources()),
+                ?assertEqual(ok, riak_core_security:print_user(<<"user">>)),
+                ok
+        end},
+       { "user grant/revoke on type/bucket works",
+        fun() ->
+                ?assertEqual(ok, riak_core_security:add_user(<<"user">>,
+                                            [{"password","password"}])),
+                ?assertEqual(ok, riak_core_security:add_source(all, {{127, 0, 0, 1}, 32}, password, [])),
+                {ok, Ctx} = riak_core_security:authenticate(<<"user">>, <<"password">>,
+                                                [{ip, {127, 0, 0, 1}}]),
+                ?assertMatch({false, _,  _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx)),
+                ?assertEqual(ok, riak_core_security:add_grant(<<"user">>, {<<"default">>, <<"mybucket">>}, ["riak_kv.get"])),
+                ?assertMatch({error, {unknown_permission, _}}, riak_core_security:add_grant(<<"user">>, {<<"default">>, <<"mybucket">>}, ["riak_kv.upsert"])),
+                ?assertMatch({true, _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx)),
+                ?assertEqual(ok, riak_core_security:add_revoke(<<"user">>, {<<"default">>, <<"mybucket">>}, ["riak_kv.get"])),
+                ?assertMatch({error, {unknown_permission, _}}, riak_core_security:add_revoke(<<"user">>, {<<"default">>, <<"mybucket">>}, ["riak_kv.upsert"])),
+                ?assertMatch({false, _, _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx)),
+                %% make sure these don't crash, at least
+                ?assertEqual(ok, riak_core_security:print_users()),
+                ?assertEqual(ok, riak_core_security:print_sources()),
+                ?assertEqual(ok, riak_core_security:print_user(<<"user">>)),
+                ok
+        end},
+       { "group grant/revoke on type/bucket works",
+        fun() ->
+                ?assertEqual(ok, riak_core_security:add_user(<<"user">>,
+                                            [{"password","password"}])),
+                ?assertEqual(ok, riak_core_security:add_group(<<"group">>,
+                                            [])),
+                ?assertEqual(ok, riak_core_security:add_source(<<"user">>, {{127, 0, 0, 1}, 32}, password, [])),
+                {ok, Ctx} = riak_core_security:authenticate(<<"user">>, <<"password">>,
+                                                [{ip, {127, 0, 0, 1}}]),
+                ?assertMatch({false, _,  _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx)),
+                ?assertEqual(ok, riak_core_security:add_grant(<<"group">>, {<<"default">>, <<"mybucket">>}, ["riak_kv.get"])),
+                ?assertMatch({error, {unknown_permission, _}}, riak_core_security:add_grant(<<"group">>, {<<"default">>, <<"mybucket">>}, ["riak_kv.upsert"])),
+                ?assertMatch({false, _, _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx)),
+                ?assertEqual(ok, riak_core_security:alter_user(<<"user">>, [{"groups", ["group"]}])),
+                ?assertMatch({true, _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx)),
+                ?assertEqual(ok, riak_core_security:add_revoke(<<"group">>, {<<"default">>, <<"mybucket">>}, ["riak_kv.get"])),
+                ?assertMatch({error, {unknown_permission, _}}, riak_core_security:add_revoke(<<"group">>, {<<"default">>, <<"mybucket">>}, ["riak_kv.upsert"])),
+                ?assertMatch({false, _, _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx)),
+                ?assertEqual(ok, riak_core_security:add_grant(<<"group">>, {<<"default">>, <<"mybucket">>}, ["riak_kv.get"])),
+                ?assertMatch({true, _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx)),
+                ?assertMatch({error, {unknown_groups, _}}, riak_core_security:alter_user(<<"user">>, [{"groups", ["nogroup"]}])),
+                ?assertEqual(ok, riak_core_security:alter_user(<<"user">>, [{"groups", []}])),
+                ?assertMatch({false, _, _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx)),
+                ?assertEqual(ok, riak_core_security:alter_user(<<"user">>, [{"groups", ["group"]}])),
+                %% make sure these don't crash, at least
+                ?assertEqual(ok, riak_core_security:print_users()),
+                ?assertEqual(ok, riak_core_security:print_sources()),
+                ?assertEqual(ok, riak_core_security:print_user(<<"user">>)),
+                ?assertEqual(ok, riak_core_security:print_groups()),
+                ?assertEqual(ok, riak_core_security:print_group(<<"group">>)),
+                ok
+        end},
+       { "all grant/revoke on type/bucket works",
+        fun() ->
+                ?assertEqual(ok, riak_core_security:add_user(<<"user">>,
+                                            [{"password","password"}])),
+                ?assertEqual(ok, riak_core_security:add_source(<<"user">>, {{127, 0, 0, 1}, 32}, password, [])),
+                {ok, Ctx} = riak_core_security:authenticate(<<"user">>, <<"password">>,
+                                                [{ip, {127, 0, 0, 1}}]),
+                ?assertMatch({false, _,  _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx)),
+                ?assertEqual(ok, riak_core_security:add_grant(all, {<<"default">>, <<"mybucket">>}, ["riak_kv.get"])),
+                ?assertMatch({error, {unknown_permission, _}}, riak_core_security:add_grant(all, {<<"default">>, <<"mybucket">>}, ["riak_kv.upsert"])),
+                ?assertMatch({true, _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx)),
+                ?assertEqual(ok, riak_core_security:add_revoke(all, {<<"default">>, <<"mybucket">>}, ["riak_kv.get"])),
+                ?assertMatch({false, _,  _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx)),
+                %% make sure these don't crash, at least
+                ?assertEqual(ok, riak_core_security:print_users()),
+                ?assertEqual(ok, riak_core_security:print_sources()),
+                ?assertEqual(ok, riak_core_security:print_user(<<"user">>)),
+                ?assertEqual(ok, riak_core_security:print_groups()),
+                ?assertEqual({error, {unknown_group, <<"all">>}}, riak_core_security:print_group(<<"all">>)),
+                ok
+        end},
+       { "groups can be members of groups and inherit permissions from them",
+        fun() ->
+                ?assertEqual(ok, riak_core_security:add_group(<<"sysadmin">>, [])),
+                ?assertEqual(ok, riak_core_security:add_group(<<"superuser">>, [{"groups", ["sysadmin"]}])),
+                ?assertEqual(ok, riak_core_security:add_user(<<"user">>,
+                                            [{"password","password"}])),
+                ?assertEqual(ok, riak_core_security:add_source(<<"user">>, {{127, 0, 0, 1}, 32}, password, [{"groups", ["superuser"]}])),
+                %% sysadmins can get/put on any key in a default bucket
+                ?assertEqual(ok, riak_core_security:add_grant(<<"sysadmin">>, <<"default">>, ["riak_kv.get", "riak_kv.put"])),
+                %% authenticating from the wrong IP
+                ?assertMatch({error, no_matching_sources}, riak_core_security:authenticate(<<"user">>, <<"password">>,
+                                                [{ip, {10, 0, 0, 1}}])),
+                {ok, Ctx} = riak_core_security:authenticate(<<"user">>, <<"password">>,
+                                                [{ip, {127, 0, 0, 1}}]),
+                ?assertMatch({false, _, _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx)),
+                ?assertMatch({false, _, _}, riak_core_security:check_permissions({"riak_kv.put", {<<"default">>, <<"myotherbucket">>}}, Ctx)),
+                ?assertEqual(ok, riak_core_security:alter_user(<<"user">>, [{"groups", ["superuser"]}])),
+                %?assertEqual(ok, riak_core_security:print_user(<<"user">>)),
+                %?assertEqual(ok, riak_core_security:print_group(<<"sysadmin">>)),
+                ?assertEqual(ok, riak_core_security:print_users()),
+                ?assertMatch({true, _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx)),
+                ?assertMatch({true, _}, riak_core_security:check_permissions({"riak_kv.put", {<<"default">>, <<"myotherbucket">>}}, Ctx)),
+                ok
+        end}
+     ]}.
+
+-endif.
+

--- a/test/riak_core_security_tests.erl
+++ b/test/riak_core_security_tests.erl
@@ -30,7 +30,7 @@ stop_manager({Mgr, Tree, Bcst}) ->
     catch exit(Bcst, kill),
     ok.
 
-sync_test_() ->
+security_test_() ->
     {foreach,
      fun() ->
              start_manager(node())

--- a/test/riak_core_security_tests.erl
+++ b/test/riak_core_security_tests.erl
@@ -64,8 +64,6 @@ security_test_() ->
                 ?assertMatch({error, _}, riak_core_security:authenticate(<<"user">>, <<"password">>,
                                                 [{ip, {127, 0, 0, 1}}])),
                 ?assertEqual(ok, riak_core_security:add_source(all, {{127, 0, 0, 1}, 32}, password, [])),
-                ?assertMatch({error, _}, riak_core_security:authenticate(<<"user">>, <<"badpassword">>,
-                                                [{ip, {127, 0, 0, 1}}])),
                 ?assertEqual({error, missing_password}, riak_core_security:authenticate(<<"user">>, <<"password">>,
                                                 [{ip, {127, 0, 0, 1}}])),
                 ?assertEqual(ok, riak_core_security:alter_user(<<"user">>, [{"password", "password"}])),
@@ -87,12 +85,13 @@ security_test_() ->
                 {ok, Ctx} = riak_core_security:authenticate(<<"user">>, <<"password">>,
                                                 [{ip, {127, 0, 0, 1}}]),
                 ?assertMatch({false, _,  _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx)),
-                ?assertEqual(ok, riak_core_security:add_grant(<<"user">>, {<<"default">>, <<"mybucket">>}, ["riak_kv.get"])),
+                ?assertEqual(ok, riak_core_security:add_grant(<<"user">>, {<<"default">>, <<"mybucket">>}, ["riak_kv.get", "riak_kv.put"])),
                 ?assertMatch({error, {unknown_permission, _}}, riak_core_security:add_grant(<<"user">>, {<<"default">>, <<"mybucket">>}, ["riak_kv.upsert"])),
                 ?assertMatch({true, _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx)),
                 ?assertEqual(ok, riak_core_security:add_revoke(<<"user">>, {<<"default">>, <<"mybucket">>}, ["riak_kv.get"])),
                 ?assertMatch({error, {unknown_permission, _}}, riak_core_security:add_revoke(<<"user">>, {<<"default">>, <<"mybucket">>}, ["riak_kv.upsert"])),
                 ?assertMatch({false, _, _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx)),
+                ?assertMatch({true, _}, riak_core_security:check_permissions({"riak_kv.put", {<<"default">>, <<"mybucket">>}}, Ctx)),
                 %% make sure these don't crash, at least
                 ?assertEqual(ok, riak_core_security:print_users()),
                 ?assertEqual(ok, riak_core_security:print_sources()),
@@ -105,7 +104,7 @@ security_test_() ->
                 %% make sure their old grants are gone
                 {ok, Ctx2} = riak_core_security:authenticate(<<"user">>, <<"password">>,
                                                 [{ip, {127, 0, 0, 1}}]),
-                ?assertMatch({false, _,  _}, riak_core_security:check_permissions({"riak_kv.get", {<<"default">>, <<"mybucket">>}}, Ctx2)),
+                ?assertMatch({false, _,  _}, riak_core_security:check_permissions({"riak_kv.put", {<<"default">>, <<"mybucket">>}}, Ctx2)),
                 ok
         end},
        { "group grant/revoke on type/bucket works",

--- a/test/riak_core_security_tests.erl
+++ b/test/riak_core_security_tests.erl
@@ -167,7 +167,7 @@ security_test_() ->
                 ?assertEqual(ok, riak_core_security:add_group(<<"superuser">>, [{"groups", ["sysadmin"]}])),
                 ?assertEqual(ok, riak_core_security:add_user(<<"user">>,
                                             [{"password","password"}])),
-                ?assertEqual(ok, riak_core_security:add_source(<<"user">>, {{127, 0, 0, 1}, 32}, password, [{"groups", ["superuser"]}])),
+                ?assertEqual(ok, riak_core_security:add_source(<<"user">>, {{127, 0, 0, 1}, 32}, password, [])),
                 %% sysadmins can get/put on any key in a default bucket
                 ?assertEqual(ok, riak_core_security:add_grant(<<"sysadmin">>, <<"default">>, ["riak_kv.get", "riak_kv.put"])),
                 %% authenticating from the wrong IP


### PR DESCRIPTION
- When granting or revoking, treat 'all' as a group
- Fix typo that prevented revocation from working for 'all'
- Update `accumulate_grants/2` to pull grants assigned to 'all'
- Block admins from using 'all' as a user or group

Ancillary change, but useful for verifying above and for admins:
- Display grants to a group or user separate from inherited

/cc @Vagabond
