### PR TITLE
Correct return type information on riak_core_bucket:set_bucket/2

### DIFF
--- a/src/riak_core_bucket.erl
+++ b/src/riak_core_bucket.erl
@@ -56,7 +56,7 @@ append_bucket_defaults(Items) when is_list(Items) ->
 %% @doc Set the given BucketProps in Bucket or {BucketType, Bucket}. If BucketType does not
 %% exist, or is not active, {error, no_type} is returned.
 -spec set_bucket(binary() | {riak_core_bucket_type:bucket_type(), binary()}, [{atom(), any()}]) ->
-                        ok | {error, no_type}.
+                        ok | {error, no_type | [{atom(), atom()}]}.
 set_bucket({<<"default">>, Name}, BucketProps) ->
     set_bucket(Name, BucketProps);
 set_bucket({Type, _Name}=Bucket, BucketProps0) ->


### PR DESCRIPTION
In basho/riak_api#62, the [dialyzer check fails](http://buildbot.bos1/builders/test-riak_api/builds/13/steps/shell_5/logs/stdio) because it believes the spec on riak_core_bucket:set_bucket/2, meaning that `{error, no_type}` would completely cover any returns matching `{error, _}`. However, validation errors may also be returned from `set_bucket/2`, as a list  of atom pairs that resulted from the call to riak_core_bucket_props:validate/4.
