### PR TITLE
Fix dialyzer warnings

### DIFF
--- a/include/riak_core_bg_manager.hrl
+++ b/include/riak_core_bg_manager.hrl
@@ -21,12 +21,12 @@
 -type bg_resource()      :: bg_token() | bg_lock().
 -type bg_resource_type() :: lock | token.
 
--type bg_meta()  :: {atom(), any()}.                %% meta data to associate with a lock/token
+-type bg_meta()  :: undefined | {atom(), any()}.    %% meta data to associate with a lock/token
 -type bg_period() :: pos_integer().                 %% token refill period in milliseconds
 -type bg_count() :: pos_integer().                  %% token refill tokens to count at each refill period
 -type bg_rate() :: undefined | {bg_period(), bg_count()}.       %% token refill rate
 -type bg_concurrency_limit() :: non_neg_integer() | infinity.   %% max lock concurrency allowed
--type bg_consumer() :: {pid, [bg_meta()]}.          %% a consumer of a resource
+-type bg_consumer() :: {undefined | pid(), bg_meta()}.          %% a consumer of a resource
 
 %% Results of a "ps" of live given or blocked locks/tokens
 -record(bg_stat_live,

--- a/include/riak_core_handoff.hrl
+++ b/include/riak_core_handoff.hrl
@@ -36,6 +36,6 @@
           type                  :: ho_type(),
           req_origin            :: node(),
           filter_mod_fun        :: {module(), atom()},
-          size                  :: {non_neg_integer(), bytes | objects}
+          size                  :: {function(), dynamic} | {non_neg_integer(), bytes | objects}
         }).
 -type handoff_status() :: #handoff_status{}.

--- a/include/riak_core_handoff.hrl
+++ b/include/riak_core_handoff.hrl
@@ -17,7 +17,7 @@
 -type ho_type() :: ownership_handoff | hinted_handoff | repair | resize_transfer.
 -type predicate() :: fun((any()) -> boolean()).
 
--type index() :: integer().
+-type index() :: chash:index_as_int().
 -type mod_src_tgt() :: {module(), index(), index()} | {undefined, undefined, undefined}.
 -type mod_partition() :: {module(), index()}.
 

--- a/include/riak_core_vnode.hrl
+++ b/include/riak_core_vnode.hrl
@@ -6,7 +6,7 @@
                   {fsm, undefined, pid()} |        % special case in
                                                    % riak_kv_util:make_request/2.erl
                   ignore.
--type partition() :: non_neg_integer().
+-type partition() :: chash:index_as_int().
 -type vnode_req() :: term().
 -type keyspaces() :: [{partition(), [partition()]}].
 

--- a/include/riak_core_vnode.hrl
+++ b/include/riak_core_vnode.hrl
@@ -1,5 +1,5 @@
 -type sender_type() :: fsm | server | raw.
--type sender() :: {sender_type(), reference(), pid()} |
+-type sender() :: {sender_type(), reference() | tuple(), pid()} |
                   %% TODO: Double-check that these special cases are kosher
                   {server, undefined, undefined} | % special case in
                                                    % riak_core_vnode_master.erl
@@ -8,6 +8,7 @@
                   ignore.
 -type partition() :: non_neg_integer().
 -type vnode_req() :: term().
+-type keyspaces() :: [{partition(), [partition()]}].
 
 -record(riak_vnode_req_v1, {
           index :: partition(),
@@ -16,7 +17,7 @@
 
 -record(riak_coverage_req_v1, {
           index :: partition(),
-          keyspaces :: [{partition(), [partition()]}],
+          keyspaces :: keyspaces(),
           sender=ignore :: sender(),
           request :: vnode_req()}).
 

--- a/src/chash.erl
+++ b/src/chash.erl
@@ -50,7 +50,7 @@
          successors/3,
          update/3]).
 
--export_type([chash/0, index/0]).
+-export_type([chash/0, index/0, index_as_int/0]).
     
 -define(RINGTOP, trunc(math:pow(2,160)-1)).  % SHA-1 space
 
@@ -65,10 +65,10 @@
 -type chash_node() :: term().
 %% Indices into the ring, used as keys for object location, are binary
 %% representations of 160-bit integers.
--type index() :: binary().
+-type index() :: <<_:160>>.
 -type index_as_int() :: integer().
 -type node_entry() :: {index_as_int(), chash_node()}.
--type num_partitions() :: integer().
+-type num_partitions() :: pos_integer().
 
 %% ===================================================================
 %% Public API

--- a/src/chashbin.erl
+++ b/src/chashbin.erl
@@ -31,9 +31,9 @@
 -define(ENTRY, binary-unit:?UNIT).
 
 -type owners_bin() :: <<_:_*?UNIT>>.
--type index()      :: non_neg_integer().
+-type index()      :: chash:index_as_int().
 -type pred_fun()   :: fun(({index(), node()}) -> boolean()).
--type chash_key()  :: <<_:160>> | non_neg_integer().
+-type chash_key()  :: index() | chash:index().
 
 -record(chashbin, {size   :: pos_integer(),
                    owners :: owners_bin(),

--- a/src/chashbin.erl
+++ b/src/chashbin.erl
@@ -24,6 +24,7 @@
          responsible_index/2, responsible_position/2, index_owner/2,
          num_partitions/1]).
 -export([iterator/2, exact_iterator/2, itr_value/1, itr_pop/2, itr_next/1, itr_next_while/2]).
+-export_type([chashbin/0]).
 
 %% 160 bits for hash, 16 bits for node id
 -define(UNIT, 176).

--- a/src/gen_nb_server.erl
+++ b/src/gen_nb_server.erl
@@ -111,7 +111,7 @@ handle_info({inet_async, ListSock, _Ref, {ok, CliSocket}}, #state{cb=Callback, s
   inet_db:register_socket(CliSocket, inet_tcp),
   case Callback:new_connection(CliSocket, ServerState) of
     {ok, NewServerState} ->
-      prim_inet:async_accept(ListSock, -1),
+      {ok, _} = prim_inet:async_accept(ListSock, -1),
       {noreply, State#state{server_state=NewServerState}};
     {stop, Reason, NewServerState} ->
       {stop, Reason, State#state{server_state=NewServerState}}

--- a/src/gen_nb_server.erl
+++ b/src/gen_nb_server.erl
@@ -27,9 +27,6 @@
 %% API
 -export([start_link/4]).
 
-%% Behavior callbacks
--export([behaviour_info/1]).
-
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
@@ -40,18 +37,35 @@
                 sock,
                 server_state}).
 
-%% @hidden
-behaviour_info(callbacks) ->
-  [{init, 1},
-   {handle_call, 3},
-   {handle_cast, 2},
-   {handle_info, 2},
-   {terminate, 2},
-   {sock_opts, 0},
-   {new_connection, 2}];
+-callback init(InitArgs::list()) -> 
+    {ok, State::term()} | 
+    {error, Reason::term()}.
 
-behaviour_info(_) ->
-  undefined.
+-callback handle_call(Msg::term(), From::{pid(), term()}, State::term()) -> 
+    {reply, Reply::term(), State::term()} | 
+    {reply, Reply::term(), State::term(), number() | hibernate} | 
+    {noreply, State::term()} | 
+    {noreply, State::term(), number() | hibernate} | 
+    {stop, Reason::term(), State::term()}.
+
+-callback handle_cast(Msg::term(), State::term()) ->
+    {noreply, State::term()} | 
+    {noreply, State::term(), number() | hibernate} | 
+    {stop, Reason::term(), State::term()}.
+
+-callback handle_info(Msg::term(), State::term()) ->
+    {noreply, State::term()} | 
+    {noreply, State::term(), number() | hibernate} | 
+    {stop, Reason::term(), State::term()}.
+
+-callback terminate(Reason::term(), State::term()) ->    
+    ok.
+
+-callback sock_opts() -> [gen_tcp:listen_option()].
+
+-callback new_connection(gen_tcp:socket(), State::term()) ->    
+    {ok, NewState::term()} | 
+    {stop, Reason::term(), NewState::term()}.
 
 %% @spec start_link(CallbackModule, IpAddr, Port, InitParams) -> Result
 %% CallbackModule = atom()

--- a/src/gen_nb_server.erl
+++ b/src/gen_nb_server.erl
@@ -63,7 +63,7 @@
 
 -callback sock_opts() -> [gen_tcp:listen_option()].
 
--callback new_connection(gen_tcp:socket(), State::term()) ->    
+-callback new_connection(inet:socket(), State::term()) ->
     {ok, NewState::term()} | 
     {stop, Reason::term(), NewState::term()}.
 

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -178,7 +178,7 @@
                 ref            :: term(),
                 path           :: string(),
                 itr            :: term(),
-                write_buffer   :: [{binary(), binary()}],
+                write_buffer   :: [{put, binary(), binary()} | {delete, binary()}],
                 write_buffer_count :: integer(),
                 dirty_segments :: array()
                }).

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -520,7 +520,7 @@ new_segment_store(Opts, State) ->
     Config6 = orddict:store(use_bloomfilter, true, Config5),
     Options = orddict:store(create_if_missing, true, Config6),
 
-    filelib:ensure_dir(DataDir),
+    ok = filelib:ensure_dir(DataDir),
     {ok, Ref} = eleveldb:open(DataDir, Options),
     State#state{ref=Ref, path=DataDir}.
 
@@ -632,7 +632,7 @@ get_disk_bucket(Level, Bucket, #state{id=Id, ref=Ref}) ->
 set_disk_bucket(Level, Bucket, Val, State=#state{id=Id, ref=Ref}) ->
     HKey = encode_bucket(Id, Level, Bucket),
     Bin = term_to_binary(Val),
-    eleveldb:put(Ref, HKey, Bin, []),
+    ok = eleveldb:put(Ref, HKey, Bin, []),
     State.
 
 -spec encode_id(binary() | non_neg_integer()) -> tree_id_bin().

--- a/src/riak_core_apl.erl
+++ b/src/riak_core_apl.erl
@@ -35,7 +35,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--type index() :: non_neg_integer().
+-type index() :: chash:index_as_int().
 -type n_val() :: non_neg_integer().
 -type ring() :: riak_core_ring:riak_core_ring().
 -type preflist() :: [{index(), node()}].

--- a/src/riak_core_apl.erl
+++ b/src/riak_core_apl.erl
@@ -30,7 +30,7 @@
          first_up/2, offline_owners/1, offline_owners/2
         ]).
 
--export_type([preflist/0, preflist2/0]).
+-export_type([preflist/0, preflist_ann/0]).
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
@@ -39,19 +39,20 @@
 -type n_val() :: non_neg_integer().
 -type ring() :: riak_core_ring:riak_core_ring().
 -type preflist() :: [{index(), node()}].
--type preflist2() :: [{{index(), node()}, primary|fallback}].
+-type preflist_ann() :: [{{index(), node()}, primary|fallback}].
 -type iterator() :: term().
 -type chashbin() :: term().
+-type docidx() :: <<_:160>>.
 
 %% Return preflist of all active primary nodes (with no
 %% substituion of fallbacks).  Used to simulate a
 %% preflist with N=ring_size
--spec active_owners(atom()) -> preflist().
+-spec active_owners(atom()) -> preflist_ann().
 active_owners(Service) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     active_owners(Ring, riak_core_node_watcher:nodes(Service)).
 
--spec active_owners(ring(), [node()]) -> preflist().
+-spec active_owners(ring(), [node()]) -> preflist_ann().
 active_owners(Ring, UpNodes) ->
     UpNodes1 = UpNodes,
     Primaries = riak_core_ring:all_owners(Ring),
@@ -59,21 +60,21 @@ active_owners(Ring, UpNodes) ->
     Up.
 
 %% Get the active preflist taking account of which nodes are up
--spec get_apl(binary(), n_val(), atom()) -> preflist().
+-spec get_apl(docidx(), n_val(), atom()) -> preflist().
 get_apl(DocIdx, N, Service) ->
     {ok, CHBin} = riak_core_ring_manager:get_chash_bin(),
     get_apl_chbin(DocIdx, N, CHBin, riak_core_node_watcher:nodes(Service)).
 
 %% Get the active preflist taking account of which nodes are up
 %% for a given chash/upnodes list
--spec get_apl_chbin(binary(), n_val(), ring(), [node()]) -> preflist().
+-spec get_apl_chbin(docidx(), n_val(), chashbin:chashbin(), [node()]) -> preflist().
 get_apl_chbin(DocIdx, N, CHBin, UpNodes) ->
     [{Partition, Node} || {{Partition, Node}, _Type} <-
                               get_apl_ann_chbin(DocIdx, N, CHBin, UpNodes)].
 
 %% Get the active preflist taking account of which nodes are up
 %% for a given ring/upnodes list
--spec get_apl(binary(), n_val(), ring(), [node()]) -> preflist().
+-spec get_apl(docidx(), n_val(), ring(), [node()]) -> preflist().
 get_apl(DocIdx, N, Ring, UpNodes) ->
     [{Partition, Node} || {{Partition, Node}, _Type} <- 
                               get_apl_ann(DocIdx, N, Ring, UpNodes)].
@@ -87,7 +88,7 @@ get_apl_ann(DocIdx, N, UpNodes) ->
 %% Get the active preflist taking account of which nodes are up
 %% for a given chash/upnodes list and annotate each node with type of
 %% primary/fallback
--spec get_apl_ann_chbin(binary(), n_val(), chashbin(), [node()]) -> preflist2().
+-spec get_apl_ann_chbin(binary(), n_val(), chashbin(), [node()]) -> preflist_ann().
 get_apl_ann_chbin(DocIdx, N, CHBin, UpNodes) ->
     UpNodes1 = UpNodes,
     Itr = chashbin:iterator(DocIdx, CHBin),
@@ -98,7 +99,7 @@ get_apl_ann_chbin(DocIdx, N, CHBin, UpNodes) ->
 %% Get the active preflist taking account of which nodes are up
 %% for a given ring/upnodes list and annotate each node with type of
 %% primary/fallback
--spec get_apl_ann(binary(), n_val(), ring(), [node()]) -> preflist2().
+-spec get_apl_ann(binary(), n_val(), ring(), [node()]) -> preflist_ann().
 get_apl_ann(DocIdx, N, Ring, UpNodes) ->
     UpNodes1 = UpNodes,
     Preflist = riak_core_ring:preflist(DocIdx, Ring),
@@ -108,13 +109,13 @@ get_apl_ann(DocIdx, N, Ring, UpNodes) ->
     Up ++ find_fallbacks(Pangs, Fallbacks, UpNodes1, []).
 
 %% Same as get_apl, but returns only the primaries.
--spec get_primary_apl(binary(), n_val(), atom()) -> preflist2().
+-spec get_primary_apl(binary(), n_val(), atom()) -> preflist_ann().
 get_primary_apl(DocIdx, N, Service) ->
     {ok, CHBin} = riak_core_ring_manager:get_chash_bin(),
     get_primary_apl_chbin(DocIdx, N, CHBin, riak_core_node_watcher:nodes(Service)).
 
 %% Same as get_apl, but returns only the primaries.
