### PR TITLE
Improve riak_ensemble integration

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -3,10 +3,10 @@ riak_core.erl:185: The pattern 'true' can never match the type 'false'
 riak_core.erl:203: The pattern <'true', _> can never match the type <'false',_>
 riak_core.erl:239: The pattern 'true' can never match the type 'false'
 riak_core.erl:262: Function legacy_remove/1 will never be called
-riak_core_claimant.erl:366: The pattern 'legacy' can never match the type {'error','invalid_resize_claim'} | {'ok',[{_,_},...]}
-riak_core_claimant.erl:403: The pattern {'legacy', _} can never match the type {'error','invalid_resize_claim'} | {'ok',{'chstate_v2',_,'undefined' | [any()],{_,_},'undefined' | dict(),'undefined' | {_,_},'undefined' | [any()],[any()],_,'undefined' | [any()],'undefined' | [any()]}}
-riak_core_claimant.erl:797: The pattern {'legacy', _} can never match the type {'error','invalid_resize_claim'} | {'ok',{'chstate_v2',_,'undefined' | [any()],{_,_},'undefined' | dict(),'undefined' | {_,_},'undefined' | [any()],[any()],_,'undefined' | [any()],'undefined' | [any()]}}
-riak_core_claimant.erl:825: The pattern {'true', 'true'} can never match the type {'true','false'}
+riak_core_claimant.erl:370: The pattern 'legacy' can never match the type {'error','invalid_resize_claim'} | {'ok',[{_,_},...]}
+riak_core_claimant.erl:407: The pattern {'legacy', _} can never match the type {'error','invalid_resize_claim'} | {'ok',{'chstate_v2',_,'undefined' | [any()],{_,_},'undefined' | dict(),'undefined' | {_,_},'undefined' | [any()],[any()],_,'undefined' | [any()],'undefined' | [any()]}}
+riak_core_claimant.erl:819: The pattern {'legacy', _} can never match the type {'error','invalid_resize_claim'} | {'ok',{'chstate_v2',_,'undefined' | [any()],{_,_},'undefined' | dict(),'undefined' | {_,_},'undefined' | [any()],[any()],_,'undefined' | [any()],'undefined' | [any()]}}
+riak_core_claimant.erl:847: The pattern {'true', 'true'} can never match the type {'true','false'}
 riak_core_console.erl:102: The pattern 'true' can never match the type 'false'
 riak_core_gossip.erl:214: The pattern 1 can never match the type 2
 riak_core_gossip.erl:229: The pattern 'true' can never match the type 'false'


### PR DESCRIPTION
Update to correctly work with latest riak_ensemble.

Ensure that any failures during ensemble bootstrapping trigger future attempt to re-bootstrap the cluster.

This is the `riak_core` sibling pull-request for basho/riak_ensemble#10
