### PR TITLE
Update core:security:bucket() spec

### DIFF
--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -76,7 +76,7 @@
          epoch}).
 
 -type context() :: #context{}.
--type bucket() :: {string(), string()} | binary().
+-type bucket() :: {binary(), binary()} | binary().
 -type permission() :: {string()} | {string(), bucket()}.
 -type userlist() :: all | [string()].
 


### PR DESCRIPTION
Buckets are binaries, not strings. See basho/riak_kv#920 for more
detail. This was discovered by the way kv was calling
riak_core_security:check_permission/2.