--spec get_primary_apl_chbin(binary(), n_val(), chashbin(), [node()]) -> preflist2().
+-spec get_primary_apl_chbin(binary(), n_val(), chashbin(), [node()]) -> preflist_ann().
 get_primary_apl_chbin(DocIdx, N, CHBin, UpNodes) ->
     UpNodes1 = UpNodes,
     Itr = chashbin:iterator(DocIdx, CHBin),
@@ -123,7 +124,7 @@ get_primary_apl_chbin(DocIdx, N, CHBin, UpNodes) ->
     Up.
 
 %% Same as get_apl, but returns only the primaries.
--spec get_primary_apl(binary(), n_val(), ring(), [node()]) -> preflist2().
+-spec get_primary_apl(binary(), n_val(), ring(), [node()]) -> preflist_ann().
 get_primary_apl(DocIdx, N, Ring, UpNodes) ->
     UpNodes1 = UpNodes,
     Preflist = riak_core_ring:preflist(DocIdx, Ring),
@@ -154,7 +155,7 @@ offline_owners(Service, CHBin) ->
     DownVNodes.
 
 %% Split a preference list into up and down lists
--spec check_up(preflist(), [node()], preflist2(), preflist()) -> {preflist2(), preflist()}.
+-spec check_up(preflist(), [node()], preflist_ann(), preflist()) -> {preflist_ann(), preflist()}.
 check_up([], _UpNodes, Up, Pangs) ->
     {lists:reverse(Up), lists:reverse(Pangs)};
 check_up([{Partition,Node}|Rest], UpNodes, Up, Pangs) ->
@@ -166,7 +167,7 @@ check_up([{Partition,Node}|Rest], UpNodes, Up, Pangs) ->
     end.
 
 %% Find fallbacks for downed nodes in the preference list
--spec find_fallbacks(preflist(), preflist(), [node()], preflist2()) -> preflist2().
+-spec find_fallbacks(preflist(), preflist(), [node()], preflist_ann()) -> preflist_ann().
 find_fallbacks(_Pangs, [], _UpNodes, Secondaries) ->
     lists:reverse(Secondaries);
 find_fallbacks([], _Fallbacks, _UpNodes, Secondaries) ->
