### PR TITLE
Fixes for YZ dialzyer warnings

### DIFF
--- a/src/riak_core_util.erl
+++ b/src/riak_core_util.erl
@@ -401,7 +401,7 @@ rpc_every_member(Module, Function, Args, Timeout) ->
 
 %% @doc Same as rpc_every_member/4, but annotate the result set with
 %%      the name of the node returning the result.
--spec rpc_every_member_ann(module(), atom(), [term()], integer()|infinity)
+-spec rpc_every_member_ann(atom(), atom(), [any()], timeout())
                           -> {Results::[{node(), term()}], Down::[node()]}.
 rpc_every_member_ann(Module, Function, Args, Timeout) ->
     {ok, MyRing} = riak_core_ring_manager:get_my_ring(),
@@ -411,13 +411,13 @@ rpc_every_member_ann(Module, Function, Args, Timeout) ->
 
 %% @doc Perform an RPC call to a list of nodes in parallel, returning the
 %%      results in the same order as the input list.
--spec multi_rpc([node()], module(), function(), [any()]) -> [any()].
+-spec multi_rpc([node()], module(), atom(), [any()]) -> [any()].
 multi_rpc(Nodes, Mod, Fun, Args) ->
     multi_rpc(Nodes, Mod, Fun, Args, infinity).
 
 %% @doc Perform an RPC call to a list of nodes in parallel, returning the
 %%      results in the same order as the input list.
--spec multi_rpc([node()], module(), function(), [any()], timeout()) -> [any()].
+-spec multi_rpc([node()], module(), atom(), [any()], timeout()) -> [any()].
 multi_rpc(Nodes, Mod, Fun, Args, Timeout) ->
     pmap(fun(Node) ->
                  rpc:call(Node, Mod, Fun, Args, Timeout)
@@ -426,7 +426,7 @@ multi_rpc(Nodes, Mod, Fun, Args, Timeout) ->
 %% @doc Perform an RPC call to a list of nodes in parallel, returning the
 %%      results in the same order as the input list. Each result is tagged
 %%      with the corresponding node name.
--spec multi_rpc_ann([node()], module(), function(), [any()])
+-spec multi_rpc_ann([node()], module(), atom(), [any()])
                    -> [{node(), any()}].
 multi_rpc_ann(Nodes, Mod, Fun, Args) ->
     multi_rpc_ann(Nodes, Mod, Fun, Args, infinity).
@@ -434,7 +434,7 @@ multi_rpc_ann(Nodes, Mod, Fun, Args) ->
 %% @doc Perform an RPC call to a list of nodes in parallel, returning the
 %%      results in the same order as the input list. Each result is tagged
 %%      with the corresponding node name.
--spec multi_rpc_ann([node()], module(), function(), [any()], timeout())
+-spec multi_rpc_ann([node()], module(), atom(), [any()], timeout())
                    -> [{node(), any()}].
 multi_rpc_ann(Nodes, Mod, Fun, Args, Timeout) ->
     Results = multi_rpc(Nodes, Mod, Fun, Args, Timeout),
@@ -445,7 +445,7 @@ multi_rpc_ann(Nodes, Mod, Fun, Args, Timeout) ->
 %%      of nodes that are down/unreachable. The results will be returned in
 %%      the same order as the input list, and each result is tagged with the
 %%      corresponding node name.
--spec multicall_ann([node()], module(), function(), [any()])
+-spec multicall_ann([node()], module(), atom(), [any()])
                    -> {Results :: [{node(), any()}], Down :: [node()]}.
 multicall_ann(Nodes, Mod, Fun, Args) ->
     multicall_ann(Nodes, Mod, Fun, Args, infinity).
@@ -455,7 +455,7 @@ multicall_ann(Nodes, Mod, Fun, Args) ->
 %%      of nodes that are down/unreachable. The results will be returned in
 %%      the same order as the input list, and each result is tagged with the
 %%      corresponding node name.
--spec multicall_ann([node()], module(), function(), [any()], timeout())
+-spec multicall_ann([node()], module(), atom(), [any()], timeout())
                    -> {Results :: [{node(), any()}], Down :: [node()]}.
 multicall_ann(Nodes, Mod, Fun, Args, Timeout) ->
     L = multi_rpc_ann(Nodes, Mod, Fun, Args, Timeout),

--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -46,7 +46,8 @@
          all_nodes/1,
          equal/2,
          prune/3,
-         timestamp/0]).
+         timestamp/0,
+         sort/1]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -221,6 +222,12 @@ timestamp() ->
 -spec equal(VClockA :: vclock(), VClockB :: vclock()) -> boolean().
 equal(VA,VB) ->
     lists:sort(VA) =:= lists:sort(VB).
+
+% @doc Sort a vclock. This is here because the opaque vclock() type causes
+%      dialyzer to warn if it's done externally.
+-spec sort(VClockA :: vclock()) -> (VClockA :: vclock()).
+sort(Vclock) ->
+    lists:sort(Vclock).
 
 % @doc Possibly shrink the size of a vclock, depending on current age and size.
 -spec prune(V::vclock(), Now::integer(), BucketProps::term()) -> vclock().


### PR DESCRIPTION
- Replace the function() type definitions with atom() in the multi-call\* family of functions which were causing dialyzer warnings in yokozuna (and possibly other places). Atoms are being passed in, not functions.
- Introduce vlock:sort/1, which simply does a lists:sort on a vlock. Because the vclock type is an opaque type, doing the sort outside the vlock module causes dialyzer to warn as it requires looking at the internals of the vlock type, which is exactly what the -opaque keyword forbids.
