### PR TITLE
Add callback annotations to riak_core_vnode

### DIFF
--- a/include/riak_core_vnode.hrl
+++ b/include/riak_core_vnode.hrl
@@ -33,3 +33,6 @@
 -define(VNODE_REQ, #riak_vnode_req_v1).
 -define(COVERAGE_REQ, #riak_coverage_req_v1).
 -define(FOLD_REQ, #riak_core_fold_req_v2).
+
+-type handoff_type() :: resize_transfer | ownership_transfer | hinted_handoff.
+-type handoff_dest() :: {handoff_type(), {partition(), node()}}.


### PR DESCRIPTION
A few concerns popped up when doing this:
- The `handoff_type()` type I added based on the code in `riak_core_vnode` differs significantly from the similar type in `riak_core_handoff.hrl`. This should be addressed.
- Based on code in `riak_core_handoff_sender`, the `encode_handoff_item/2` callback seems to be called with a term shaped like `{_, _}` as the key. This should probably be generalized so as not to crash if a new type of vnode returns `corrupted` from the callback.
- Although the comments in the module mention that `handle_exit/3` is optional, it was included in the `behaviour_info/1` function previously, so I added the callback annotation anyway.
