### PR TITLE
Fix minor display bug with security sources

### DIFF
--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -1114,12 +1114,13 @@ group_sources(Sources) ->
         end, dict:new(), Sources),
     R1 = [{Users, CIDR, Source, Options} || {{CIDR, Source, Options}, Users} <-
                                        dict:to_list(D)],
-    %% Split any entries where the user list contains 'all' so that 'all' has
-    %% its own entry. We could actually elide any user sources that overlap
-    %% with an 'all' source, but that may be more confusing because deleting
-    %% the all source would then 'ressurrect' the user sources.
+    %% Split any entries where the user list contains (but is not
+    %% exclusively) 'all' so that 'all' has its own entry. We could
+    %% actually elide any user sources that overlap with an 'all'
+    %% source, but that may be more confusing because deleting the all
+    %% source would then 'ressurrect' the user sources.
     R2 = lists:foldl(fun({Users, CIDR, Source, Options}=E, Acc) ->
-                    case lists:member(all, Users) of
+                    case Users =/= [all] andalso lists:member(all, Users) of
                         true ->
                             [{[all], CIDR, Source, Options},
                              {Users -- [all], CIDR, Source, Options}|Acc];

--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -1118,7 +1118,7 @@ group_sources(Sources) ->
     %% exclusively) 'all' so that 'all' has its own entry. We could
     %% actually elide any user sources that overlap with an 'all'
     %% source, but that may be more confusing because deleting the all
-    %% source would then 'ressurrect' the user sources.
+    %% source would then 'resurrect' the user sources.
     R2 = lists:foldl(fun({Users, CIDR, Source, Options}=E, Acc) ->
                     case Users =/= [all] andalso lists:member(all, Users) of
                         true ->


### PR DESCRIPTION
Address basho/riak#470. Any security source with `all` as the only "member" would be displayed twice via `riak-admin security print-sources`.

Thanks to @lordnull for chasing this down.
