### PR TITLE
attempt to isolate hashtree tests more by using a reference

### DIFF
--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -494,7 +494,7 @@ new_segment_store(Opts, State) ->
     DataDir = case proplists:get_value(segment_path, Opts) of
                   undefined ->
                       Root = "/tmp/anti/level",
-                      <<P:128/integer>> = md5(term_to_binary(erlang:now())),
+                      <<P:128/integer>> = md5(term_to_binary({erlang:now(), make_ref()})),
                       filename:join(Root, integer_to_list(P));
                   SegmentPath ->
                       SegmentPath


### PR DESCRIPTION
#593

one idea -- maybe it won't work. `hashtree` tests still pass and I am still unable to repro the failure.

cc/ @jtuple @reiddraper 
