### PR TITLE
Error handling in riak_core_coverage_fsm:init

### DIFF
--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -158,25 +158,7 @@ init([Mod,
       From={_, ReqId, _},
       RequestArgs]) ->
     Exports = Mod:module_info(exports),
-    {Request, VNodeSelector, NVal, PrimaryVNodeCoverage,
-     NodeCheckService, VNodeMaster, Timeout, ModState} =
-        Mod:init(From, RequestArgs),
-    maybe_start_timeout_timer(Timeout),
-    PlanFun = plan_callback(Mod, Exports),
-    ProcessFun = process_results_callback(Mod, Exports),
-    StateData = #state{mod=Mod,
-                       mod_state=ModState,
-                       node_check_service=NodeCheckService,
-                       vnode_selector=VNodeSelector,
-                       n_val=NVal,
-                       pvc = PrimaryVNodeCoverage,
-                       request=Request,
-                       req_id=ReqId,
-                       timeout=infinity,
-                       vnode_master=VNodeMaster,
-                       plan_fun = PlanFun,
-                       process_fun = ProcessFun},
-    {ok, initialize, StateData, 0};
+    maybe_transition_to_initialize(Mod, Exports, ReqId, Mod:init(From, RequestArgs));
 init({test, Args, StateProps}) ->
     %% Call normal init
     {ok, initialize, StateData, 0} = init(Args),
@@ -193,6 +175,30 @@ init({test, Args, StateProps}) ->
     %% Enter into the execute state, skipping any code that relies on the
     %% state of the rest of the system
     {ok, waiting_results, TestStateData, 0}.
+
+
+%% @private
+maybe_transition_to_initialize(Mod, Exports, ReqId, {Request, VNodeSelector, NVal, PrimaryVNodeCoverage, 
+    NodeCheckService, VNodeMaster, Timeout, ModState}) ->
+    maybe_start_timeout_timer(Timeout),
+    PlanFun = plan_callback(Mod, Exports),
+    ProcessFun = process_results_callback(Mod, Exports),
+    StateData = #state{mod=Mod,
+                       mod_state=ModState,
+                       node_check_service=NodeCheckService,
+                       vnode_selector=VNodeSelector,
+                       n_val=NVal,
+                       pvc = PrimaryVNodeCoverage,
+                       request=Request,
+                       req_id=ReqId,
+                       timeout=infinity,
+                       vnode_master=VNodeMaster,
+                       plan_fun = PlanFun,
+                       process_fun = ProcessFun},
+    {ok, initialize, StateData, 0};
+maybe_transition_to_initialize(_Mod, _Exports, _ReqId, {stop, Reason, _}) ->
+    {stop, Reason}.
+
 
 %% @private
 maybe_start_timeout_timer(infinity) ->


### PR DESCRIPTION
Adds error handling the riak_core_coverage_fsm:init to stop the FSM when the Mod:init function call returns {stop, _}.  This change supports the for https://github.com/basho/riak_kv/issues/875 (PB List Keys to missing bucket type causes crash, hangs client).

This PR replaces https://github.com/basho/riak_core/pull/588 to squash commits.  Due to a mistake rebasing to squash, I simply created a new branch with the few relevant changes.  
