### PR TITLE
Be more rigorous with security command-line arguments

### DIFF
--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -841,55 +841,54 @@ security_error_xlate({error, unknown_user}) ->
 security_error_xlate({error, unknown_group}) ->
     "Group not recognized";
 security_error_xlate({error, {unknown_permission, Name}}) ->
-    io_lib:format("Permission not recognized: ~s", [Name]);
+    io_lib:format("Permission not recognized: ~ts", [Name]);
 security_error_xlate({error, {unknown_role, Name}}) ->
-    io_lib:format("Name not recognized: ~s", [Name]);
+    io_lib:format("Name not recognized: ~ts", [Name]);
 security_error_xlate({error, {unknown_user, Name}}) ->
-    io_lib:format("User not recognized: ~s", [Name]);
+    io_lib:format("User not recognized: ~ts", [Name]);
 security_error_xlate({error, {unknown_group, Name}}) ->
-    io_lib:format("Group not recognized: ~s", [Name]);
+    io_lib:format("Group not recognized: ~ts", [Name]);
 security_error_xlate({error, {unknown_users, Names}}) ->
-    io_lib:format("User(s) not recognized: ~s",
+    io_lib:format("User(s) not recognized: ~ts",
                   [
                    string:join(
-                     lists:map(fun(X) -> binary_to_list(X) end, Names),
+                     lists:map(fun(X) -> unicode:characters_to_list(X, utf8) end, Names),
                      ", ")
                   ]);
 security_error_xlate({error, {unknown_groups, Names}}) ->
-    io_lib:format("Group(s) not recognized: ~s",
+    io_lib:format("Group(s) not recognized: ~ts",
                   [
                    string:join(
-                     lists:map(fun(X) -> binary_to_list(X) end, Names),
+                     lists:map(fun(X) -> unicode:characters_to_list(X, utf8) end, Names),
                      ", ")
                   ]);
 security_error_xlate({error, {unknown_roles, Names}}) ->
-    io_lib:format("Name(s) not recognized: ~s",
+    io_lib:format("Name(s) not recognized: ~ts",
                   [
                    string:join(
-                    lists:map(fun(X) -> binary_to_list(X) end, Names),
+                    lists:map(fun(X) -> unicode:characters_to_list(X, utf8) end, Names),
                     ", ")
                   ]);
 security_error_xlate({error, {duplicate_roles, Names}}) ->
-    io_lib:format("Ambiguous names need to be prefixed with 'user/' or 'group/': ~s",
+    io_lib:format("Ambiguous names need to be prefixed with 'user/' or 'group/': ~ts",
                   [
                    string:join(
-                     lists:map(fun(X) -> binary_to_list(X) end, Names),
+                     lists:map(fun(X) -> unicode:characters_to_list(X, utf8) end, Names),
                      ", ")
                   ]);
 security_error_xlate({error, reserved_name}) ->
     "This name is reserved for system use";
 security_error_xlate({error, no_matching_sources}) ->
     "No matching source";
-security_error_xlate({error, user_exists}) ->
-    "User already exists";
-security_error_xlate({error, group_exists}) ->
-    "Group already exists";
+security_error_xlate({error, illegal_name_char}) ->
+    "Illegal character(s) in name";
+security_error_xlate({error, role_exists}) ->
+    "This name is already in use";
 
 %% If we get something we hadn't planned on, better an ugly error
 %% message than an ugly RPC call failure
 security_error_xlate(Error) ->
     io_lib:format("~p", [Error]).
-
 
 add_user([Username|Options]) ->
     add_role(Username, Options, fun riak_core_security:add_user/2).
@@ -898,7 +897,7 @@ add_group([Groupname|Options]) ->
     add_role(Groupname, Options, fun riak_core_security:add_group/2).
 
 add_role(Name, Options, Fun) ->
-    try Fun(list_to_binary(Name), parse_options(Options)) of
+    try Fun(Name, parse_options(Options)) of
         ok ->
             ok;
         Error ->
@@ -919,7 +918,7 @@ alter_group([Groupname|Options]) ->
     alter_role(Groupname, Options, fun riak_core_security:alter_group/2).
 
 alter_role(Name, Options, Fun) ->
-    try Fun(list_to_binary(Name), parse_options(Options)) of
+    try Fun(Name, parse_options(Options)) of
         ok ->
             ok;
         Error ->
@@ -940,9 +939,9 @@ del_group([Groupname]) ->
     del_role(Groupname, fun riak_core_security:del_group/1).
 
 del_role(Name, Fun) ->
-    case Fun(list_to_binary(Name)) of
+    case Fun(Name) of
         ok ->
-            io:format("Successfully deleted ~s~n", [Name]),
+            io:format("Successfully deleted ~ts~n", [Name]),
             ok;
         Error ->
             io:format(security_error_xlate(Error)),
@@ -955,10 +954,12 @@ add_source([Users, CIDR, Source | Options]) ->
         ["all"] ->
             all;
         Other ->
-            [list_to_binary(O) || O <- Other]
+            Other
     end,
+    %% Unicode note: atoms are constrained to latin1 until R18, so our
+    %% sources are as well
     try riak_core_security:add_source(Unames, parse_cidr(CIDR),
-                                  list_to_atom(Source),
+                                  list_to_atom(string:to_lower(Source)),
                                   parse_options(Options)) of
         ok ->
             io:format("Successfully added source~n"),
@@ -970,8 +971,10 @@ add_source([Users, CIDR, Source | Options]) ->
     catch
         throw:{error, {invalid_option, Option}} ->
             io:format("Invalid option ~p, options are of the form key=value~n",
-                      [Option]),
-            error
+                      [Option]);
+        error:badarg ->
+            io:format("Invalid source ~ts, must be latin1, sorry~n",
+                      [Source])
     end.
 
 del_source([Users, CIDR]) ->
@@ -979,20 +982,25 @@ del_source([Users, CIDR]) ->
         ["all"] ->
             all;
         Other ->
-            [list_to_binary(O) || O <- Other]
+            Other
     end,
     riak_core_security:del_source(Unames, parse_cidr(CIDR)),
     io:format("Deleted source~n").
 
-grant([Grants, "ON", "ANY", "TO", Users]) ->
-    Unames = case string:tokens(Users, ",") of
+
+parse_roles(Roles) ->
+    case string:tokens(Roles, ",") of
         ["all"] ->
             all;
         Other ->
-            [list_to_binary(O) || O <- Other]
-    end,
-    Permissions = string:tokens(Grants, ","),
-    case riak_core_security:add_grant(Unames, any, Permissions) of
+            Other
+    end.
+
+parse_grants(Grants) ->
+    string:tokens(Grants, ",").
+
+grant_int(Permissions, Bucket, Roles) ->
+    case riak_core_security:add_grant(Roles, Bucket, Permissions) of
         ok ->
             io:format("Successfully granted~n"),
             ok;
@@ -1000,42 +1008,27 @@ grant([Grants, "ON", "ANY", "TO", Users]) ->
             io:format(security_error_xlate(Error)),
             io:format("~n"),
             Error
-    end;
-grant([Grants, "ON", Type, Bucket, "TO", Users]) ->
-    grant([Grants, "ON", {list_to_binary(Type), list_to_binary(Bucket)}, "TO",
-           Users]);
-grant([Grants, "ON", Type, "TO", Users]) when is_list(Type) ->
-    grant([Grants, "ON", list_to_binary(Type), "TO", Users]);
-grant([Grants, "ON", Bucket, "TO", Users]) ->
-    Unames = case string:tokens(Users, ",") of
-        ["all"] ->
-            all;
-        Other ->
-            [list_to_binary(O) || O <- Other]
-    end,
-    Permissions = string:tokens(Grants, ","),
-    case riak_core_security:add_grant(Unames, Bucket, Permissions) of
-        ok ->
-            io:format("Successfully granted~n"),
-            ok;
-        Error ->
-            io:format(security_error_xlate(Error)),
-            io:format("~n"),
-            Error
-    end;
+    end.
+
+
+grant([Grants, "on", "any", "to", Users]) ->
+    grant_int(parse_grants(Grants),
+              any,
+              parse_roles(Users));
+grant([Grants, "on", Type, Bucket, "to", Users]) ->
+    grant_int(parse_grants(Grants),
+              { Type, Bucket },
+              parse_roles(Users));
+grant([Grants, "on", Type, "to", Users]) ->
+    grant_int(parse_grants(Grants),
+              Type,
+              parse_roles(Users));
 grant(_) ->
-    io:format("Usage: grant <permissions> ON (<type> [bucket]|ANY) TO <users>~n"),
+    io:format("Usage: grant <permissions> on (<type> [bucket]|any) to <users>~n"),
     error.
 
-revoke([Grants, "ON", "ANY", "FROM", Users]) ->
-    Unames = case string:tokens(Users, ",") of
-        ["all"] ->
-            all;
-        Other ->
-            [list_to_binary(O) || O <- Other]
-    end,
-    Permissions = string:tokens(Grants, ","),
-    case riak_core_security:add_revoke(Unames, any, Permissions) of
+revoke_int(Permissions, Bucket, Roles) ->
+    case riak_core_security:add_revoke(Roles, Bucket, Permissions) of
         ok ->
             io:format("Successfully revoked~n"),
             ok;
@@ -1043,36 +1036,26 @@ revoke([Grants, "ON", "ANY", "FROM", Users]) ->
             io:format(security_error_xlate(Error)),
             io:format("~n"),
             Error
-    end;
-revoke([Grants, "ON", Type, Bucket, "FROM", Users]) ->
-    revoke([Grants, "ON", {list_to_binary(Type), list_to_binary(Bucket)},
-            "FROM",
-           Users]);
-revoke([Grants, "ON", Type, "FROM", Users]) when is_list(Type) ->
-    revoke([Grants, "ON", list_to_binary(Type), "FROM", Users]);
-revoke([Grants, "ON", Bucket, "FROM", Users]) ->
-    Unames = case string:tokens(Users, ",") of
-        ["all"] ->
-            all;
-        Other ->
-            [list_to_binary(O) || O <- Other]
-    end,
-    Permissions = string:tokens(Grants, ","),
-    case riak_core_security:add_revoke(Unames, Bucket, Permissions) of
-        ok ->
-            io:format("Successfully revoked~n"),
-            ok;
-        Error ->
-            io:format(security_error_xlate(Error)),
-            io:format("~n"),
-            Error
-    end;
+    end.
+
+revoke([Grants, "on", "any", "from", Users]) ->
+    revoke_int(parse_grants(Grants),
+               any,
+               parse_roles(Users));
+revoke([Grants, "on", Type, Bucket, "from", Users]) ->
+    revoke_int(parse_grants(Grants),
+               { Type, Bucket },
+               parse_roles(Users));
+revoke([Grants, "on", Type, "from", Users]) ->
+    revoke_int(parse_grants(Grants),
+               Type,
+               parse_roles(Users));
 revoke(_) ->
-    io:format("Usage: revoke <permissions> ON <type> [bucket] FROM <users>~n"),
+    io:format("Usage: revoke <permissions> on <type> [bucket] from <users>~n"),
     error.
 
 print_grants([Name]) ->
-    case riak_core_security:print_grants(list_to_binary(Name)) of
+    case riak_core_security:print_grants(Name) of
         ok ->
             ok;
         Error ->
@@ -1085,7 +1068,7 @@ print_users([]) ->
     riak_core_security:print_users().
 
 print_user([User]) ->
-    case riak_core_security:print_user(list_to_binary(User)) of
+    case riak_core_security:print_user(User) of
         ok ->
             ok;
         Error ->
@@ -1099,7 +1082,7 @@ print_groups([]) ->
     riak_core_security:print_groups().
 
 print_group([Group]) ->
-    case riak_core_security:print_group(list_to_binary(Group)) of
+    case riak_core_security:print_group(Group) of
         ok ->
             ok;
         Error ->
@@ -1148,7 +1131,7 @@ parse_options([], Acc) ->
 parse_options([H|T], Acc) ->
     case re:split(H, "=", [{parts, 2}, {return, list}]) of
         [Key, Value] when is_list(Key), is_list(Value) ->
-            parse_options(T, [{Key, Value}|Acc]);
+            parse_options(T, [{string:to_lower(Key), Value}|Acc]);
         _Other ->
             throw({error, {invalid_option, H}})
     end.

--- a/src/riak_core_console_table.erl
+++ b/src/riak_core_console_table.erl
@@ -29,7 +29,7 @@ print(_Spec, []) ->
     ok;
 print(Spec, Rows) ->
     Table = create_table(Spec, Rows),
-    io:format("~n~s~n", [Table]).
+    io:format("~n~ts~n", [Table]).
 
 
 -spec print(list(), list(), list()) -> ok.
@@ -37,7 +37,7 @@ print(_Hdr, _Spec, []) ->
     ok;
 print(Header, Spec, Rows) ->
     Table = create_table(Spec, Rows),
-    io:format("~s~n~n~s~n", [Header, Table]).
+    io:format("~ts~n~n~ts~n", [Header, Table]).
 
 -spec create_table(list(), list()) -> iolist().
 create_table(Spec, Rows) ->
@@ -94,7 +94,7 @@ align(undefined, Size) ->
 align(Str, Size) when is_integer(Str) ->
     align(integer_to_list(Str), Size);
 align(Str, Size) when is_binary(Str) ->
-    align(binary_to_list(Str), Size);
+    align(unicode:characters_to_list(Str, utf8), Size);
 align(Str, Size) when is_atom(Str) ->
     align(atom_to_list(Str), Size);
 %align(Str, Size) when is_list(Str), length(Str) > Size ->
@@ -131,7 +131,7 @@ find_longest_field(Rows, ColumnNo) ->
 field_length(Field) when is_atom(Field) ->
     field_length(atom_to_list(Field));
 field_length(Field) when is_binary(Field) ->
-    field_length(binary_to_list(Field));
+    field_length(unicode:characters_to_list(Field, utf8));
 field_length(Field) when is_list(Field) ->
     Lines = string:tokens(lists:flatten(Field), "\n"),
     lists:foldl(fun(Line, Longest) ->
@@ -144,7 +144,7 @@ field_length(Field) ->
 expand_field(Field) when is_atom(Field) ->
     expand_field(atom_to_list(Field));
 expand_field(Field) when is_binary(Field) ->
-    expand_field(binary_to_list(Field));
+    expand_field(unicode:characters_to_list(Field, utf8));
 expand_field(Field) when is_list(Field) ->
     string:tokens(lists:flatten(Field), "\n");
 expand_field(Field) ->


### PR DESCRIPTION
- Remove upper-case requirements on grant command
- Lower-case (at least for Latin-1 character set) all user/group names
- Restrict names from containing control characters, whitespace, most latin1 punctuation
- Block creation of names that would conflict with grant syntax
- Make `riak_core_console:grant/1` (and `revoke`) easier to read/modify by extracting common logic to `grant_int`
- Stop converting names to binary in `riak_core_console` so we can centrally apply lower-case, unicode conversions in `riak_core_security`
- Allow unicode names, render unicode output properly
- Catch and interpret badarg exception when a character outside latin1 space is specified as part of a source name (atoms won't allow unicode until R18)
- Lower-case all keys in options
- Be explicit with `unicode:characters_to_binary` at @jrwest's suggestion: we're converting from utf8 lists to utf8 binaries, so use the 3-ary version
- Convert (potentially utf-8) error messages from `check_permissions` to binary so the protocol buffers stack doesn't choke on them

Several other PRs are necessary to complete this:
- basho/riak_ee#229
- basho/riak#513
- basho/riak_test#555
- basho/riak_kv#874
- basho/node_package#119

Also related:
- #567 (prevent `any` from being used as a bucket type name, conflicting with granting permissions)

Should be able to be closed without merging if this goes through first:
- #558 

/cc @Vagabond @jrwest 
