### PR TITLE
Only wait for the finished message in the updown test

### DIFF
--- a/src/riak_core_tcp_mon.erl
+++ b/src/riak_core_tcp_mon.erl
@@ -404,10 +404,7 @@ updown() ->
           end,
         lists:seq(1,10000)),
     receive
-        finished -> ok;
-        {'EXIT', _, normal} -> ok;
-        X -> io:format(user, "Unexpected message received ~p~n", [X]),
-            ?assert(fail)
+        finished -> ok
     end,
     gen_tcp:close(Socket),
     unlink(TCPMonPid),


### PR DESCRIPTION
Previously any unexpected messages would crash, but I think just
blocking until the finish message comes in is enough.

cc @metadave 
