### PR TITLE
Prevent a bucket type named 'any' from being created

### DIFF
--- a/src/riak_core_bucket_type.erl
+++ b/src/riak_core_bucket_type.erl
@@ -143,9 +143,14 @@ defaults() ->
 %% calls and the type is not active. An error will also be returned if the properties
 %% are not valid. Properties not provided will be taken from those returned by
 %% {@see defaults/0}.
+%%
+%% `default` and `any` are reserved names; `any` because the security subsystem needs a
+%% way to refer to any bucket type when granting permissions.
 -spec create(bucket_type(), bucket_type_props()) -> ok | {error, term()}.
 create(?DEFAULT_TYPE, _Props) ->
     {error, default_type};
+create(<<"any">>, _Props) ->
+    {error, reserved_name};
 create(BucketType, Props) when is_binary(BucketType) ->
     ?IF_CAPABLE(riak_core_claimant:create_bucket_type(BucketType,
                                                       riak_core_bucket_props:merge(Props, defaults())),


### PR DESCRIPTION
In order for the security CLI to be able to grant permissions to any bucket type, we need to prevent the administrator from creating a bucket type named "any".

This is dependent on an unfinished PR that would change the grant syntax to use lower-case keywords; this may need to be changed to "ANY" before approval and merging.

/cc @jrwest 