@@ -181,7 +182,7 @@ find_fallbacks([{Partition, _Node}|Rest]=Pangs, [{_,FN}|Fallbacks], UpNodes, Sec
     end.
 
 %% Find fallbacks for downed nodes in the preference list
--spec find_fallbacks_chbin(preflist(), iterator(),[node()], preflist2()) -> preflist2().
+-spec find_fallbacks_chbin(preflist(), iterator(),[node()], preflist_ann()) -> preflist_ann().
 find_fallbacks_chbin([], _Fallbacks, _UpNodes, Secondaries) ->
     lists:reverse(Secondaries);
 find_fallbacks_chbin(_, done, _UpNodes, Secondaries) ->

--- a/src/riak_core_bg_manager.erl
+++ b/src/riak_core_bg_manager.erl
@@ -403,10 +403,10 @@ query_resource(Resource, Types) ->
 %%%
 
 -record(state,
-        {info_table:: ets:tid(),          %% TableID of ?BG_INFO_ETS_TABLE
-         entry_table:: ets:tid(),         %% TableID of ?BG_ENTRY_ETS_TABLE
-         enabled :: boolean(),            %% Global enable/disable switch, true at startup
-         bypassed:: boolean()             %% Global kill switch. false at startup
+        {info_table:: ets:tab(),  %% TableID of ?BG_INFO_ETS_TABLE
+         entry_table:: ets:tab(), %% TableID of ?BG_ENTRY_ETS_TABLE
+         enabled :: boolean(),    %% Global enable/disable switch, true at startup
+         bypassed:: boolean()     %% Global kill switch. false at startup
         }).
 
 %%%===================================================================
@@ -561,7 +561,7 @@ validate_hold({Key,Entry}=Obj, TableId) when ?e_type(Entry) == lock ->
             ets:delete_object(TableId, Obj)
     end;
 validate_hold(_Obj, _TableId) -> %% tokens don't monitor processes
-    ok.
+    true.
 
 %% @doc Update state with bypassed status and store to ETS
 update_bypassed(_Bypassed, State) when ?NOT_TRANSFERED(State) ->

--- a/src/riak_core_bg_manager.erl
+++ b/src/riak_core_bg_manager.erl
@@ -541,7 +541,7 @@ status_of(_E,_S) -> disabled.
 %%      Walk through the given resources and release any holds by dead processes.
 %%      Assumes TableId is always valid (called only after transfer)
 validate_holds(State=#state{entry_table=TableId}) ->
-    [validate_hold(Obj, TableId) || Obj <- ets:match_object(TableId, {{given, '_'},'_'})],
+    _ = [validate_hold(Obj, TableId) || Obj <- ets:match_object(TableId, {{given, '_'},'_'})],
     State.
 
 %% @private
@@ -706,7 +706,7 @@ release_resource(Ref, State=#state{entry_table=TableId}) ->
     %% There should only be one instance of the object, but we'll zap all that match.
     Given = [Obj || Obj <- ets:match_object(TableId, {{given, '_'},'_'})],
     Matches = [Obj || {_Key,Entry}=Obj <- Given, ?e_ref(Entry) == Ref],
-    [ets:delete_object(TableId, Obj) || Obj <- Matches],
+    _ = [ets:delete_object(TableId, Obj) || Obj <- Matches],
     State.
 
 maybe_honor_limit(true, Lock, Limit, #state{entry_table=TableId}) ->
@@ -716,7 +716,7 @@ maybe_honor_limit(true, Lock, Limit, #state{entry_table=TableId}) ->
         true ->
             {_Keep, Discards} = lists:split(Limit, Held),
             %% killing of processes will generate 'DOWN' messages and release the locks
-            [erlang:exit(?e_pid(Discard), max_concurrency) || Discard <- Discards],
+            _ = [erlang:exit(?e_pid(Discard), max_concurrency) || Discard <- Discards],
             ok;
         false ->
             ok
@@ -780,7 +780,8 @@ resource_info_tuple(Resource, State) ->
 %% after a crash. Assumes table is available. Called only after Transfer.
 reschedule_token_refills(State) ->
     Tokens = all_registered_resources(token, State),
-    [schedule_refill_tokens(Token, State) || Token <- Tokens].
+    _ = [schedule_refill_tokens(Token, State) || Token <- Tokens],
+    ok.
  
 %% Schedule a timer event to refill tokens of given type
 schedule_refill_tokens(_Token, State) when ?NOT_TRANSFERED(State) ->

--- a/src/riak_core_bg_manager.erl
+++ b/src/riak_core_bg_manager.erl
@@ -790,7 +790,8 @@ schedule_refill_tokens(Token, State) ->
         undefined ->
             ok;
         {Period, _Count} ->
-            erlang:send_after(Period, self(), {refill_tokens, Token})
+            erlang:send_after(Period, self(), {refill_tokens, Token}),
+            ok
     end.
 
 %% @private

--- a/src/riak_core_broadcast.erl
+++ b/src/riak_core_broadcast.erl
@@ -55,13 +55,13 @@
           %% Initially trees rooted at each node are the same.
           %% Portions of that tree belonging to this node are
           %% shared in this set.
-          common_eagers :: ordset:ordset(nodename()),
+          common_eagers :: ordsets:ordset(nodename()),
 
           %% Initially trees rooted at each node share the same lazy links.
           %% Typically this set will contain a single element. However, it may
           %% contain more in large clusters and may be empty for clusters with
           %% less than three nodes.
-          common_lazys  :: ordset:ordset(nodename()),
+          common_lazys  :: ordsets:ordset(nodename()),
 
           %% A mapping of sender node (root of each broadcast tree)
           %% to this node's portion of the tree. Elements are
@@ -69,14 +69,14 @@
           %% propogate to this node. Nodes that are never the
           %% root of a message will never have a key added to
           %% `eager_sets'
-          eager_sets    :: [{nodename(), ordset:ordset(nodename())}],
+          eager_sets    :: [{nodename(), ordsets:ordset(nodename())}],
 
           %% A Mapping of sender node (root of each spanning tree)
           %% to this node's set of lazy peers. Elements are added
           %% to this structure as messages rooted at a node
           %% propogate to this node. Nodes that are never the root
           %% of a message will never have a key added to `lazy_sets'
-          lazy_sets     :: [{nodename(), ordset:ordset(nodename())}],
+          lazy_sets     :: [{nodename(), ordsets:ordset(nodename())}],
 
           %% Lazy messages that have not been acked. Messages are added to
           %% this set when a node is sent a lazy message (or when it should be
@@ -94,7 +94,7 @@
 
           %% Set of all known members. Used to determine
           %% which members have joined and left during a membership update
-          all_members   :: ordset:ordset(nodename())
+          all_members   :: ordsets:ordset(nodename())
          }).
 
 %%%===================================================================
@@ -155,13 +155,13 @@ ring_update(Ring) ->
 
 %% @doc Returns the broadcast servers view of full cluster membership.
 %% Wait indefinitely for a response is returned from the process
--spec broadcast_members() -> ordset:ordset(nodename()).
+-spec broadcast_members() -> ordsets:ordset(nodename()).
 broadcast_members() ->
     broadcast_members(infinity).
 
 %% @doc Returns the broadcast servers view of full cluster membership.
 %% Waits `Timeout' ms for a response from the server
--spec broadcast_members(infinity | pos_integer()) -> ordset:ordset(nodename()).
+-spec broadcast_members(infinity | pos_integer()) -> ordsets:ordset(nodename()).
 broadcast_members(Timeout) ->
     gen_server:call(?SERVER, broadcast_members, Timeout).
 
@@ -190,21 +190,21 @@ cancel_exchanges(WhichExchanges) ->
 
 %% @doc return the peers for `Node' for the tree rooted at `Root'.
 %% Wait indefinitely for a response is returned from the process
--spec debug_get_peers(node(), node()) -> {ordset:ordset(node()), ordset:ordset(node())}.
+-spec debug_get_peers(node(), node()) -> {ordsets:ordset(node()), ordsets:ordset(node())}.
 debug_get_peers(Node, Root) ->
     debug_get_peers(Node, Root, infinity).
 
 %% @doc return the peers for `Node' for the tree rooted at `Root'.
 %% Waits `Timeout' ms for a response from the server
 -spec debug_get_peers(node(), node(), infinity | pos_integer()) ->
-                             {ordset:ordset(node()), ordset:ordset(node())}.
+                             {ordsets:ordset(node()), ordsets:ordset(node())}.
 debug_get_peers(Node, Root, Timeout) ->
     gen_server:call({?SERVER, Node}, {get_peers, Root}, Timeout).
 
 %% @doc return peers for all `Nodes' for tree rooted at `Root'
 %% Wait indefinitely for a response is returned from the process
 -spec debug_get_tree(node(), [node()]) ->
-                            [{node(), {ordset:ordset(node()), ordset:ordset(node())}}].
+                            [{node(), {ordsets:ordset(node()), ordsets:ordset(node())}}].
 debug_get_tree(Root, Nodes) ->
     [begin
          Peers = try debug_get_peers(Node, Root)

--- a/src/riak_core_bucket_props.erl
+++ b/src/riak_core_bucket_props.erl
@@ -119,53 +119,54 @@ resolve(PropsA, PropsB) when is_list(PropsA) andalso
     PropsASorted = lists:ukeysort(1, PropsA),
     PropsBSorted = lists:ukeysort(1, PropsB),
     {_, Resolved} = lists:foldl(fun({KeyA, _}=PropA, {[{KeyA, _}=PropB | RestB], Acc}) ->
-                                        {RestB, [{KeyA, resolve(PropA, PropB)} | Acc]};
+                                        {RestB, [{KeyA, resolve_prop(PropA, PropB)} | Acc]};
                                    (PropA, {RestB, Acc}) ->
                                         {RestB, [PropA | Acc]}
                                 end,
                                 {PropsBSorted, []},
                                 PropsASorted),
-    Resolved;
-resolve({allow_mult, Mult1}, {allow_mult, Mult2}) ->
+    Resolved.
+
+resolve_prop({allow_mult, Mult1}, {allow_mult, Mult2}) ->
     Mult1 orelse Mult2; %% assumes allow_mult=true is default
-resolve({basic_quorum, Basic1}, {basic_quorum, Basic2}) ->
+resolve_prop({basic_quorum, Basic1}, {basic_quorum, Basic2}) ->
     Basic1 andalso Basic2;
-resolve({big_vclock, Big1}, {big_vclock, Big2}) ->
+resolve_prop({big_vclock, Big1}, {big_vclock, Big2}) ->
     max(Big1, Big2);
-resolve({chash_keyfun, KeyFun1}, {chash_keyfun, _KeyFun2}) ->
+resolve_prop({chash_keyfun, KeyFun1}, {chash_keyfun, _KeyFun2}) ->
     KeyFun1; %% arbitrary choice
-resolve({dw, DW1}, {dw, DW2}) ->
+resolve_prop({dw, DW1}, {dw, DW2}) ->
     %% 'quorum' wins over set numbers
     max(DW1, DW2);
-resolve({last_write_wins, LWW1}, {last_write_wins, LWW2}) ->
+resolve_prop({last_write_wins, LWW1}, {last_write_wins, LWW2}) ->
     LWW1 andalso LWW2;
-resolve({linkfun, LinkFun1}, {linkfun, _LinkFun2}) ->
+resolve_prop({linkfun, LinkFun1}, {linkfun, _LinkFun2}) ->
     LinkFun1; %% arbitrary choice
-resolve({n_val, N1}, {n_val, N2}) ->
+resolve_prop({n_val, N1}, {n_val, N2}) ->
     max(N1, N2);
-resolve({notfound_ok, NF1}, {notfound_ok, NF2}) ->
+resolve_prop({notfound_ok, NF1}, {notfound_ok, NF2}) ->
     NF1 orelse NF2;
-resolve({old_vclock, Old1}, {old_vclock, Old2}) ->
+resolve_prop({old_vclock, Old1}, {old_vclock, Old2}) ->
     max(Old1, Old2);
-resolve({postcommit, PC1}, {postcommit, PC2}) ->
+resolve_prop({postcommit, PC1}, {postcommit, PC2}) ->
     resolve_hooks(PC1, PC2);
-resolve({pr, PR1}, {pr, PR2}) ->
+resolve_prop({pr, PR1}, {pr, PR2}) ->
     max(PR1, PR2);
-resolve({precommit, PC1}, {precommit, PC2}) ->
+resolve_prop({precommit, PC1}, {precommit, PC2}) ->
     resolve_hooks(PC1, PC2);
-resolve({pw, PW1}, {pw, PW2}) ->
+resolve_prop({pw, PW1}, {pw, PW2}) ->
     max(PW1, PW2);
-resolve({r, R1}, {r, R2}) ->
+resolve_prop({r, R1}, {r, R2}) ->
     max(R1, R2);
-resolve({rw, RW1}, {rw, RW2}) ->
+resolve_prop({rw, RW1}, {rw, RW2}) ->
     max(RW1, RW2);
-resolve({small_vclock, Small1}, {small_vclock, Small2}) ->
+resolve_prop({small_vclock, Small1}, {small_vclock, Small2}) ->
     max(Small1, Small2);
-resolve({w, W1}, {w, W2}) ->
+resolve_prop({w, W1}, {w, W2}) ->
     max(W1, W2);
-resolve({young_vclock, Young1}, {young_vclock, Young2}) ->
+resolve_prop({young_vclock, Young1}, {young_vclock, Young2}) ->
     max(Young1, Young2);
-resolve({_, V1}, {_, _V2}) ->
+resolve_prop({_, V1}, {_, _V2}) ->
     V1.
 
 resolve_hooks(Hooks1, Hooks2) ->

--- a/src/riak_core_capability.erl
+++ b/src/riak_core_capability.erl
@@ -90,7 +90,7 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
--type capability() :: atom().
+-type capability() :: atom() | {atom(), atom()}.
 -type mode() :: term().
 
 -record(capability, {supported :: [mode()],

--- a/src/riak_core_capability.erl
+++ b/src/riak_core_capability.erl
@@ -409,11 +409,6 @@ add_supported_to_ring(Node, Supported, Ring) ->
 %% list of application env overrides, and the current view of all node's
 %% supported capabilities, determine the most preferred mode for each capability
 %% that is supported by all nodes.
--spec preferred_modes([{capability(), [mode()]}],
-                      [{node(), [{capability(), [mode()]}]}],
-                      registered(),
-                      [{capability(), [mode()]}])
-                     -> [{capability(), mode()}].
 preferred_modes(MyCaps, Capabilities, Registered, Override) ->
     N1 = reformat_capabilities(Registered, Capabilities),
     N2 = intersect_capabilities(N1),

--- a/src/riak_core_capability.erl
+++ b/src/riak_core_capability.erl
@@ -195,7 +195,7 @@ make_capability(Capability, Supported, Default, Legacy) ->
 %%%===================================================================
 
 init([]) ->
-    ets:new(?ETS, [named_table, {read_concurrency, true}]),
+    ?ETS = ets:new(?ETS, [named_table, {read_concurrency, true}]),
     schedule_tick(),
     Registered = load_registered(),
     State = init_state(Registered),

--- a/src/riak_core_claim.erl
+++ b/src/riak_core_claim.erl
@@ -411,7 +411,8 @@ choose_claim_v3(Ring, _ClaimNode, Params) ->
         undefined ->
             ok;
         _ ->
-            {_,_,_} = random:seed(OldSeed)
+            {_,_,_} = random:seed(OldSeed),
+            ok
     end,
 
     lager:debug("Claim3 metrics: ~p\n", [NewMetrics]),

--- a/src/riak_core_claim.erl
+++ b/src/riak_core_claim.erl
@@ -411,7 +411,7 @@ choose_claim_v3(Ring, _ClaimNode, Params) ->
         undefined ->
             ok;
         _ ->
-            random:seed(OldSeed)
+            {_,_,_} = random:seed(OldSeed)
     end,
 
     lager:debug("Claim3 metrics: ~p\n", [NewMetrics]),

--- a/src/riak_core_claim.erl
+++ b/src/riak_core_claim.erl
@@ -455,7 +455,7 @@ claim_v3(Wants, Owners, Params) ->
             NIs = build_nis(Wants, Owners),
 
             lager:debug("claim3 - NIs\n",[]),
-            [lager:debug("  ~p\n", [NI]) || NI <- NIs],
+            _ = [lager:debug("  ~p\n", [NI]) || NI <- NIs],
 
             %% Generate plans that resolve violations and overloads
             Plans = lists:usort(make_plans(Trials, NIs, Q, TN)),

--- a/src/riak_core_claim_sim.erl
+++ b/src/riak_core_claim_sim.erl
@@ -412,7 +412,7 @@ commission(Base, Test, {Wants, Choose}) ->
             ok
     end,
     
-    filelib:ensure_dir(filename:join(Dir, empty)),
+    ok = filelib:ensure_dir(filename:join(Dir, empty)),
 
     {ok, SeqFh} = file:open(filename:join([Dir, "sequential.txt"]), [write]),
     io:format(SeqFh, "cmds,balance,violations,diversity\n", []),
@@ -431,7 +431,7 @@ commission(Base, Test, {Wants, Choose}) ->
                   put(sim_seq, Seq+1),
                   FN = filename:join([Dir, 
                                       "sj"++integer_to_list(Seq)++".ring" ]),
-                  file:write_file(FN, term_to_binary(Ring2)),
+                  ok = file:write_file(FN, term_to_binary(Ring2)),
 
                   Stats = try
                               riak_core_claim_util:ring_stats(Ring2, TN)
@@ -448,7 +448,7 @@ commission(Base, Test, {Wants, Choose}) ->
           end},
     put(sim_seq, 2),
     dryrun(Ring, SeqJoinCmds, SeqSimOpts),
-    file:close(SeqFh),
+    ok = file:close(SeqFh),
 
     %% Bulk node joins
     %%   bulk join N nodes to a single node
@@ -466,7 +466,7 @@ commission(Base, Test, {Wants, Choose}) ->
                   put(sim_seq, Seq+1),
                   FN = filename:join([Dir, 
                                       "bk"++integer_to_list(Nodes)++".ring" ]),
-                  file:write_file(FN, term_to_binary(Ring2)),
+                  ok = file:write_file(FN, term_to_binary(Ring2)),
 
                   Stats = try
                               riak_core_claim_util:ring_stats(Ring2, TN)

--- a/src/riak_core_claim_sim.erl
+++ b/src/riak_core_claim_sim.erl
@@ -401,10 +401,6 @@ commission(Base, Test, {Wants, Choose}) ->
     BulkJoinCmds =  [ [ {join, sim_node(I)} || I <- lists:seq(2, Nodes) ] ],
 
     Dir = commission_test_dir(Base, RingSize, Nodes, NVal, TN, Choose),
-    filename:join(Base,
-                  lists:flatten(io_lib:format("q~b_s~b_n~b_t~b_~p", 
-                                              [RingSize, Nodes, NVal, TN,
-                                               element(2, Choose)]))),
     case filelib:is_dir(Dir) of
         true ->
             throw(already_generated);

--- a/src/riak_core_claim_sim.erl
+++ b/src/riak_core_claim_sim.erl
@@ -163,7 +163,7 @@ read_ringfile(RingFile) ->
     end.
 
 setup_environment(Vars) ->
-    [application:set_env(riak_core, Key, Val) || {Key, Val} <- Vars],
+    _ = [application:set_env(riak_core, Key, Val) || {Key, Val} <- Vars],
     ok.
 
 %% Perform the dry run, if printing is disabled, return the ring
@@ -237,7 +237,7 @@ make_rebalance(IoDev, TN) ->
             o(IoDev, "Pending: ~p~n", [length(Next)]),
             BadPL = riak_core_ring_util:check_ring(Ring2, TN),
             o(IoDev, "Preflists violating targetN=~p: ~p~n", [TN, length(BadPL)]),
-            [o(IoDev, "~b transfers from ~p to ~p~n", [Count, PrevOwner, NewOwner])
+            _ = [o(IoDev, "~b transfers from ~p to ~p~n", [Count, PrevOwner, NewOwner])
              || {{PrevOwner, NewOwner}, Count} <- dict:to_list(Tally)],
             ok
     end.
@@ -368,15 +368,15 @@ o(IoDev, Fmt, Args) ->
 
 %% Run each commission test against each commission claim
 commission() ->
-    commission("."),
-    ok.
+    commission(".").
 
 commission(Base) ->
     Claims = commission_claims(),
-    [begin
+    _ = [begin
          io:format("~p\n", [Test]),
          commission(Base, Test, Claims)
-     end || Test <- commission_tests_first()].
+     end || Test <- commission_tests_first()],
+    ok.
 
 commission(Base, Test) ->
     commission(Base, Test, commission_claims()).

--- a/src/riak_core_claimant.erl
+++ b/src/riak_core_claimant.erl
@@ -764,7 +764,7 @@ bootstrap_members(Ring) ->
     RootMembers = riak_ensemble_manager:get_members(root),
     Known = riak_ensemble_manager:rget(members, []),
     Need = Members -- Known,
-    [riak_ensemble_manager:join(node(), Member) || Member <- Need],
+    _ = [riak_ensemble_manager:join(node(), Member) || Member <- Need],
 
     RootNodes = [Node || {_, Node} <- RootMembers],
     RootAdd = Members -- RootNodes,
@@ -1018,10 +1018,9 @@ inform_removed_nodes(Node, OldRing, NewRing) ->
     Invalid = riak_core_ring:members(NewRing, [invalid]),
     Changed = ordsets:intersection(ordsets:from_list(Exiting),
                                    ordsets:from_list(Invalid)),
-    lists:map(fun(ExitingNode) ->
-                      %% Tell exiting node to shutdown.
-                      riak_core_ring_manager:refresh_ring(ExitingNode, CName)
-              end, Changed),
+    %% Tell exiting node to shutdown.
+    _ = [riak_core_ring_manager:refresh_ring(ExitingNode, CName) || 
+            ExitingNode <- Changed],
     ok.
 
 do_claimant_quiet(Node, CState, Replacing, Seed) ->
@@ -1194,7 +1193,7 @@ update_ring(CNode, CState, Replacing, Seed, Log, false) ->
             OldS = ordsets:from_list([{Idx,O,NO} || {Idx,O,NO,_,_} <- Next0]),
             NewS = ordsets:from_list([{Idx,O,NO} || {Idx,O,NO,_,_} <- Next4]),
             Diff = ordsets:subtract(NewS, OldS),
-            [Log(next, NChange) || NChange <- Diff],
+            _ = [Log(next, NChange) || NChange <- Diff],
             ?ROUT("Updating ring :: next3 : ~p~n", [Next4]),
             CState5 = riak_core_ring:set_pending_changes(CState4, Next4),
             CState6 = riak_core_ring:increment_ring_version(CNode, CState5),
@@ -1355,7 +1354,7 @@ remove_node(CState, Node, Status, Replacing, Seed, Log, Indices) ->
                PrevOwner /= NewOwner,
                not lists:member(Idx, RemovedIndices)],
 
-    [Log(reassign, {Idx, NewOwner, CState}) || {Idx, NewOwner} <- Reassign],
+    _ = [Log(reassign, {Idx, NewOwner, CState}) || {Idx, NewOwner} <- Reassign],
 
     %% Unlike rebalance_ring, remove_node can be called when Next is non-empty,
     %% therefore we need to merge the values. Original Next has priority.

--- a/src/riak_core_claimant.erl
+++ b/src/riak_core_claimant.erl
@@ -403,7 +403,7 @@ maybe_commit_staged(Ring, State=#state{changes=Changes, seed=Seed}) ->
         {legacy, _} ->
             {ignore, legacy};
         {error, invalid_resize_claim} ->
-            lager:error("invalid_resize_claim BUG");
+            {ignore, invalid_resize_claim};
         {ok, NextRing} ->
             maybe_commit_staged(Ring, NextRing, State)
     end.

--- a/src/riak_core_claimant.erl
+++ b/src/riak_core_claimant.erl
@@ -402,6 +402,8 @@ maybe_commit_staged(Ring, State=#state{changes=Changes, seed=Seed}) ->
     case compute_next_ring(Changes2, Seed, Ring) of
         {legacy, _} ->
             {ignore, legacy};
+        {error, invalid_resize_claim} ->
+            lager:error("invalid_resize_claim BUG");
         {ok, NextRing} ->
             maybe_commit_staged(Ring, NextRing, State)
     end.

--- a/src/riak_core_claimant.erl
+++ b/src/riak_core_claimant.erl
@@ -994,10 +994,10 @@ internal_ring_changed(Node, CState) ->
     case {IsClaimant, riak_core_ring:cluster_name(CState5)} of
         {true, undefined} ->
             ClusterName = {Node, erlang:now()},
-            riak_core_util:rpc_every_member(riak_core_ring_manager,
-                                            set_cluster_name,
-                                            [ClusterName],
-                                            1000),
+            {_,_} = riak_core_util:rpc_every_member(riak_core_ring_manager,
+                                                    set_cluster_name,
+                                                    [ClusterName],
+                                                    1000),
             ok;
         _ ->
             ClusterName = riak_core_ring:cluster_name(CState5),

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -757,6 +757,11 @@ commit_staged([]) ->
         {error, plan_changed} ->
             io:format("The plan has changed. Verify with "
                       "'riak-admin cluster plan' before committing~n");
+        {error, invalid_resize_claim} ->
+            io:format("Unable to commit staged ring changes.~n"
+                      "Check that there are no pending changes in 'riak-admin ring-status'~n"
+                      "If there are, try again once they are completed,~n"
+                      "Otherwise try again shortly.~n");
         _ ->
             io:format("Unable to commit cluster changes. Plan "
                       "may have changed, please verify the~n"

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -260,10 +260,10 @@ transfers([]) ->
         end,
 
     io:format("~nActive Transfers:~n~n", []),
-    [DisplayXfer(Xfer) || Xfer <- lists:flatten(Xfers)],
+    _ = [DisplayXfer(Xfer) || Xfer <- lists:flatten(Xfers)],
 
     io:format("~n"),
-    [DisplayDown(Node) || Node <- Down],
+    _ = [DisplayDown(Node) || Node <- Down],
     ok.
 
 print_v2_status(Type, Mod, {SrcPartition, TargetPartition}, StartTS) ->
@@ -631,7 +631,7 @@ print_plan(Changes, Ring, NextRings) ->
     io:format("Action         Details(s)~n"),
     io:format("~79..-s~n", [""]),
 
-    lists:map(fun({Node, join}) ->
+    lists:foreach(fun({Node, join}) ->
                       io:format("join           ~p~n", [Node]);
                  ({Node, leave}) ->
                       io:format("leave          ~p~n", [Node]);
@@ -651,7 +651,7 @@ print_plan(Changes, Ring, NextRings) ->
     io:format("~79..-s~n", [""]),
     io:format("~n"),
 
-    lists:map(fun({Node, remove}) ->
+    lists:foreach(fun({Node, remove}) ->
                       io:format("WARNING: All of ~p replicas will be lost~n", [Node]);
                  ({Node, {force_replace, _}}) ->
                       io:format("WARNING: All of ~p replicas will be lost~n", [Node]);
@@ -670,13 +670,13 @@ print_plan(Changes, Ring, NextRings) ->
                       "cluster transitions~n~n", [Transitions])
     end,
 
-    lists:mapfoldl(fun({Ring1, Ring2}, I) ->
+    _ = lists:foldl(fun({Ring1, Ring2}, I) ->
                            io:format("~79..#s~n", [""]),
                            io:format("~24.. s After cluster transition ~b/~b~n",
                                      ["", I, Transitions]),
                            io:format("~79..#s~n~n", [""]),
                            output(Ring1, Ring2),
-                           {ok, I+1}
+                           I+1
                    end, 1, NextRings),
     ok.
 
@@ -713,8 +713,8 @@ output(Ring, NextRing) ->
         _ ->
             io:format("Partitions reassigned from cluster changes: ~p~n",
                       [length(Reassigned)]),
-            [io:format("  ~b reassigned from ~p to ~p~n", [Count, PrevOwner, NewOwner])
-             || {{PrevOwner, NewOwner}, Count} <- ReassignedTally],
+            _ = [io:format("  ~b reassigned from ~p to ~p~n", [Count, PrevOwner, NewOwner])
+                 || {{PrevOwner, NewOwner}, Count} <- ReassignedTally],
             io:format("~n"),
             ok
     end,
@@ -727,8 +727,8 @@ output(Ring, NextRing) ->
         _ ->
             io:format("Transfers resulting from cluster changes: ~p~n",
                       [length(Next)]),
-            [io:format("  ~b transfers from ~p to ~p~n", [Count, PrevOwner, NewOwner])
-             || {{PrevOwner, NewOwner}, Count} <- NextTally],
+            _ = [io:format("  ~b transfers from ~p to ~p~n", [Count, PrevOwner, NewOwner])
+                 || {{PrevOwner, NewOwner}, Count} <- NextTally],
             ok,
             io:format("~n")
     end,

--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -200,7 +200,8 @@ maybe_start_timeout_timer(infinity) ->
 maybe_start_timeout_timer(Bad) when not is_integer(Bad) ->
     maybe_start_timeout_timer(?DEFAULT_TIMEOUT);
 maybe_start_timeout_timer(Timeout) ->
-    gen_fsm:start_timer(Timeout, {timer_expired, Timeout}).
+    gen_fsm:start_timer(Timeout, {timer_expired, Timeout}),
+    ok.
 
 
 %% @private

--- a/src/riak_core_coverage_plan.erl
+++ b/src/riak_core_coverage_plan.erl
@@ -29,7 +29,7 @@
 %% API
 -export([create_plan/5]).
 
--type index() :: non_neg_integer().
+-type index() :: chash:index_as_int().
 -type req_id() :: non_neg_integer().
 -type coverage_vnodes() :: [{index(), node()}].
 -type vnode_filters() :: [{node(), [{index(), [index()]}]}].

--- a/src/riak_core_dist_mon.erl
+++ b/src/riak_core_dist_mon.erl
@@ -81,7 +81,7 @@ handle_info({nodeup, Node, _InfoList}, #state{sndbuf=SndBuf,
             lager:error("Could not get dist for ~p\n~p\n", [Node, DistCtrl]),
             {noreply, State};
         Port ->
-            set_port_buffers(Port, SndBuf, RecBuf),
+            ok = set_port_buffers(Port, SndBuf, RecBuf),
             {noreply, State}
     end;
 handle_info({nodedown, _Node, _InfoList}, State) ->

--- a/src/riak_core_dist_mon.erl
+++ b/src/riak_core_dist_mon.erl
@@ -51,7 +51,7 @@ init(_) ->
     {SndBuf, RecBuf} = get_riak_env_vars(),
     DistCtrl = erlang:system_info(dist_ctrl),
     %% make sure that buffers are correct on existing connections.
-    [set_port_buffers(Port, SndBuf, RecBuf)
+    _ = [set_port_buffers(Port, SndBuf, RecBuf)
      || {_Node, Port} <- DistCtrl],
     {ok, #state{sndbuf=SndBuf, recbuf=RecBuf}}.
 
@@ -61,7 +61,7 @@ get_riak_env_vars() ->
     {SndBuf, RecBuf}.
 
 handle_call({set_dist_buf_sizes, SndBuf, RecBuf}, _From, State) ->
-    [set_port_buffers(Port, SndBuf, RecBuf)
+    _ = [set_port_buffers(Port, SndBuf, RecBuf)
      || {_Node, Port} <- erlang:system_info(dist_ctrl)],
     {reply, ok, State#state{sndbuf=SndBuf, recbuf=RecBuf}};
 handle_call(Msg, _From, State) ->

--- a/src/riak_core_dtrace.erl
+++ b/src/riak_core_dtrace.erl
@@ -127,12 +127,7 @@ put_tag(Tag) ->
         true ->
             FTag = iolist_to_binary(Tag),
             put(?DTRACE_TAG_KEY, FTag),
-            case get(?MAGIC) of
-                dtrace ->
-                    dtrace:put_utag(FTag);
-                dyntrace ->
-                    dyntrace:put_tag(FTag)
-            end;
+            dyntrace:put_tag(FTag);
         false ->
             ok
     end.

--- a/src/riak_core_format.erl
+++ b/src/riak_core_format.erl
@@ -69,7 +69,7 @@ epoch_to_datetime(S) ->
 %% @doc Formats a byte size into a human-readable size with units.
 %%      Thanks StackOverflow:
 %%      http://stackoverflow.com/questions/2163691/simpler-way-to-format-bytesize-in-a-human-readable-way
--spec human_size(non_neg_integer(), list()) -> iolist().
+-spec human_size(number(), list()) -> {float(), iolist()}.
 human_size(S, [_|[_|_] = L]) when S >= 1024 -> human_size(S/1024, L);
 human_size(S, [M|_]) ->
     {float(S), M}.

--- a/src/riak_core_format.erl
+++ b/src/riak_core_format.erl
@@ -82,9 +82,9 @@ human_size(S, [M|_]) ->
 human_time(Micros) ->
     human_time(Micros, {1000, "us"}, [{1000, "ms"}, {60, "s"}, {60, "min"}, {24, "hr"}, {365, "d"}]).
 
--spec human_time(non_neg_integer(), {pos_integer(), string()},
+-spec human_time(number(), {pos_integer(), string()},
                  [{pos_integer(), string()}]) ->
-                        {number(), string()}.
+                        {float(), string()}.
 human_time(T, {Divisor, Unit}, Units) when T < Divisor orelse Units == [] ->
     {float(T), Unit};
 human_time(T, {Divisor, _}, [Next|Units]) ->

--- a/src/riak_core_format.erl
+++ b/src/riak_core_format.erl
@@ -38,7 +38,7 @@ fmt(FmtStr, Args) ->
 
 %% @doc Create a human friendly string `Str' for number of bytes
 %%      `Bytes' and format based on format string `Fmt'.
--spec human_size_fmt(string(), non_neg_integer()) -> Str::string().
+-spec human_size_fmt(string(), number()) -> string().
 human_size_fmt(Fmt, Bytes) ->
     Fmt2 = Fmt ++ " ~s",
     {Value, Units} = human_size(Bytes, ["B","KB","MB","GB","TB","PB"]),

--- a/src/riak_core_gen_server.erl
+++ b/src/riak_core_gen_server.erl
@@ -135,7 +135,6 @@
 	 multi_call/2, multi_call/3, multi_call/4,
 	 enter_loop/3, enter_loop/4, enter_loop/5, wake_hib/7]).
 
--export([behaviour_info/1]).
 
 %% System exports
 -export([system_continue/3,
@@ -152,15 +151,32 @@
 %%%  API
 %%%=========================================================================
 
--ifdef(use_specs).
--spec behaviour_info(atom()) -> 'undefined' | [{atom(), any()}].
--endif.
-
-behaviour_info(callbacks) ->
-    [{init,1},{handle_call,3},{handle_cast,2},{handle_info,2},
-     {terminate,2},{code_change,3}];
-behaviour_info(_Other) ->
-    undefined.
+-callback init(Args :: term()) ->
+    {ok, State :: term()} | {ok, State :: term(), timeout() | hibernate} |
+    {stop, Reason :: term()} | ignore.
+-callback handle_call(Request :: term(), From :: {pid(), Tag :: term()},
+                      State :: term()) ->
+    {reply, Reply :: term(), NewState :: term()} |
+    {reply, Reply :: term(), NewState :: term(), timeout() | hibernate} |
+    {noreply, NewState :: term()} |
+    {noreply, NewState :: term(), timeout() | hibernate} |
+    {stop, Reason :: term(), Reply :: term(), NewState :: term()} |
+    {stop, Reason :: term(), NewState :: term()}.
+-callback handle_cast(Request :: term(), State :: term()) ->
+    {noreply, NewState :: term()} |
+    {noreply, NewState :: term(), timeout() | hibernate} |
+    {stop, Reason :: term(), NewState :: term()}.
+-callback handle_info(Info :: timeout | term(), State :: term()) ->
+    {noreply, NewState :: term()} |
+    {noreply, NewState :: term(), timeout() | hibernate} |
+    {stop, Reason :: term(), NewState :: term()}.
+-callback terminate(Reason :: (normal | shutdown | {shutdown, term()} |
+                               term()),
+                    State :: term()) ->
+    term().
+-callback code_change(OldVsn :: (term() | {down, term()}), State :: term(),
+                      Extra :: term()) ->
+    {ok, NewState :: term()} | {error, Reason :: term()}.
 
 %%%  -----------------------------------------------------------------
 %%% Starts a generic server.

--- a/src/riak_core_gossip.erl
+++ b/src/riak_core_gossip.erl
@@ -265,7 +265,7 @@ handle_cast(gossip_ring, State) ->
 handle_cast({rejoin, RingIn}, State) ->
     OtherRing = riak_core_ring:upgrade(RingIn),
     {ok, Ring} = riak_core_ring_manager:get_raw_ring(),
-    SameCluster = (riak_core_ring:cluster_name(Ring) =:= 
+    SameCluster = (riak_core_ring:cluster_name(Ring) =:=
                        riak_core_ring:cluster_name(OtherRing)),
     case SameCluster of
         true ->
@@ -444,7 +444,7 @@ attempt_simple_transfer(Seed, Ring, [{P, Exit}|Rest], TargetN, Exit, Idx, Last) 
                                            fun({_, Owner}) -> Node /= Owner end,
                                            Rest))
                           end,
-            case lists:filter(fun(N) -> 
+            case lists:filter(fun(N) ->
                                  Next = StepsToNext(N),
                                  (Next+1 >= TargetN)
                                           orelse (Next == length(Rest))

--- a/src/riak_core_gossip.erl
+++ b/src/riak_core_gossip.erl
@@ -271,7 +271,12 @@ handle_cast({rejoin, RingIn}, State) ->
         true ->
             Legacy = check_legacy_gossip(Ring, State),
             OtherNode = riak_core_ring:owner_node(OtherRing),
-            riak_core:join(Legacy, node(), OtherNode, true, true),
+            case riak_core:join(Legacy, node(), OtherNode, true, true) of
+                ok -> ok;
+                {error, Reason} ->
+                    lager:error("Could not rejoin cluster: ~p", [Reason]),
+                    ok
+            end,
             {noreply, State};
         false ->
             {noreply, State}

--- a/src/riak_core_gossip.erl
+++ b/src/riak_core_gossip.erl
@@ -114,7 +114,7 @@ recursive_gossip(Ring, Node) ->
     Nodes = riak_core_ring:active_members(Ring),
     Tree = riak_core_util:build_tree(2, Nodes, [cycles]),
     Children = orddict:fetch(Node, Tree),
-    [send_ring(node(), OtherNode) || OtherNode <- Children],
+    _ = [send_ring(node(), OtherNode) || OtherNode <- Children],
     ok.
 recursive_gossip(Ring) ->
     %% A non-active member will not show-up in the tree decomposition

--- a/src/riak_core_gossip.erl
+++ b/src/riak_core_gossip.erl
@@ -356,34 +356,45 @@ reconcile(Ring0, [OtherRing0]) ->
     end.
 
 log_membership_changes(OldRing, NewRing) ->
-    OldStatus = orddict:from_list(riak_core_ring:all_member_status(OldRing)),
-    NewStatus = orddict:from_list(riak_core_ring:all_member_status(NewRing)),
+    OldStatus = riak_core_ring:all_member_status(OldRing),
+    NewStatus = riak_core_ring:all_member_status(NewRing),
 
-    %% Pad both old and new status to the same length
-    OldDummyStatus = [{Node, undefined} || {Node, _} <- NewStatus],
-    OldStatus2 = orddict:merge(fun(_, Status, _) ->
-                                       Status
-                               end, OldStatus, OldDummyStatus),
+    do_log_membership_changes(lists:sort(OldStatus), lists:sort(NewStatus)).
 
-    NewDummyStatus = [{Node, undefined} || {Node, _} <- OldStatus],
-    NewStatus2 = orddict:merge(fun(_, Status, _) ->
-                                       Status
-                               end, NewStatus, NewDummyStatus),
+do_log_membership_changes([], []) ->
+    ok;
+do_log_membership_changes([{Node, Status}|Old], [{Node, Status}|New]) ->
+    %% No change
+    do_log_membership_changes(Old, New);
+do_log_membership_changes([{Node, Status1}|Old], [{Node, Status2}|New]) ->
+    %% State changed, did not join or leave
+    log_node_changed(Node, Status1, Status2),
+    do_log_membership_changes(Old, New);
+do_log_membership_changes([{OldNode, _OldStatus}|_]=Old, [{NewNode, NewStatus}|New]) when NewNode < OldNode->
+    %% Node added
+    log_node_added(NewNode, NewStatus),
+    do_log_membership_changes(Old, New);
+do_log_membership_changes([{OldNode, OldStatus}|Old], [{NewNode, _NewStatus}|_]=New) when OldNode < NewNode ->
+    %% Node removed
+    log_node_removed(OldNode, OldStatus),
+    do_log_membership_changes(Old, New);
+do_log_membership_changes([{OldNode, OldStatus}|Old], []) ->
+    %% Trailing nodes were removed
+    log_node_removed(OldNode, OldStatus),
+    do_log_membership_changes(Old, []);
+do_log_membership_changes([], [{NewNode, NewStatus}|New]) ->
+    %% Trailing nodes were added
+    log_node_added(NewNode, NewStatus),
+    do_log_membership_changes([], New).
 
-    %% Merge again to determine changed status
-    orddict:merge(fun(_, Same, Same) ->
-                          Same;
-                     (Node, undefined, New) ->
-                          lager:info("'~s' joined cluster with status '~s'~n",
-                                     [Node, New]);
-                     (Node, Old, undefined) ->
-                          lager:info("'~s' removed from cluster (previously: "
-                                     "'~s')~n", [Node, Old]);
-                     (Node, Old, New) ->
-                          lager:info("'~s' changed from '~s' to '~s'~n",
-                                     [Node, Old, New])
-                  end, OldStatus2, NewStatus2),
-    ok.
+log_node_changed(Node, Old, New) ->
+    lager:info("'~s' changed from '~s' to '~s'~n", [Node, Old, New]).
+
+log_node_added(Node, New) ->
+    lager:info("'~s' joined cluster with status '~s'~n", [Node, New]).
+
+log_node_removed(Node, Old) ->
+    lager:info("'~s' removed from cluster (previously: '~s')~n", [Node, Old]).
 
 remove_from_cluster(Ring, ExitingNode) ->
     remove_from_cluster(Ring, ExitingNode, erlang:now()).

--- a/src/riak_core_gossip_legacy.erl
+++ b/src/riak_core_gossip_legacy.erl
@@ -153,7 +153,7 @@ code_change(_OldVsn, State, _Extra) ->
 schedule_next_gossip() ->
     MaxInterval = app_helper:get_env(riak_core, gossip_interval),
     Interval = random:uniform(MaxInterval),
-    timer:apply_after(Interval, gen_server, cast, [?MODULE, gossip_ring]),
+    {ok, _} = timer:apply_after(Interval, gen_server, cast, [?MODULE, gossip_ring]),
     ok.
 
 claim_until_balanced(Ring) ->

--- a/src/riak_core_gossip_legacy.erl
+++ b/src/riak_core_gossip_legacy.erl
@@ -153,7 +153,8 @@ code_change(_OldVsn, State, _Extra) ->
 schedule_next_gossip() ->
     MaxInterval = app_helper:get_env(riak_core, gossip_interval),
     Interval = random:uniform(MaxInterval),
-    timer:apply_after(Interval, gen_server, cast, [?MODULE, gossip_ring]).
+    timer:apply_after(Interval, gen_server, cast, [?MODULE, gossip_ring]),
+    ok.
 
 claim_until_balanced(Ring) ->
     {WMod, WFun} = app_helper:get_env(riak_core, wants_claim_fun),

--- a/src/riak_core_handoff_listener.erl
+++ b/src/riak_core_handoff_listener.erl
@@ -76,7 +76,7 @@ code_change(_OldVsn, State, _Extra) -> {ok, State}.
 new_connection(Socket, State = #state{ssl_opts = SslOpts}) ->
     case riak_core_handoff_manager:add_inbound(SslOpts) of
         {ok, Pid} ->
-            gen_tcp:controlling_process(Socket, Pid),
+            ok = gen_tcp:controlling_process(Socket, Pid),
             ok = riak_core_handoff_receiver:set_socket(Pid, Socket),
             {ok, State};
         {error, _Reason} ->

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -74,13 +74,9 @@ start_link() ->
 init([]) ->
     {ok, #state{excl=sets:new(), handoffs=[]}}.
 
--spec add_outbound(ho_type(),atom(),integer(),term(),pid(),[{atom(),term()}]) ->
-                          {ok, pid()} | {error, term()}.
 add_outbound(HOType,Module,Idx,Node,VnodePid,Opts) ->
     add_outbound(HOType,Module,Idx,Idx,Node,VnodePid,Opts).
 
--spec add_outbound(ho_type(),atom(),integer(),integer(),term(),pid(),[{atom,term()}]) ->
-                          {ok, pid()} | {error, term()}.
 add_outbound(HOType,Module,SrcIdx,TargetIdx,Node,VnodePid,Opts) ->
     case application:get_env(riak_core, disable_outbound_handoff) of
         {ok, true} ->

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -208,7 +208,7 @@ handle_call({set_concurrency,Limit},_From,State=#state{handoffs=HS}) ->
             %% a reason of 'max_concurrency' and we want to be able to do
             %% something with that if necessary.
             {_Keep,Discard}=lists:split(Limit,HS),
-            [erlang:exit(Pid,max_concurrency) ||
+            _ = [erlang:exit(Pid,max_concurrency) ||
                 #handoff_status{transport_pid=Pid} <- Discard],
             {reply, ok, State};
         false ->

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -237,9 +237,9 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
                  end,
 
                  FoldTimeDiff = end_fold_time(StartFoldTime),
-                ThroughputBytes = TotalBytes/FoldTimeDiff,
+                 ThroughputBytes = TotalBytes/FoldTimeDiff,
 
-                 lager:info("~p transfer of ~p from ~p ~p to ~p ~p"
+                 ok = lager:info("~p transfer of ~p from ~p ~p to ~p ~p"
                             " completed: sent ~s bytes in ~p of ~p objects"
                             " in ~.2f seconds (~s/second)",
                             [Type, Module, SrcNode, SrcPartition, TargetNode, TargetPartition, 

--- a/src/riak_core_metadata_hashtree.erl
+++ b/src/riak_core_metadata_hashtree.erl
@@ -97,7 +97,7 @@ prefix_hash(Prefix) ->
 %% @doc Return the bucket for a node in the tree managed by this
 %% process running on `Node'.
 -spec get_bucket(node(), hashtree_tree:tree_node(),
-                 non_neg_integer(), non_neg_integer()) -> ordict:ordict().
+                 non_neg_integer(), non_neg_integer()) -> orddict:orddict().
 get_bucket(Node, Prefixes, Level, Bucket) ->
     gen_server:call({?SERVER, Node}, {get_bucket, Prefixes, Level, Bucket}, infinity).
 

--- a/src/riak_core_mochiglobal.erl
+++ b/src/riak_core_mochiglobal.erl
@@ -30,7 +30,7 @@ put(K, V) ->
 put(_K, V, Mod) ->
     Bin = compile(Mod, V),
     code:purge(Mod),
-    code:load_binary(Mod, atom_to_list(Mod) ++ ".erl", Bin),
+    {module, Mod} = code:load_binary(Mod, atom_to_list(Mod) ++ ".erl", Bin),
     ok.
 
 -spec delete(atom()) -> boolean().

--- a/src/riak_core_net_ticktime.erl
+++ b/src/riak_core_net_ticktime.erl
@@ -100,10 +100,12 @@ set_net_ticktime_daemon_loop(Time, Count) ->
             %% connected to us.  Force them to change their tick time,
             %% in case they're using something different.  And pick up
             %% any regular nodes that have connected since we started.
-            if Count rem 5 == 0 ->
+            if
+                Count rem 5 == 0 ->
                     async_start_set_net_ticktime_daemons(
-                      Time, da_nodes(nodes(connected)));
-               true ->
+                      Time, da_nodes(nodes(connected))),
+                    ok;
+                true ->
                     ok
             end,
             set_net_ticktime_daemon_loop(Time, Count + 1)

--- a/src/riak_core_net_ticktime.erl
+++ b/src/riak_core_net_ticktime.erl
@@ -52,7 +52,7 @@ start_set_net_ticktime_daemon(Node, Time) ->
                             lager:info("start_set_net_ticktime_daemon: started "
                                        "changing net_ticktime on ~p to ~p\n",
                                  [Node, Time]),
-                            random:seed(os:timestamp()),
+                            _ = random:seed(os:timestamp()),
                             set_net_ticktime_daemon_loop(Time, 1)
                         catch _:_ ->
                                 ok

--- a/src/riak_core_node_watcher.erl
+++ b/src/riak_core_node_watcher.erl
@@ -325,8 +325,7 @@ handle_info({'DOWN', Mref, _, _Pid, _Info}, State) ->
 
             %% Update our list of active services and ETS table
             Services = ordsets:del_element(Id, State#state.services),
-            S3 = S2#state { services = Services },
-            local_update(S3),
+            S3 = local_update(S2#state { services = Services }),
             {noreply, update_avsn(S3)}
     end;
 
@@ -401,7 +400,7 @@ schedule_broadcast(State) ->
         undefined ->
             ok;
         OldTref ->
-            erlang:cancel_timer(OldTref),
+            _ = erlang:cancel_timer(OldTref),
             ok
     end,
     Interval = app_helper:get_env(riak_core, gossip_interval),
@@ -501,7 +500,7 @@ local_delete(State) ->
     case node_delete(node()) of
         [] ->
             %% No services changed; no local notification required
-            State;
+            ok;
 
         AffectedServices ->
             riak_core_node_watcher_events:service_update(AffectedServices)
@@ -627,7 +626,7 @@ remove_health_check(ServiceId, State) ->
         error ->
             Healths;
         {ok, Check} ->
-            health_fsm(remove, ServiceId, Check),
+            {_, _} = health_fsm(remove, ServiceId, Check),
             orddict:erase(ServiceId, Healths)
     end,
     State#state{health_checks = Healths2}.
@@ -711,8 +710,9 @@ health_fsm(checking, {'EXIT', Pid, Cause}, Service, #health_check{checking_pid =
 health_fsm(waiting, suspend, _Service, InCheck) ->
     case InCheck#health_check.interval_tref of
         undefined -> ok;
-        _ -> erlang:cancel_timer(InCheck#health_check.interval_tref),
-             ok
+        _ ->
+            _ = erlang:cancel_timer(InCheck#health_check.interval_tref),
+            ok
     end,
     {ok, suspend, InCheck#health_check{interval_tref = undefined}};
 
@@ -723,8 +723,9 @@ health_fsm(waiting, check_health, Service, InCheck) ->
 health_fsm(waiting, remove, _Service, InCheck) ->
     case InCheck#health_check.interval_tref of
         undefined -> ok;
-        Tref -> erlang:cancel_timer(Tref),
-                ok
+        Tref ->
+            _ = erlang:cancel_timer(Tref),
+            ok
     end,
     OutCheck = InCheck#health_check{interval_tref = undefined},
     {remove, waiting, OutCheck};
@@ -754,8 +755,9 @@ start_health_check(Service, #health_check{checking_pid = undefined} = CheckRec) 
     Pid = CheckRec#health_check.service_pid,
     case CheckRec#health_check.interval_tref of
         undefined -> ok;
-        Tref -> erlang:cancel_timer(Tref),
-                ok
+        Tref ->
+            _ = erlang:cancel_timer(Tref),
+            ok
     end,
     CheckingPid = proc_lib:spawn_link(fun() ->
         case erlang:apply(Mod, Func, [Pid | Args]) of

--- a/src/riak_core_node_watcher.erl
+++ b/src/riak_core_node_watcher.erl
@@ -401,7 +401,8 @@ schedule_broadcast(State) ->
         undefined ->
             ok;
         OldTref ->
-            erlang:cancel_timer(OldTref)
+            erlang:cancel_timer(OldTref),
+            ok
     end,
     Interval = app_helper:get_env(riak_core, gossip_interval),
     Tref = erlang:send_after(Interval, self(), broadcast),
@@ -710,7 +711,8 @@ health_fsm(checking, {'EXIT', Pid, Cause}, Service, #health_check{checking_pid =
 health_fsm(waiting, suspend, _Service, InCheck) ->
     case InCheck#health_check.interval_tref of
         undefined -> ok;
-        _ -> erlang:cancel_timer(InCheck#health_check.interval_tref)
+        _ -> erlang:cancel_timer(InCheck#health_check.interval_tref),
+             ok
     end,
     {ok, suspend, InCheck#health_check{interval_tref = undefined}};
 
@@ -721,7 +723,8 @@ health_fsm(waiting, check_health, Service, InCheck) ->
 health_fsm(waiting, remove, _Service, InCheck) ->
     case InCheck#health_check.interval_tref of
         undefined -> ok;
-        Tref -> erlang:cancel_timer(Tref)
+        Tref -> erlang:cancel_timer(Tref),
+                ok
     end,
     OutCheck = InCheck#health_check{interval_tref = undefined},
     {remove, waiting, OutCheck};
@@ -751,7 +754,8 @@ start_health_check(Service, #health_check{checking_pid = undefined} = CheckRec) 
     Pid = CheckRec#health_check.service_pid,
     case CheckRec#health_check.interval_tref of
         undefined -> ok;
-        Tref -> erlang:cancel_timer(Tref)
+        Tref -> erlang:cancel_timer(Tref),
+                ok
     end,
     CheckingPid = proc_lib:spawn_link(fun() ->
         case erlang:apply(Mod, Func, [Pid | Args]) of

--- a/src/riak_core_node_watcher.erl
+++ b/src/riak_core_node_watcher.erl
@@ -454,7 +454,7 @@ node_down(Node, State) ->
 
 node_delete(Node) ->
     Services = internal_get_services(Node),
-    [internal_delete(Node, Service) || Service <- Services],
+    _ = [internal_delete(Node, Service) || Service <- Services],
     ets:delete(?MODULE, Node),
     Services.
 
@@ -470,8 +470,8 @@ node_update(Node, Services) ->
 
     %% Update ets table with changes; make sure to touch unchanged
     %% service with latest timestamp
-    [internal_delete(Node, Ss) || Ss <- Deleted],
-    [internal_insert(Node, Ss) || Ss <- Added],
+    _ = [internal_delete(Node, Ss) || Ss <- Deleted],
+    _ = [internal_insert(Node, Ss) || Ss <- Added],
 
     %% Keep track of the last time we recv'd data from a node
     ets:insert(?MODULE, {Node, Now}),

--- a/src/riak_core_node_watcher.erl
+++ b/src/riak_core_node_watcher.erl
@@ -175,10 +175,10 @@ init([]) ->
     watch_for_ring_events(),
 
     %% Watch for node up/down events
-    net_kernel:monitor_nodes(true),
+    ok = net_kernel:monitor_nodes(true),
 
     %% Setup ETS table to track node status
-    ets:new(?MODULE, [protected, {read_concurrency, true}, named_table]),
+    ?MODULE = ets:new(?MODULE, [protected, {read_concurrency, true}, named_table]),
 
     {ok, schedule_broadcast(#state{})}.
 

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -1803,8 +1803,7 @@ reconcile_test() ->
     Ring1 = transfer_node(0,x,Ring0),
     %% Only members and seen should have changed
     {new_ring, Ring2} = reconcile(fresh(2,someone_else),Ring1),
-    ?assertMatch([{false, members}, {false, seen}],
-                 equal_cstate(Ring1, Ring2, true)),
+    ?assertNot(equal_cstate(Ring1, Ring2, false)),
     RingB0 = fresh(2,node()),
     RingB1 = transfer_node(0,x,RingB0),
     RingB2 = RingB1?CHSTATE{nodename=b},

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -1313,7 +1313,7 @@ pretty_print(Ring, Opts) ->
     case OptLegend of
         true ->
             io:format(Out, "~36..=s Nodes ~36..=s~n", ["", ""]),
-            [begin
+            _ = [begin
                  NodeIndices = [Idx || {Idx,Owner} <- Indices,
                                        Owner =:= Node],
                  RingPercent = length(NodeIndices) * 100 / RingSize,

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -185,6 +185,8 @@
                            awaiting | complete}
                         | {undefined, undefined, undefined}.
 
+-type resize_transfer() :: {{integer(),term()}, ordsets:ordset(node()), awaiting | complete}.
+
 %% ===================================================================
 %% Public API
 %% ===================================================================
@@ -1095,10 +1097,15 @@ complete_resize_transfers(State, Source, Mod) ->
 deletion_complete(State, Idx, Mod) ->
     transfer_complete(State, Idx, Mod).
 
+-spec resize_transfers(chstate(), {integer(), term()}) ->
+                              [resize_transfer()].
 resize_transfers(State, Source) ->
     {ok, Transfers} = get_meta({resize, Source}, [], State),
     Transfers.
 
+-spec set_resize_transfers(chstate(),
+                           {integer(), term()},
+                           [resize_transfer()]) -> chstate().
 set_resize_transfers(State, Source, Transfers) ->
     update_meta({resize, Source}, Transfers, State).
 

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -1713,7 +1713,7 @@ update_seen(Node, CState=?CHSTATE{vclock=VClock, seen=Seen}) ->
 equal_cstate(StateA, StateB) ->
     equal_cstate(StateA, StateB, false).
 
-equal_cstate(StateA, StateB, Verbose) ->
+equal_cstate(StateA, StateB, false) ->
     T1 = equal_members(StateA?CHSTATE.members, StateB?CHSTATE.members),
     T2 = vclock:equal(StateA?CHSTATE.rvsn, StateB?CHSTATE.rvsn),
     T3 = equal_seen(StateA, StateB),
@@ -1729,19 +1729,7 @@ equal_cstate(StateA, StateB, Verbose) ->
                            meta=undefined, clustername=undefined},
     T5 = (StateA2 =:= StateB2),
 
-    case Verbose of
-        false ->
-            T1 and T2 and T3 and T4 and T5;
-        true ->
-            Failed =
-                lists:filter(fun({Test,_}) -> Test =:= false end,
-                             [{T1, members},
-                              {T2, rvsn},
-                              {T3, seen},
-                              {T4, ring},
-                              {T5, other}]),
-            Failed
-    end.
+    T1 andalso T2 andalso T3 andalso T4 andalso T5.
 
 %% @private
 equal_members(M1, M2) ->

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -1095,15 +1095,10 @@ complete_resize_transfers(State, Source, Mod) ->
 deletion_complete(State, Idx, Mod) ->
     transfer_complete(State, Idx, Mod).
 
--spec resize_transfers(chstate(), {integer(), term()}) ->
-                              [{{integer(),term()}, ordsets:ordset(), awaiting | complete}].
 resize_transfers(State, Source) ->
     {ok, Transfers} = get_meta({resize, Source}, [], State),
     Transfers.
 
--spec set_resize_transfers(chstate(),
-                           {integer(), term()},
-                           [{{integer(),term()},ordsets:ordset(),awaiting | complete}]) -> chstate().
 set_resize_transfers(State, Source, Transfers) ->
     update_meta({resize, Source}, Transfers, State).
 

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -273,7 +273,7 @@ nearly_equal(RingA, RingB) ->
 
 %% @doc Determine if a given Index/Node `IdxNode' combination is a
 %%      primary.
--spec is_primary(chstate(), {integer(), node()}) -> boolean().
+-spec is_primary(chstate(), {chash:index_as_int(), node()}) -> boolean().
 is_primary(Ring, IdxNode) ->
     Owners = all_owners(Ring),
     lists:member(IdxNode, Owners).
@@ -402,7 +402,7 @@ get_buckets(State) ->
         end, [], Keys).
 
 %% @doc Return the node that owns the given index.
--spec index_owner(State :: chstate(), Idx :: integer()) -> Node :: term().
+-spec index_owner(State :: chstate(), Idx :: chash:index_as_int()) -> Node :: term().
 index_owner(State, Idx) ->
     {Idx, Owner} = lists:keyfind(Idx, 1, all_owners(State)),
     Owner.
@@ -410,12 +410,12 @@ index_owner(State, Idx) ->
 %% @doc Return the node that will own this index after transtions have completed
 %%      this function will error if the ring is shrinking and Idx no longer exists
 %%      in it
--spec future_owner(chstate(), integer()) -> term().
+-spec future_owner(chstate(), chash:index_as_int()) -> term().
 future_owner(State, Idx) ->
     index_owner(future_ring(State), Idx).
 
 %% @doc Return all partition indices owned by the node executing this function.
--spec my_indices(State :: chstate()) -> [integer()].
+-spec my_indices(State :: chstate()) -> [chash:index_as_int()].
 my_indices(State) ->
     [I || {I,Owner} <- ?MODULE:all_owners(State), Owner =:= node()].
 
@@ -439,7 +439,7 @@ owner_node(State) ->
 %% @doc For a given object key, produce the ordered list of
 %%      {partition,node} pairs that could be responsible for that object.
 -spec preflist(Key :: binary(), State :: chstate()) ->
-                               [{Index :: integer(), Node :: term()}].
+                               [{Index :: chash:index_as_int(), Node :: term()}].
 preflist(Key, State) -> chash:successors(Key, State?CHSTATE.chring).
 
 %% @doc Return a randomly-chosen node from amongst the owners.
@@ -450,7 +450,7 @@ random_node(State) ->
 
 %% @doc Return a partition index not owned by the node executing this function.
 %%      If this node owns all partitions, return any index.
--spec random_other_index(State :: chstate()) -> integer().
+-spec random_other_index(State :: chstate()) -> chash:index_as_int().
 random_other_index(State) ->
     L = [I || {I,Owner} <- ?MODULE:all_owners(State), Owner =/= node()],
     case L of
@@ -458,7 +458,7 @@ random_other_index(State) ->
         _ -> lists:nth(random:uniform(length(L)), L)
     end.
 
--spec random_other_index(State :: chstate(), Exclude :: [term()]) -> integer() | no_indices.
+-spec random_other_index(State :: chstate(), Exclude :: [term()]) -> chash:index_as_int() | no_indices.
 random_other_index(State, Exclude) when is_list(Exclude) ->
     L = [I || {I, Owner} <- ?MODULE:all_owners(State),
               Owner =/= node(),

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -363,7 +363,7 @@ fresh(RingSize, NodeName) ->
 %% @doc change the size of the ring to `NewRingSize'. If the ring
 %%      is larger than the current ring any new indexes will be owned
 %%      by a dummy host
--spec resize(chstate(), integer()) -> chstate().
+-spec resize(chstate(), pos_integer()) -> chstate().
 resize(State, NewRingSize) ->
     NewRing = lists:foldl(fun({Idx,Owner}, RingAcc) ->
                                   chash:update(Idx, Owner, RingAcc)
@@ -420,11 +420,11 @@ my_indices(State) ->
     [I || {I,Owner} <- ?MODULE:all_owners(State), Owner =:= node()].
 
 %% @doc Return the number of partitions in this Riak ring.
--spec num_partitions(State :: chstate()) -> integer().
+-spec num_partitions(State :: chstate()) -> pos_integer().
 num_partitions(State) ->
     chash:size(State?CHSTATE.chring).
 
--spec future_num_partitions(chstate()) -> integer().
+-spec future_num_partitions(chstate()) -> pos_integer().
 future_num_partitions(State=?CHSTATE{chring=CHRing}) ->
     case resized_ring(State) of
         {ok, C} -> chash:size(C);

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -144,10 +144,10 @@
 -define(CHSTATE, #chstate_v2).
 -record(chstate_v2, {
     nodename :: term(),          % the Node responsible for this chstate
-    vclock   :: vclock:vclock(), % for this chstate object, entries are
+    vclock   :: vclock:vclock() | undefined, % for this chstate object, entries are
                                  % {Node, Ctr}
     chring   :: chash:chash(),   % chash ring of {IndexAsInt, Node} mappings
-    meta     :: dict(),          % dict of cluster-wide other data (primarily
+    meta     :: dict() | undefined,  % dict of cluster-wide other data (primarily
                                  % bucket N-value, etc)
 
     clustername :: {term(), term()},

--- a/src/riak_core_ring_handler.erl
+++ b/src/riak_core_ring_handler.erl
@@ -178,7 +178,7 @@ maybe_start_vnode_proxies(Ring) ->
     case Larger of
         true ->
             FutureIdxs = riak_core_ring:all_owners(riak_core_ring:future_ring(Ring)),
-            [riak_core_vnode_proxy_sup:start_proxy(Mod, Idx) || {Idx, _} <- FutureIdxs,
+            _ = [riak_core_vnode_proxy_sup:start_proxy(Mod, Idx) || {Idx, _} <- FutureIdxs,
                                                                 Mod <- Mods],
             ok;
         false ->
@@ -193,7 +193,8 @@ maybe_stop_vnode_proxies(Ring) ->
             ProxySpecs = supervisor:which_children(riak_core_vnode_proxy_sup),
             Running = [{I,M} || {{M,I},_,_,_} <- ProxySpecs, lists:member(M, Mods)],
             ToShutdown = Running -- Idxs,
-            [riak_core_vnode_proxy_sup:stop_proxy(M,I) || {I, M} <- ToShutdown];
+            _ = [riak_core_vnode_proxy_sup:stop_proxy(M,I) || {I, M} <- ToShutdown],
+            ok;
         _ ->
             ok
     end.

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -304,7 +304,7 @@ prune_ringfiles() ->
                                                           lists:all(fun(TS) ->
                                                                             string:str(FN,TS)=:=0
                                                                     end, KeepTSs)],
-                            [file:delete(DelFN) || DelFN <- DelFNs],
+                            _ = [file:delete(DelFN) || DelFN <- DelFNs],
                             ok;
                        true ->
                             %% directory wasn't empty, but there are no ring

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -374,7 +374,7 @@ handle_call(refresh_my_ring, _From, State) ->
     FreshRing = riak_core_ring:fresh(),
     State2 = set_ring(FreshRing, State),
     %% Make sure the fresh ring gets written before stopping
-    do_write_ringfile(FreshRing),
+    ok = do_write_ringfile(FreshRing),
 
     %% Handoff is complete and fresh ring is written
     %% so we can safely stop now.
@@ -427,7 +427,7 @@ handle_cast(write_ringfile, test) ->
     {noreply,test};
 
 handle_cast(write_ringfile, State=#state{raw_ring=Ring}) ->
-    do_write_ringfile(Ring),
+    ok = do_write_ringfile(Ring),
     {noreply,State}.
 
 
@@ -526,7 +526,7 @@ setup_ets(Mode) ->
                  live -> protected;
                  test -> public
              end,
-    ets:new(?ETS, [named_table, Access, {read_concurrency, true}]),
+    ?ETS = ets:new(?ETS, [named_table, Access, {read_concurrency, true}]),
     Id = reset_ring_id(),
     ets:insert(?ETS, [{changes, 0}, {promoted, 0}, {id, Id}]),
     ok.
@@ -625,8 +625,8 @@ prune_write_notify_ring(Ring, State) ->
 
 prune_write_ring(Ring, State) ->
     riak_core_ring:check_tainted(Ring, "Error: Persisting tainted ring"),
-    riak_core_ring_manager:prune_ringfiles(),
-    do_write_ringfile(Ring),
+    ok = riak_core_ring_manager:prune_ringfiles(),
+    _ = do_write_ringfile(Ring),
     State2 = set_ring(Ring, State),
     State2.
 

--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -615,7 +615,7 @@ del_source(all, CIDR) ->
                               {all, anchor_mask(CIDR)}),
     ok;
 del_source([H|_T]=UserList, CIDR) when is_binary(H) ->
-    [riak_core_metadata:delete({<<"security">>, <<"sources">>},
+    _ = [riak_core_metadata:delete({<<"security">>, <<"sources">>},
                               {User, anchor_mask(CIDR)}) || User <- UserList],
     ok;
 del_source(User, CIDR) ->

--- a/src/riak_core_stat.erl
+++ b/src/riak_core_stat.erl
@@ -42,8 +42,8 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_stats() ->
-    [(catch folsom_metrics:delete_metric({?APP, Name})) || {Name, _Type} <- stats()],
-    [register_stat({?APP, Name}, Type) || {Name, Type} <- stats()],
+    _ = [(catch folsom_metrics:delete_metric({?APP, Name})) || {Name, _Type} <- stats()],
+    _ = [register_stat({?APP, Name}, Type) || {Name, Type} <- stats()],
     riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
 
 %% @spec get_stats() -> proplist()

--- a/src/riak_core_stat.erl
+++ b/src/riak_core_stat.erl
@@ -75,7 +75,7 @@ handle_call(_Req, _From, State) ->
     {reply, ok, State}.
 
 handle_cast({update, Arg}, State) ->
-    update1(Arg),
+    ok = update1(Arg),
     {noreply, State};
 handle_cast(_Req, State) ->
     {noreply, State}.

--- a/src/riak_core_stat_cache.erl
+++ b/src/riak_core_stat_cache.erl
@@ -37,8 +37,6 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
--type registered_app() :: {MFA::mfa(), RerfreshRateMillis::non_neg_integer()}.
-
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
@@ -209,7 +207,6 @@ make_freshness_stat(App, TS) ->
 make_freshness_stat_name(App) ->
     list_to_atom(atom_to_list(App) ++ "_stat_ts").
 
--spec register_mod(atom(), registered_app(), orddict:orddict()) -> orddict:orddict().
 register_mod(App, AppRegistration, Apps0) ->
     {{Mod, _, _}=MFA, RefreshRateMillis} = AppRegistration,
     ok = folsom_metrics:new_histogram({?MODULE, Mod}),

--- a/src/riak_core_stat_cache.erl
+++ b/src/riak_core_stat_cache.erl
@@ -212,8 +212,8 @@ make_freshness_stat_name(App) ->
 -spec register_mod(atom(), registered_app(), orddict:orddict()) -> orddict:orddict().
 register_mod(App, AppRegistration, Apps0) ->
     {{Mod, _, _}=MFA, RefreshRateMillis} = AppRegistration,
-    folsom_metrics:new_histogram({?MODULE, Mod}),
-    folsom_metrics:new_meter({?MODULE, App}),
+    ok = folsom_metrics:new_histogram({?MODULE, Mod}),
+    ok = folsom_metrics:new_meter({?MODULE, App}),
     Apps = orddict:store(App, AppRegistration, Apps0),
     schedule_get_stats(RefreshRateMillis, App, MFA),
     Apps.
@@ -249,8 +249,9 @@ maybe_get_stats(App, From, Active, MFA) ->
 do_get_stats(App, {M, F, A}) ->
     spawn_link(fun() ->
                        Stats = folsom_metrics:histogram_timed_update({?MODULE, M}, M, F, A),
-                       folsom_metrics:notify_existing_metric({?MODULE, App}, 1, meter),
-                       gen_server:cast(?MODULE, {stats, App, Stats, folsom_utils:now_epoch()}) end).
+                       ok = folsom_metrics:notify_existing_metric({?MODULE, App}, 1, meter),
+                       gen_server:cast(?MODULE, {stats, App, Stats, folsom_utils:now_epoch()})
+               end).
 
 awaiting_for_pid(Pid, Active) ->
     case  [{App, Awaiting} || {App, {Proc, Awaiting}} <- orddict:to_list(Active),

--- a/src/riak_core_stat_cache.erl
+++ b/src/riak_core_stat_cache.erl
@@ -132,7 +132,7 @@ handle_cast({stats, App, Stats0, TS}, State0=#state{tab=Tab, active=Active, apps
     ets:insert(Tab, {App, TS, Stats}),
     State = case orddict:find(App, Active) of
                 {ok, {_Pid, Awaiting}} ->
-                    [gen_server:reply(From, {ok, [make_freshness_stat(App, TS) |Stats], TS}) || From <- Awaiting, From /= ?SERVER],
+                    _ = [gen_server:reply(From, {ok, [make_freshness_stat(App, TS) |Stats], TS}) || From <- Awaiting, From /= ?SERVER],
                     State0#state{active=orddict:erase(App, Active)};
                 error ->
                     State0
@@ -152,7 +152,7 @@ handle_info({'EXIT', FromPid, Reason}, State0=#state{active=Active, apps=Apps}) 
                  not_found ->
                      {stop, Reason, State0};
                  {ok, {App, Awaiting}} ->
-                     [gen_server:reply(From, {error, Reason}) || From <- Awaiting, From /= ?SERVER],
+                     _ = [gen_server:reply(From, {error, Reason}) || From <- Awaiting, From /= ?SERVER],
                      {ok, {MFA, RefreshRateMillis}} = orddict:find(App, Apps),
                      Apps2 = update_fail_count(App, Apps),
                      FailCnt = get_fail_count(App, Apps2),

--- a/src/riak_core_stat_cache.erl
+++ b/src/riak_core_stat_cache.erl
@@ -37,6 +37,8 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
+-type registered_app() :: {MFA::{module(), atom(), [term()]}, RerfreshRateMillis::non_neg_integer()}.
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
@@ -207,6 +209,7 @@ make_freshness_stat(App, TS) ->
 make_freshness_stat_name(App) ->
     list_to_atom(atom_to_list(App) ++ "_stat_ts").
 
+-spec register_mod(atom(), registered_app(), orddict:orddict()) -> orddict:orddict().
 register_mod(App, AppRegistration, Apps0) ->
     {{Mod, _, _}=MFA, RefreshRateMillis} = AppRegistration,
     ok = folsom_metrics:new_histogram({?MODULE, Mod}),

--- a/src/riak_core_stat_calc_sup.erl
+++ b/src/riak_core_stat_calc_sup.erl
@@ -42,8 +42,8 @@ calc_proc(Stat) ->
     Pid.
 
 stop_proc(Stat) ->
-    supervisor:terminate_child(?MODULE, Stat),
-    supervisor:delete_child(?MODULE, Stat),
+    _ = supervisor:terminate_child(?MODULE, Stat),
+    _ = supervisor:delete_child(?MODULE, Stat),
     ok.
 
 %% @private

--- a/src/riak_core_stats_sup.erl
+++ b/src/riak_core_stats_sup.erl
@@ -41,8 +41,8 @@ start_server(Mod) ->
     Pid.
 
 stop_server(Mod) ->
-    supervisor:terminate_child(?MODULE, Mod),
-    supervisor:delete_child(?MODULE, Mod),
+    _ = supervisor:terminate_child(?MODULE, Mod),
+    _ = supervisor:delete_child(?MODULE, Mod),
     ok.
 
 %% @private

--- a/src/riak_core_sysmon_handler.erl
+++ b/src/riak_core_sysmon_handler.erl
@@ -224,5 +224,5 @@ maybe_collect_garbage(_) ->
 reset_timer(undefined) ->
     erlang:send_after(?INACTIVITY_TIMEOUT, self(), inactivity_timeout);
 reset_timer(TimerRef) ->
-    erlang:cancel_timer(TimerRef),
+    _ = erlang:cancel_timer(TimerRef),
     reset_timer(undefined).

--- a/src/riak_core_tcp_mon.erl
+++ b/src/riak_core_tcp_mon.erl
@@ -89,7 +89,7 @@ socket_status(Socket) ->
 
 format() ->
     Status = status(),
-    io:fwrite([format(Status, recv_kbps),
+    io:write([format(Status, recv_kbps),
               format(Status, send_kbps)]).
 
 format(Status, Stat) ->
@@ -224,9 +224,9 @@ handle_info({nodedown, Node, _InfoList}, State) ->
     end,
     {noreply, State#state{conns = Conns2}};
 
-handle_info(measurement_tick, State = #state{limit = Limit, stats = Stats,
+handle_info(measurement_tick, State0 = #state{limit = Limit, stats = Stats,
                                              opts = Opts, conns = Conns}) ->
-    schedule_tick(State),
+    State = schedule_tick(State0),
     Fun = fun(Socket, Conn = #conn{type = Type, ts_hist = TSHist, hist = Hist}) when Type /= error ->
                   try
                       {ok, StatVals} = inet:getstat(unwrap_socket(Socket), Stats),

--- a/src/riak_core_tracer.erl
+++ b/src/riak_core_tracer.erl
@@ -86,7 +86,7 @@ all_events({trace, Pid, call, {M,F,A}}) ->
     [{node(Pid), {M,F,A}}].
 
 test_all_events(Ms) ->
-    riak_core_tracer:start_link(),
+    {ok, _Pid} = riak_core_tracer:start_link(),
     riak_core_tracer:reset(),
     riak_core_tracer:filter(Ms, fun all_events/1),
     riak_core_tracer:collect(5000).

--- a/src/riak_core_tracer.erl
+++ b/src/riak_core_tracer.erl
@@ -132,7 +132,7 @@ handle_call({collect, Duration, Nodes}, _From, State) ->
                                  end,
                                  Pid
                          end, self()}),
-    [{ok, N} = dbg:n(N) || N <- Nodes],
+    _ = [{ok, N} = dbg:n(N) || N <- Nodes],
     dbg:p(all, [call]),
     {ok, _} = dbg:tpl(?MODULE, trigger_sentinel, []),
     add_tracers(State#state.mfs),

--- a/src/riak_core_tracer.erl
+++ b/src/riak_core_tracer.erl
@@ -134,7 +134,7 @@ handle_call({collect, Duration, Nodes}, _From, State) ->
                          end, self()}),
     [{ok, N} = dbg:n(N) || N <- Nodes],
     dbg:p(all, [call]),
-    dbg:tpl(?MODULE, trigger_sentinel, []),
+    {ok, _} = dbg:tpl(?MODULE, trigger_sentinel, []),
     add_tracers(State#state.mfs),
     {reply, ok, State#state{trace=[], stop_tref = Tref, tracing = true}};
 handle_call(stop_collect, From, State = #state{tracing = true}) ->
@@ -190,10 +190,10 @@ code_change(_OldVsn, State, _Extra) ->
 add_tracers([]) ->
     ok;
 add_tracers([{M, F} | Rest]) ->
-    dbg:tpl(M, F, [{'_',[],[{message,{return_trace}}]}]),
-     add_tracers(Rest);
+    {ok, _} = dbg:tpl(M, F, [{'_',[],[{message,{return_trace}}]}]),
+    add_tracers(Rest);
 add_tracers([M | Rest]) ->
-    dbg:tpl(M,[{'_',[],[{message,{return_trace}}]}]),
+    {ok, _} = dbg:tpl(M,[{'_',[],[{message,{return_trace}}]}]),
     add_tracers(Rest).
 
 cancel_timer(undefined) ->

--- a/src/riak_core_util.erl
+++ b/src/riak_core_util.erl
@@ -282,7 +282,7 @@ node_hostname() ->
 %% @doc Start depedent applications of App.
 start_app_deps(App) ->
     {ok, DepApps} = application:get_key(App, applications),
-    [ensure_started(A) || A <- DepApps],
+    _ = [ensure_started(A) || A <- DepApps],
     ok.
     
 

--- a/src/riak_core_util.erl
+++ b/src/riak_core_util.erl
@@ -409,13 +409,13 @@ rpc_every_member_ann(Module, Function, Args, Timeout) ->
 
 %% @doc Perform an RPC call to a list of nodes in parallel, returning the
 %%      results in the same order as the input list.
--spec multi_rpc([node()], module(), function(), [any()]) -> [any()].
+-spec multi_rpc([node()], module(), atom(), [any()]) -> [any()].
 multi_rpc(Nodes, Mod, Fun, Args) ->
     multi_rpc(Nodes, Mod, Fun, Args, infinity).
 
 %% @doc Perform an RPC call to a list of nodes in parallel, returning the
 %%      results in the same order as the input list.
--spec multi_rpc([node()], module(), function(), [any()], timeout()) -> [any()].
+-spec multi_rpc([node()], module(), atom(), [any()], timeout()) -> [any()].
 multi_rpc(Nodes, Mod, Fun, Args, Timeout) ->
     pmap(fun(Node) ->
                  rpc:call(Node, Mod, Fun, Args, Timeout)
@@ -424,7 +424,7 @@ multi_rpc(Nodes, Mod, Fun, Args, Timeout) ->
 %% @doc Perform an RPC call to a list of nodes in parallel, returning the
 %%      results in the same order as the input list. Each result is tagged
 %%      with the corresponding node name.
--spec multi_rpc_ann([node()], module(), function(), [any()])
+-spec multi_rpc_ann([node()], module(), atom(), [any()])
                    -> [{node(), any()}].
 multi_rpc_ann(Nodes, Mod, Fun, Args) ->
     multi_rpc_ann(Nodes, Mod, Fun, Args, infinity).
@@ -432,7 +432,7 @@ multi_rpc_ann(Nodes, Mod, Fun, Args) ->
 %% @doc Perform an RPC call to a list of nodes in parallel, returning the
 %%      results in the same order as the input list. Each result is tagged
 %%      with the corresponding node name.
--spec multi_rpc_ann([node()], module(), function(), [any()], timeout())
+-spec multi_rpc_ann([node()], module(), atom(), [any()], timeout())
                    -> [{node(), any()}].
 multi_rpc_ann(Nodes, Mod, Fun, Args, Timeout) ->
     Results = multi_rpc(Nodes, Mod, Fun, Args, Timeout),
@@ -443,7 +443,7 @@ multi_rpc_ann(Nodes, Mod, Fun, Args, Timeout) ->
 %%      of nodes that are down/unreachable. The results will be returned in
 %%      the same order as the input list, and each result is tagged with the
 %%      corresponding node name.
--spec multicall_ann([node()], module(), function(), [any()])
+-spec multicall_ann([node()], module(), atom(), [any()])
                    -> {Results :: [{node(), any()}], Down :: [node()]}.
 multicall_ann(Nodes, Mod, Fun, Args) ->
     multicall_ann(Nodes, Mod, Fun, Args, infinity).
@@ -453,7 +453,7 @@ multicall_ann(Nodes, Mod, Fun, Args) ->
 %%      of nodes that are down/unreachable. The results will be returned in
 %%      the same order as the input list, and each result is tagged with the
 %%      corresponding node name.
--spec multicall_ann([node()], module(), function(), [any()], timeout())
+-spec multicall_ann([node()], module(), atom(), [any()], timeout())
                    -> {Results :: [{node(), any()}], Down :: [node()]}.
 multicall_ann(Nodes, Mod, Fun, Args, Timeout) ->
     L = multi_rpc_ann(Nodes, Mod, Fun, Args, Timeout),

--- a/src/riak_core_util.erl
+++ b/src/riak_core_util.erl
@@ -143,7 +143,7 @@ replace_file(FN, Data) ->
 read_file(FName) ->
     {ok, FD} = file:open(FName, [read, raw, binary]),
     IOList = read_file(FD, []),
-    file:close(FD),
+    ok = file:close(FD),
     {ok, iolist_to_binary(IOList)}.
 
 read_file(FD, Acc) ->

--- a/src/riak_core_util.erl
+++ b/src/riak_core_util.erl
@@ -401,8 +401,6 @@ rpc_every_member(Module, Function, Args, Timeout) ->
 
 %% @doc Same as rpc_every_member/4, but annotate the result set with
 %%      the name of the node returning the result.
--spec rpc_every_member_ann(module(), atom(), [term()], integer()|infinity)
-                          -> {Results::[{node(), term()}], Down::[node()]}.
 rpc_every_member_ann(Module, Function, Args, Timeout) ->
     {ok, MyRing} = riak_core_ring_manager:get_my_ring(),
     Nodes = riak_core_ring:all_members(MyRing),

--- a/src/riak_core_util.erl
+++ b/src/riak_core_util.erl
@@ -470,8 +470,9 @@ multicall_ann(Nodes, Mod, Fun, Args, Timeout) ->
 %%      2i and 2i+1. The conversion also supports a "cycles" mode where
 %%      the array is logically wrapped around to ensure leaf nodes also
 %%      have children by giving them backedges to other elements.
+
 -spec build_tree(N :: integer(), Nodes :: [term()], Opts :: [term()])
-                -> orddict:orddict(Node :: term(), Children :: [term()]).
+                -> orddict:orddict().
 build_tree(N, Nodes, Opts) ->
     case lists:member(cycles, Opts) of
         true -> 

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -989,7 +989,7 @@ start_manager_event_timer(Event, State=#state{mod=Mod, index=Idx}) ->
 stop_manager_event_timer(#state{manager_event_timer=undefined}) ->
     ok;
 stop_manager_event_timer(#state{manager_event_timer=T}) ->
-    gen_fsm:cancel_timer(T),
+    _ = gen_fsm:cancel_timer(T),
     ok.
 
 is_request_forwardable(#riak_core_fold_req_v2{forwardable=false}) ->

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -375,6 +375,11 @@ vnode_handoff_command(Sender, Request, ForwardTo,
             riak_core_vnode_worker_pool:handle_work(Pool, Work, From),
             continue(State, NewModState);
         {forward, NewModState} ->
+            %% FIXME: vnode_forward returns a gen_fsm state return
+            %% value by calling continue/1 internally. Questions:
+            %% 1) Why are we not passing the NewModState to vnode_forward?
+            %% 2) If vnode_forward produces the gen_fsm state return
+            %%    type, why not use it?
             case HOType of
                 %% resize op and transfer ongoing
                 resize_transfer -> vnode_forward(resize, ForwardTo, Sender,
@@ -383,7 +388,7 @@ vnode_handoff_command(Sender, Request, ForwardTo,
                 %% via forward_or_vnode_command
                 undefined -> vnode_forward(resize, ForwardTo, Sender,
                                            {resize_forward, Request}, State);
-                %% normal explicit forwarding during owhership transfer
+                %% normal explicit forwarding during ownership transfer
                 _ -> vnode_forward(explicit, HOTarget, Sender, Request, State)
             end,
             continue(State, NewModState);

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -984,7 +984,8 @@ start_manager_event_timer(Event, State=#state{mod=Mod, index=Idx}) ->
 stop_manager_event_timer(#state{manager_event_timer=undefined}) ->
     ok;
 stop_manager_event_timer(#state{manager_event_timer=T}) ->
-    gen_fsm:cancel_timer(T).
+    gen_fsm:cancel_timer(T),
+    ok.
 
 is_request_forwardable(#riak_core_fold_req_v2{forwardable=false}) ->
     false;

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -563,8 +563,6 @@ delmon(MonRef, _State=#state{idxtab=T}) ->
 add_vnode_rec(I,  _State=#state{idxtab=T}) -> ets:insert(T,I).
 
 %% @private
--spec get_vnode(Idx::integer() | [integer()], Mod::term(), State:: #state{}) ->
-          pid() | [pid()].
 get_vnode(Idx, Mod, State) when not is_list(Idx) ->
     [Result] = get_vnode([Idx], Mod, State),
     Result;

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -368,7 +368,7 @@ handle_call(_, _From, State) ->
 
 %% @private
 handle_cast({Partition, Mod, start_vnode}, State) ->
-    get_vnode(Partition, Mod, State),
+    _ = get_vnode(Partition, Mod, State),
     {noreply, State};
 handle_cast({unregister, Index, Mod, Pid}, #state{idxtab=T} = State) ->
     %% Update forwarding state to ensure vnode is not restarted in
@@ -849,7 +849,7 @@ maybe_start_vnodes(State=#state{vnode_start_tokens=Tokens,
         {_, []} ->
             State;
         {_, [{Idx, Mod} | NeverStarted2]} ->
-            get_vnode(Idx, Mod, State),
+            _ = get_vnode(Idx, Mod, State),
             gen_server:cast(?MODULE, maybe_start_vnodes),
             State#state{vnode_start_tokens=Tokens-1,
                         never_started=NeverStarted2}

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -494,7 +494,8 @@ maybe_ensure_vnodes_started(Ring) ->
     Status = riak_core_ring:member_status(Ring, node()),
     case lists:member(Status, ExitingStates) of
         true ->
-            ensure_vnodes_started(Ring);
+            ensure_vnodes_started(Ring),
+            ok;
         _ ->
             ok
     end.

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -386,8 +386,8 @@ handle_cast(force_handoffs, State) ->
     {ok, Ring, CHBin} = riak_core_ring_manager:get_raw_ring_chashbin(),
     State2 = update_handoff(AllVNodes, Ring, CHBin, State),
 
-    [maybe_trigger_handoff(Mod, Idx, Pid, State2)
-     || {Mod, Idx, Pid} <- AllVNodes],
+    _ = [maybe_trigger_handoff(Mod, Idx, Pid, State2)
+         || {Mod, Idx, Pid} <- AllVNodes],
 
     {noreply, State2};
 
@@ -524,7 +524,7 @@ trigger_ownership_handoff(Transfers, Mods, Ring, State) ->
                               S =:= awaiting,
                               Node =:= node(),
                               not lists:member(Mod, CMods)],
-    [maybe_trigger_handoff(Mod, Idx, State) || {Mod, Idx} <- Awaiting],
+    _ = [maybe_trigger_handoff(Mod, Idx, State) || {Mod, Idx} <- Awaiting],
     ok.
 
 limit_ownership_handoff(Transfers, IsResizing) ->
@@ -591,7 +591,7 @@ get_vnode(IdxList, Mod, State) ->
     Pairs = Started ++ riak_core_util:pmap(StartFun, NotStarted, MaxStart),
     % Return Pids in same order as input
     PairsDict = dict:from_list(Pairs),
-    [begin
+    _ = [begin
          Pid = dict:fetch(Idx, PairsDict),
          MonRef = erlang:monitor(process, Pid),
          IdxRec = #idxrec{key={Idx,Mod},idx=Idx,mod=Mod,pid=Pid,
@@ -599,10 +599,7 @@ get_vnode(IdxList, Mod, State) ->
          MonRec = #monrec{monref=MonRef, key={Idx,Mod}},
          add_vnode_rec([IdxRec, MonRec], State)
      end || Idx <- NotStarted],
-    [begin
-         Pid = dict:fetch(Idx, PairsDict),
-         Pid
-     end || Idx <- IdxList].
+    [ dict:fetch(Idx, PairsDict) || Idx <- IdxList].
 
 
 get_forward(Mod, Idx, #state{forwarding=Fwd}) ->
@@ -966,7 +963,7 @@ get_plus_one([_, _, PlusOne]) ->
 %%      targeting this node with `Reason'.
 -spec kill_repairs([repair()], term()) -> ok.
 kill_repairs(Repairs, Reason) ->
-    [kill_repair(Repair, Reason) || Repair <- Repairs],
+    _ = [kill_repair(Repair, Reason) || Repair <- Repairs],
     ok.
 
 kill_repair(Repair, Reason) ->

--- a/src/riak_core_vnode_master.erl
+++ b/src/riak_core_vnode_master.erl
@@ -163,7 +163,7 @@ make_request(Request, Sender, Index) ->
               request=Request}.
 
 %% Make a request record - exported for use by legacy modules
--spec make_coverage_request(vnode_req(), [{partition(), [partition()]}], sender(), partition()) -> #riak_coverage_req_v1{}.
+-spec make_coverage_request(vnode_req(), keyspaces(), sender(), partition()) -> #riak_coverage_req_v1{}.
 make_coverage_request(Request, KeySpaces, Sender, Index) ->
     #riak_coverage_req_v1{index=Index,
                           keyspaces=KeySpaces,

--- a/src/riak_core_vnode_master.erl
+++ b/src/riak_core_vnode_master.erl
@@ -210,19 +210,12 @@ do_proxy_cast({VMaster, Node}, Req=?COVERAGE_REQ{index=Idx}, How) ->
     Mod = vmaster_to_vmod(VMaster),
     Proxy = riak_core_vnode_proxy:reg_name(Mod, Idx, Node),
     send_an_event(Proxy, Req, How),
-    ok;
-do_proxy_cast({VMaster, Node}, Other, How) ->
-    send_a_cast({VMaster, Node}, Other, How).
+    ok.
 
 send_an_event(Dest, Event, normal) ->
     gen_fsm:send_event(Dest, Event);
 send_an_event(Dest, Event, unreliable) ->
     riak_core_send_msg:send_event_unreliable(Dest, Event).
-
-send_a_cast(Dest, Msg, normal) ->
-    gen_server:cast(Dest, Msg);
-send_a_cast(Dest, Msg, unreliable) ->
-    riak_core_send_msg:cast_unreliable(Dest, Msg).
 
 handle_cast({wait_for_service, Service}, State) ->
     case Service of

--- a/src/riak_core_vnode_proxy.erl
+++ b/src/riak_core_vnode_proxy.erl
@@ -135,7 +135,7 @@ loop(Parent, State) ->
     receive
         {'$vnode_proxy_call', From, Msg} ->
             {reply, Reply, NewState} = handle_call(Msg, From, State),
-            gen:reply(From, Reply),
+            {_, Reply} = gen:reply(From, Reply),
             loop(Parent, NewState);
         {'$vnode_proxy_cast', Msg} ->
             {noreply, NewState} = handle_cast(Msg, State),

--- a/src/riak_core_vnode_proxy_sup.erl
+++ b/src/riak_core_vnode_proxy_sup.erl
@@ -42,8 +42,8 @@ start_proxy(Mod, Index) ->
     Pid.
 
 stop_proxy(Mod, Index) ->
-    supervisor:terminate_child(?MODULE, {Mod, Index}),
-    supervisor:delete_child(?MODULE, {Mod, Index}),
+    _ = supervisor:terminate_child(?MODULE, {Mod, Index}),
+    _ = supervisor:delete_child(?MODULE, {Mod, Index}),
     ok.
 
 start_proxies(Mod) ->

--- a/src/riak_core_vnode_proxy_sup.erl
+++ b/src/riak_core_vnode_proxy_sup.erl
@@ -49,7 +49,7 @@ stop_proxy(Mod, Index) ->
 start_proxies(Mod) ->
     lager:debug("Starting vnode proxies for: ~p", [Mod]),
     Indices = get_indices(),
-    [start_proxy(Mod, Index) || Index <- Indices],
+    _ = [start_proxy(Mod, Index) || Index <- Indices],
     ok.
 
 %% @private

--- a/src/riak_core_vnode_worker_pool.erl
+++ b/src/riak_core_vnode_worker_pool.erl
@@ -195,8 +195,8 @@ handle_info({'DOWN', _Ref, _, Pid, Info}, StateName, #state{monitors=Monitors} =
     end;
 handle_info(shutdown, shutdown, #state{monitors=Monitors} = State) ->
     %% we've waited too long to shutdown, time to force the issue.
-    [riak_core_vnode:reply(From, {error, vnode_shutdown}) || {_, _, From, _}
-        <- Monitors],
+    _ = [riak_core_vnode:reply(From, {error, vnode_shutdown}) || 
+            {_, _, From, _} <- Monitors],
     {stop, shutdown, State};
 handle_info(_Info, StateName, State) ->
     {next_state, StateName, State}.

--- a/src/riak_core_vnode_worker_pool.erl
+++ b/src/riak_core_vnode_worker_pool.erl
@@ -172,7 +172,8 @@ handle_sync_event({shutdown, Time}, From, _StateName, #state{queue=Q,
                 infinity ->
                     ok;
                 _ when is_integer(Time) ->
-                    erlang:send_after(Time, self(), shutdown)
+                    erlang:send_after(Time, self(), shutdown),
+                    ok
             end,
             {next_state, shutdown, State#state{shutdown=From, queue=queue:new()}}
     end;

--- a/src/supervisor_pre_r14b04.erl
+++ b/src/supervisor_pre_r14b04.erl
@@ -64,7 +64,7 @@
 %%--------------------------------------------------------------------------
 
 -record(child, {% pid is undefined when child is not running
-	        pid = undefined :: child(),
+	        pid = undefined :: child() | [pid()],
 		name,
 		mfargs          :: mfargs(),
 		restart_type    :: restart(),
@@ -899,7 +899,7 @@ wait_dynamic_children(_Child, _Pids, 0, undefined, EStack) ->
 wait_dynamic_children(_Child, _Pids, 0, TRef, EStack) ->
 	%% If the timer has expired before its cancellation, we must empty the
 	%% mail-box of the 'timeout'-message.
-    erlang:cancel_timer(TRef),
+    _ = erlang:cancel_timer(TRef),
     receive
         {timeout, TRef, kill} ->
             EStack
@@ -1238,16 +1238,15 @@ report_error(Error, Reason, Child, SupName) ->
 		{offender, extract_child(Child)}],
     error_logger:error_report(supervisor_report, ErrorMsg).
 
-
-extract_child(Child) when is_pid(Child#child.pid) ->
-    [{pid, Child#child.pid},
+extract_child(Child) when is_list(Child#child.pid) ->
+    [{nb_children, length(Child#child.pid)},
      {name, Child#child.name},
      {mfargs, Child#child.mfargs},
      {restart_type, Child#child.restart_type},
      {shutdown, Child#child.shutdown},
      {child_type, Child#child.child_type}];
 extract_child(Child) ->
-    [{nb_children, length(Child#child.pid)},
+    [{pid, Child#child.pid},
      {name, Child#child.name},
      {mfargs, Child#child.mfargs},
      {restart_type, Child#child.restart_type},

--- a/src/supervisor_pre_r14b04.erl
+++ b/src/supervisor_pre_r14b04.erl
@@ -243,7 +243,7 @@ init_children(State, StartSpec) ->
                 {ok, NChildren} ->
                     {ok, State#state{children = NChildren}};
                 {error, NChildren} ->
-                    terminate_children(NChildren, SupName),
+                    _ = terminate_children(NChildren, SupName),
                     {stop, shutdown}
             end;
         Error ->

--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -54,11 +54,8 @@
 
 -export_type([vclock/0, timestamp/0, vclock_node/0, dot/0]).
 
--opaque vclock() :: [vc_entry()].
--opaque dot() :: vc_entry().
-
-% The timestamp is present but not used, in case a client wishes to inspect it.
--type vc_entry() :: {vclock_node(), {counter(), timestamp()}}.
+-type vclock() :: [dot()].
+-opaque dot() :: {vclock_node(), {counter(), timestamp()}}.
 
 % Nodes can have any term() as a name, but they must differ from each other.
 -type   vclock_node() :: term().
@@ -75,7 +72,7 @@ fresh(Node, Count) ->
     [{Node, {Count, timestamp()}}].
 
 % @doc Return true if Va is a direct descendant of Vb, else false -- remember, a vclock is its own descendant!
--spec descends(Va :: vclock()|[], Vb :: vclock()|[]) -> boolean().
+-spec descends(Va :: vclock(), Vb :: vclock()) -> boolean().
 descends(_, []) ->
     % all vclocks descend from the empty vclock
     true;
@@ -123,7 +120,7 @@ dominates(A, B) ->
 
 % @doc Combine all VClocks in the input list into their least possible
 %      common descendant.
--spec merge(VClocks :: [vclock()]) -> vclock() | [].
+-spec merge(VClocks :: [vclock()]) -> vclock().
 merge([])             -> [];
 merge([SingleVclock]) -> SingleVclock;
 merge([First|Rest])   -> merge(Rest, lists:keysort(1, First)).


### PR DESCRIPTION
This is a rebase/cleanup of #528. As agreed with @jrwest, this _does not_ include removal of legacy gossip, which will be in a separate PR. Also, warnings from `riak_core_security` are left alone until fixes land from @Vagabond and @macintux.

There should be no eunit failures on this branch, but these warnings _should_ exist:

```
# These are legacy gossip warnings:
riak_core.erl:85: The pattern 'true' can never match the type 'false'
riak_core.erl:185: The pattern 'true' can never match the type 'false'
riak_core.erl:203: The pattern <'true', _> can never match the type <'false',_>
riak_core.erl:239: The pattern 'true' can never match the type 'false'
riak_core.erl:262: Function legacy_remove/1 will never be called
riak_core_claimant.erl:366: The pattern 'legacy' can never match the type {'error','invalid_resize_claim'} | {'ok',[{_,_},...]}
riak_core_claimant.erl:403: The pattern {'legacy', _} can never match the type {'error','invalid_resize_claim'} | {'ok',{'chstate_v2',_,'undefined' | [any()],{_,_},'undefined' | dict(),'undefined' | {_,_},'undefined' | [any()],[any()],_,'undefined' | [any()],'undefined' | [any()]}}
riak_core_claimant.erl:797: The pattern {'legacy', _} can never match the type {'error','invalid_resize_claim'} | {'ok',{'chstate_v2',_,'undefined' | [any()],{_,_},'undefined' | dict(),'undefined' | {_,_},'undefined' | [any()],[any()],_,'undefined' | [any()],'undefined' | [any()]}}
riak_core_claimant.erl:825: The pattern {'true', 'true'} can never match the type {'true','false'}
riak_core_console.erl:102: The pattern 'true' can never match the type 'false'
riak_core_console.erl:918: The variable Error can never match since previous clauses completely covered the type 'ok'
riak_core_gossip.erl:214: The pattern 1 can never match the type 2
riak_core_gossip.erl:229: The pattern 'true' can never match the type 'false'
riak_core_gossip.erl:245: The pattern 'true' can never match the type 'false'
riak_core_ring_handler.erl:73: The pattern {'true', _, _, _} can never match the type {'false',boolean(),[integer()],'down' | 'exiting' | 'invalid' | 'joining' | 'leaving' | 'valid'}

# These are security warnings:
riak_core_security.erl:252: The test [any()] == 'all' can never evaluate to 'true'
riak_core_security.erl:265: The test [any()] == 'all' can never evaluate to 'true'
riak_core_security.erl:488: The call riak_core_security:add_grant_int(['all'],Bucket::any(),Grants::maybe_improper_list()) will never return since it differs in the 1st argument from the success typing arguments: ([{_,'group' | 'user'}],any(),maybe_improper_list())
riak_core_security.erl:530: The call riak_core_security:add_revoke_int(['all'],Bucket::any(),'revokes') will never return since it differs in the 1st argument from the success typing arguments: ([{_,'group' | 'user'}],any(),'revokes' | maybe_improper_list())
riak_core_security.erl:533: The variable Error2 can never match since previous clauses completely covered the type 'ok'
riak_core_security.erl:882: The variable Error can never match since previous clauses completely covered the type {'ok',[tuple(),...]}
riak_core_security.erl:917: The pattern {'error', Error} can never match the type {'ok',binary() | [1..255],'pbkdf2','sha',binary(),65536}
```
