### PR TITLE
Allow handoff sender to abort handoff by throw'ing from fold fun

### DIFF
--- a/src/riak_core_handoff_receiver.erl
+++ b/src/riak_core_handoff_receiver.erl
@@ -81,10 +81,10 @@ handle_info({tcp_closed,_Socket},State=#state{partition=Partition,count=Count,
     lager:info("Handoff receiver for partition ~p exited after processing ~p"
                           " objects from ~p", [Partition, Count, Peer]),
     {stop, normal, State};
-handle_info({tcp_error, _Socket, _Reason}, State=#state{partition=Partition,count=Count,
-                                                        peer=Peer}) ->
+handle_info({tcp_error, _Socket, Reason}, State=#state{partition=Partition,count=Count,
+                                                       peer=Peer}) ->
     lager:info("Handoff receiver for partition ~p exited after processing ~p"
-                          " objects from ~p", [Partition, Count, Peer]),
+                          " objects from ~p: TCP error ~p", [Partition, Count, Peer, Reason]),
     {stop, normal, State};
 handle_info({tcp, Socket, Data}, State) ->
     [MsgType|MsgData] = Data,

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -200,7 +200,7 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
                                                           VMaster, infinity),
 
          %% Send any straggler entries remaining in the buffer:
-        AccRecord = send_objects(AccRecord0#ho_acc.item_queue, AccRecord0),
+         AccRecord = send_objects(AccRecord0#ho_acc.item_queue, AccRecord0),
 
          if AccRecord == {error, vnode_shutdown} ->
                  ?log_info("because the local vnode was shutdown", []),
@@ -281,11 +281,10 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
              gen_fsm:send_event(ParentPid, {handoff_error, Err, Reason})
      end.
 
-%% When a tcp error occurs, the ErrStatus argument is set to {error, Reason}.
-%% Since we can't abort the fold, this clause is just a no-op.
 visit_item(_K, _V, Acc=#ho_acc{error={error, _Reason}}) ->
-    Acc;
-visit_item(K, V, Acc = #ho_acc{ack = _AccSyncThreshold, acksync_threshold = _AccSyncThreshold}) ->
+    %% When a TCP/SSL error occurs, #ho_acc.error is set to {error, Reason}.
+    throw(Acc);
+visit_item(K, V, Acc = #ho_acc{ack = AccSyncThreshold, acksync_threshold = AccSyncThreshold}) ->
     #ho_acc{module=Module,
             socket=Sock,
             src_target={SrcPartition, TargetPartition},


### PR DESCRIPTION
Depends upon: https://github.com/basho/riak_kv/pull/869

There's no reason why the handoff sender fold fun has to continue
folding when there's a TCP error.  Instead, throw the #ho_acc{}
record with its error={error,Reason} field intact.

If we force the handoff receiver to exit (using exit(HO_pid, kill)),
then we simply see the following logged on the sender side:

```
2014-03-17 15:53:30.949 [error] <0.27207.2>@riak_core_handoff_sender:start_fold:266 hinted_handoff transfer of riak_kv_vnode from 'dev1@127.0.0.1' 1415829711164312202009819681693899175291684651008 to 'dev2@127.0.0.1' 1415829711164312202009819681693899175291684651008 failed because of closed
2014-03-17 15:53:30.950 [error] <0.220.0>@riak_core_handoff_manager:handle_info:289 An outbound handoff of partition riak_kv_vnode 1415829711164312202009819681693899175291684651008 was terminated for reason: {shutdown,{error,closed}}
```

Also, change the lager:info() message when the handoff receiver
gets a tcp_error message that _includes_ the reason and
distiguishes itself from other handoff receiver log messages.

Also, one whitespace correction.
