### PR TITLE
Do not allow a bucket type named 'any'

### DIFF
--- a/src/riak_core_bucket_props.erl
+++ b/src/riak_core_bucket_props.erl
@@ -39,6 +39,8 @@ merge(Overriding, Other) ->
                {riak_core_bucket_type:bucket_type(), undefined | binary()} | binary(),
                undefined | [{atom(), any()}],
                [{atom(), any()}]) -> {ok, [{atom(), any()}]} | {error, [{atom(), atom()}]}.
+validate(create, {<<"any">>, _Bucket}, _ExistingProps, _BucketProps) ->
+    {error, [{reserved_name, "The name 'any' may not be used for bucket types"}]};
 validate(CreateOrUpdate, Bucket, ExistingProps, BucketProps) ->
     CoreErrors = validate_core_props(CreateOrUpdate, Bucket, ExistingProps, BucketProps),
     validate(CreateOrUpdate, Bucket, ExistingProps, BucketProps, riak_core:bucket_validators(), CoreErrors).

--- a/test/btypes_eqc.erl
+++ b/test/btypes_eqc.erl
@@ -279,7 +279,7 @@ existing_type_name(#state{types=Types}) ->
     oneof(ExistingTypes).
 
 new_type_name() ->
-    binary(10).
+    ?SUCHTHAT(X, binary(10), X =/= <<"any">>).
 
 bucket_name() ->
     binary(10).

--- a/test/btypes_eqc.erl
+++ b/test/btypes_eqc.erl
@@ -315,6 +315,10 @@ prop_btype_invariant() ->
             aggregate(command_names(Cmds),
                       ?TRAPEXIT(
                          begin
+                             meck:new(riak_core_capability, []),
+                             meck:expect(riak_core_capability, get,
+                                         fun({riak_core, bucket_types}) -> true;
+                                            (X) -> meck:passthrough([X]) end),
                              os:cmd("rm -r ./btypes_eqc_meta"),
                              application:set_env(riak_core, claimant_tick, 4294967295),
                              application:set_env(riak_core, broadcast_lazy_timer, 4294967295),
@@ -336,6 +340,7 @@ prop_btype_invariant() ->
                              riak_core_ring_manager:stop(),
                              stop_pid(RingEvents),
                              os:cmd("rm -r ./btypes_eqc_meta"),
+                             meck:unload(riak_core_capability),
                              pretty_commands(?MODULE, Cmds, {H, S, Res},
                                              Res == ok)
                          end))).


### PR DESCRIPTION
In order for the security CLI to be able to grant permissions to any bucket type, we need to prevent the administrator from creating a bucket type named "any".

This is dependent on an unfinished PR that would change the grant syntax to use lower-case keywords; this may need to be changed to "ANY" before approval and merging.

**Note**: I don't have a registered copy of QuickCheck, nor would I know what to do with it if I had it, so the eqc fix is untested. Seems self-evidently correct based on my reading, but yolo.

/cc @jrwest 

(Supersedes #556)
