### PR TITLE
Update lager version and relax version check

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 {eunit_opts, [verbose]}.
 
 {deps, [
-  {lager, "2.0.0", {git, "git://github.com/basho/lager", {tag, "2.0.0"}}},
+  {lager, "2.0.*", {git, "git://github.com/basho/lager", {tag, "2.0.3"}}},
   {poolboy, ".*", {git, "git://github.com/basho/poolboy", {branch, "master"}}},
   {protobuffs, "0.8.*", {git, "git://github.com/basho/erlang_protobuffs",
                               {branch, "master"}}},


### PR DESCRIPTION
Update the version for the lager dependency to 2.0.3 and relax the
version check to permit overriding it from the top-level rebar.config.
