### PR TITLE
Make riak_core_util:safe_rpc catch exit correctly

### DIFF
--- a/src/riak_core_util.erl
+++ b/src/riak_core_util.erl
@@ -401,7 +401,7 @@ safe_rpc(Node, Module, Function, Args) ->
         Result ->
             Result
     catch
-        'EXIT':{noproc, _NoProcDetails} ->
+        exit:{noproc, _NoProcDetails} ->
             {badrpc, rpc_process_down}
     end.
 


### PR DESCRIPTION
The function was attempting to catch exit exception with 'EXIT':{noproc, ...}; should be exit:{noproc, ...}

http://erlang.org/doc/reference_manual/errors.html

Related riak_test PR:

https://github.com/basho/riak_test/pull/624
