### PR TITLE
change bucket_fixup_test:fixup_test_/0 to wait for ring manager death

### DIFF
--- a/src/riak_core_test_util.erl
+++ b/src/riak_core_test_util.erl
@@ -25,8 +25,29 @@
 -module(riak_core_test_util).
 
 -ifdef(TEST).
--export([setup_mockring1/0, fake_ring/2]).
+-export([setup_mockring1/0,
+         fake_ring/2,
+         stop_pid/1,
+         wait_for_pid/1]).
 -include_lib("eunit/include/eunit.hrl").
+
+stop_pid(Other) when not is_pid(Other) ->
+    ok;
+stop_pid(Pid) ->
+    unlink(Pid),
+    exit(Pid, shutdown),
+    ok = wait_for_pid(Pid).
+
+wait_for_pid(Pid) ->
+    Mref = erlang:monitor(process, Pid),
+    receive
+        {'DOWN', Mref, process, _, _} ->
+            ok
+    after
+        5000 ->
+            {error, didnotexit}
+    end.
+
 
 setup_mockring1() ->
     % requires a running riak_core_ring_manager, in test-mode is ok

--- a/test/bucket_fixup_test.erl
+++ b/test/bucket_fixup_test.erl
@@ -55,8 +55,8 @@ fixup_test_() ->
              application:unset_env(riak_core, default_bucket_props),
              process_flag(trap_exit, true),
              catch application:stop(riak_core),
-             catch(riak_core_ring_manager:stop()),
-             catch(exit(whereis(riak_core_ring_events), shutdown))
+             riak_core_test_util:stop_pid(whereis(riak_core_ring_manager)),
+             riak_core_test_util:stop_pid(whereis(riak_core_ring_events))
      end,
      [
       fun do_no_harm/0,


### PR DESCRIPTION
`riak_core_ring_manager:stop/0` is async and races w/ the start of `load_test_/0`. see #590

NOTE: `stop_pid` and `wait_for_pid` are copied from other `riak_core` tests. This PR does not modify those tests.
