### PR TITLE
Make print-user/group look like print-users/groups

### DIFF
--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -27,7 +27,7 @@
          add_group/1, alter_group/1, del_group/1,
          add_source/1, del_source/1, grant/1, revoke/1,
          print_users/1, print_user/1, print_sources/1,
-         print_groups/1, print_group/1,
+         print_groups/1, print_group/1, print_grants/1,
          security_enable/1, security_disable/1, security_status/1, ciphers/1]).
 
 %% @doc Return for a given ring and node, percentage currently owned and
@@ -838,12 +838,16 @@ security_error_xlate({errors, Errors}) ->
       "~n");
 security_error_xlate({error, unknown_user}) ->
     "User not recognized";
+security_error_xlate({error, unknown_group}) ->
+    "Group not recognized";
 security_error_xlate({error, {unknown_permission, Name}}) ->
     io_lib:format("Permission not recognized: ~s", [Name]);
+security_error_xlate({error, {unknown_role, Name}}) ->
+    io_lib:format("Name not recognized: ~s", [Name]);
 security_error_xlate({error, {unknown_user, Name}}) ->
     io_lib:format("User not recognized: ~s", [Name]);
 security_error_xlate({error, {unknown_group, Name}}) ->
-    io_lib:format("User not recognized: ~s", [Name]);
+    io_lib:format("Group not recognized: ~s", [Name]);
 security_error_xlate({error, {unknown_users, Names}}) ->
     io_lib:format("User(s) not recognized: ~s",
                   [
@@ -896,7 +900,6 @@ add_group([Groupname|Options]) ->
 add_role(Name, Options, Fun) ->
     try Fun(list_to_binary(Name), parse_options(Options)) of
         ok ->
-            io:format("Successfully added ~s~n", [Name]),
             ok;
         Error ->
             io:format(security_error_xlate(Error)),
@@ -918,7 +921,6 @@ alter_group([Groupname|Options]) ->
 alter_role(Name, Options, Fun) ->
     try Fun(list_to_binary(Name), parse_options(Options)) of
         ok ->
-            io:format("Changes to ~s applied~n", [Name]),
             ok;
         Error ->
             io:format(security_error_xlate(Error)),
@@ -1069,6 +1071,15 @@ revoke(_) ->
     io:format("Usage: revoke <permissions> ON <type> [bucket] FROM <users>~n"),
     error.
 
+print_grants([Name]) ->
+    case riak_core_security:print_grants(list_to_binary(Name)) of
+        ok ->
+            ok;
+        Error ->
+            io:format(security_error_xlate(Error)),
+            io:format("~n"),
+            Error
+    end.
 
 print_users([]) ->
     riak_core_security:print_users().

--- a/src/riak_core_console_table.erl
+++ b/src/riak_core_console_table.erl
@@ -21,13 +21,23 @@
 -module(riak_core_console_table).
 
 %% API
--export([print/2,
+-export([print/2, print/3,
          create_table/2]).
 
 -spec print(list(), list()) -> ok.
+print(_Spec, []) ->
+    ok;
 print(Spec, Rows) ->
     Table = create_table(Spec, Rows),
-    io:format("~s", [Table]).
+    io:format("~n~s~n", [Table]).
+
+
+-spec print(list(), list(), list()) -> ok.
+print(_Hdr, _Spec, []) ->
+    ok;
+print(Header, Spec, Rows) ->
+    Table = create_table(Spec, Rows),
+    io:format("~s~n~n~s~n", [Header, Table]).
 
 -spec create_table(list(), list()) -> iolist().
 create_table(Spec, Rows) ->
@@ -57,7 +67,7 @@ get_row_length(Spec, Rows) ->
     Res = lists:foldl(fun({_Name, MinSize}, Total) ->
                         Longest = find_longest_field(Rows, length(Total)+1),
                         Size = erlang:max(MinSize, Longest),
-                        [Size | Total] 
+                        [Size | Total]
                 end, [], Spec),
     lists:reverse(Res).
 
@@ -87,9 +97,9 @@ align(Str, Size) when is_binary(Str) ->
     align(binary_to_list(Str), Size);
 align(Str, Size) when is_atom(Str) ->
     align(atom_to_list(Str), Size);
-%align(Str, Size) when is_list(Str), length(Str) > Size -> 
+%align(Str, Size) when is_list(Str), length(Str) > Size ->
     %Truncated = lists:sublist(Str, Size),
-    %Truncated ++ " |"; 
+    %Truncated ++ " |";
 %align(Str, Size) when is_list(Str), length(Str) =:= Size ->
     %Str ++ " |";
 align(Str, Size) when is_list(Str) ->
@@ -153,4 +163,3 @@ pad_field(Field, MaxHeight) when length(Field) < MaxHeight ->
     Field ++ ["" || _ <- lists:seq(1, MaxHeight - length(Field))];
 pad_field(Field, _MaxHeight) ->
     Field.
-


### PR DESCRIPTION
- `print-user` (likewise `-group`) is just a single-entity version of `print-users` now
- Create `print-grants <user|group>` to replace the old `print-user/group`
- Make `print_grants` much less noisy by making the `console_table` code smarter
- Allow `user/` and `group/` prefixes for print-grants, also fix old render bug with `print-grants` and groups
- Extend unit tests

PRs exist for the related repositories:
- basho/riak#504
- basho/riak_ee#227
- basho/riak_test#548

/cc @Vagabond 
