### PR TITLE
Made many rpc:call/4,5 calls safer if rex is down.

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,8 +1,8 @@
 riak_core.erl:85: The pattern 'true' can never match the type 'false'
-riak_core.erl:185: The pattern 'true' can never match the type 'false'
-riak_core.erl:203: The pattern <'true', _> can never match the type <'false',_>
-riak_core.erl:239: The pattern 'true' can never match the type 'false'
-riak_core.erl:262: Function legacy_remove/1 will never be called
+riak_core.erl:187: The pattern 'true' can never match the type 'false'
+riak_core.erl:205: The pattern <'true', _> can never match the type <'false',_>
+riak_core.erl:241: The pattern 'true' can never match the type 'false'
+riak_core.erl:264: Function legacy_remove/1 will never be called
 riak_core_claimant.erl:370: The pattern 'legacy' can never match the type {'error','invalid_resize_claim'} | {'ok',[{_,_},...]}
 riak_core_claimant.erl:407: The pattern {'legacy', _} can never match the type {'error','invalid_resize_claim'} | {'ok',{'chstate_v2',_,'undefined' | [any()],{_,_},'undefined' | dict(),'undefined' | {_,_},'undefined' | [any()],[any()],_,'undefined' | [any()],'undefined' | [any()]}}
 riak_core_claimant.erl:819: The pattern {'legacy', _} can never match the type {'error','invalid_resize_claim'} | {'ok',{'chstate_v2',_,'undefined' | [any()],{_,_},'undefined' | dict(),'undefined' | {_,_},'undefined' | [any()],[any()],_,'undefined' | [any()],'undefined' | [any()]}}

--- a/src/riak_core_capability.erl
+++ b/src/riak_core_capability.erl
@@ -605,7 +605,7 @@ query_capability(_, Capability, DefaultSup, undefined) ->
     {true, Default};
 query_capability(Node, Capability, DefaultSup, {App, Var, Map}) ->
     Default = {Capability, [DefaultSup]},
-    Result = rpc:call(Node, application, get_env, [App, Var]),
+    Result = riak_core_util:safe_rpc(Node, application, get_env, [App, Var]),
     case Result of
         {badrpc, _} ->
             {false, Default};

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -811,7 +811,7 @@ transfer_limit([NodeStr, LimitStr]) ->
             io:format("Invalid limit: ~s~n", [LimitStr]),
             error;
         true ->
-            case rpc:call(Node, riak_core_handoff_manager,
+            case riak_core_util:safe_rpc(Node, riak_core_handoff_manager,
                           set_concurrency, [Limit]) of
                 {badrpc, _} ->
                     io:format("Failed to set transfer limit for ~p~n", [Node]);

--- a/src/riak_core_gen_server.erl
+++ b/src/riak_core_gen_server.erl
@@ -624,7 +624,7 @@ rec_nodes(Tag, [N|Tail], Name, Badnodes, Replies, Time, TimerId) ->
 	    %% Collect all replies that already have arrived
 	    rec_nodes_rest(Tag, Tail, Name, [N | Badnodes], Replies)
     after Time ->
-	    case rpc:call(N, erlang, whereis, [Name]) of
+	    case riak_core_util:safe_rpc(N, erlang, whereis, [Name]) of
 		Pid when is_pid(Pid) -> % It exists try again.
 		    rec_nodes(Tag, [N|Tail], Name, Badnodes,
 			      Replies, infinity, TimerId);

--- a/src/riak_core_gossip.erl
+++ b/src/riak_core_gossip.erl
@@ -193,7 +193,7 @@ rpc_gossip_version(Ring, Node) ->
     GossipVsn = riak_core_ring:get_member_meta(Ring, Node, gossip_vsn),
     case GossipVsn of
         undefined ->
-            case rpc:call(Node, riak_core_gossip, gossip_version, [], 1000) of
+            case riak_core_util:safe_rpc(Node, riak_core_gossip, gossip_version, [], 1000) of
                 {badrpc, _} ->
                     ?LEGACY_RING_VSN;
                 Vsn ->

--- a/src/riak_core_gossip_legacy.erl
+++ b/src/riak_core_gossip_legacy.erl
@@ -173,7 +173,7 @@ claim_until_balanced(Ring) ->
 remove_from_cluster(ExitingNode) ->
     % Set the remote node to stop claiming.
     % Ignore return of rpc as this should succeed even if node is offline
-    rpc:call(ExitingNode, application, set_env,
+    _ = riak_core_util:safe_rpc(ExitingNode, application, set_env,
              [riak_core, wants_claim_fun, {riak_core_claim, never_wants_claim}]),
 
     % Get a list of indices owned by the ExitingNode...

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -429,7 +429,7 @@ send_objects(ItemsReverseList, Acc) ->
     end.
 
 get_handoff_ip(Node) when is_atom(Node) ->
-    case rpc:call(Node, riak_core_handoff_listener, get_handoff_ip, [],
+    case riak_core_util:safe_rpc(Node, riak_core_handoff_listener, get_handoff_ip, [],
                   infinity) of
         {badrpc, _} ->
             error;

--- a/src/riak_core_status.erl
+++ b/src/riak_core_status.erl
@@ -86,7 +86,7 @@ ring_status() ->
 
     %% Check if the claimant is running and if it believes the ring is ready
     Claimant = riak_core_ring:claimant(Ring),
-    case rpc:call(Claimant, riak_core_ring, ring_ready, [], 5000) of
+    case riak_core_util:safe_rpc(Claimant, riak_core_ring, ring_ready, [], 5000) of
         {badrpc, _} ->
             Down2 = lists:usort([Claimant|Down]),
             RingReady = undefined;


### PR DESCRIPTION
Created a couple of utility functions to handle do the wrapping. Most
rpc:call/4,5 that where not wrapped in a try/catch have been changed to
use the utility. Those that weren't appeared to want a crash due to
context (such as explictly matching for only the success value).

There are some dialyzer issues that were introduced, however I'm not able to see how they are related to the changes.
