### PR TITLE
Add logic to automatically enable consensus system

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -5,8 +5,8 @@ riak_core.erl:241: The pattern 'true' can never match the type 'false'
 riak_core.erl:264: Function legacy_remove/1 will never be called
 riak_core_claimant.erl:370: The pattern 'legacy' can never match the type {'error','invalid_resize_claim'} | {'ok',[{_,_},...]}
 riak_core_claimant.erl:407: The pattern {'legacy', _} can never match the type {'error','invalid_resize_claim'} | {'ok',{'chstate_v2',_,'undefined' | [any()],{_,_},'undefined' | dict(),'undefined' | {_,_},'undefined' | [any()],[any()],_,'undefined' | [any()],'undefined' | [any()]}}
-riak_core_claimant.erl:826: The pattern {'legacy', _} can never match the type {'error','invalid_resize_claim'} | {'ok',{'chstate_v2',_,'undefined' | [any()],{_,_},'undefined' | dict(),'undefined' | {_,_},'undefined' | [any()],[any()],_,'undefined' | [any()],'undefined' | [any()]}}
-riak_core_claimant.erl:854: The pattern {'true', 'true'} can never match the type {'true','false'}
+riak_core_claimant.erl:911: The pattern {'legacy', _} can never match the type {'error','invalid_resize_claim'} | {'ok',{'chstate_v2',_,'undefined' | [any()],{_,_},'undefined' | dict(),'undefined' | {_,_},'undefined' | [any()],[any()],_,'undefined' | [any()],'undefined' | [any()]}}
+riak_core_claimant.erl:939: The pattern {'true', 'true'} can never match the type {'true','false'}
 riak_core_console.erl:102: The pattern 'true' can never match the type 'false'
 riak_core_gossip.erl:214: The pattern 1 can never match the type 2
 riak_core_gossip.erl:229: The pattern 'true' can never match the type 'false'


### PR DESCRIPTION
Currently, in addition to enabling consensus in app.config, a user must also manually call `riak_ensemble_manager:enable()` from one and only one node in a cluster to activate the consensus sub-system. This is necessary to ensure that there is only a single logical root ensemble history -- all other nodes adopt the history from the single enabled node.

However, this step is not only annoying but also error-prone. Enabling consensus on multiple nodes can break the consensus system, requiring manual intervention.

This commit addresses this problem by making riak_core automatically enable the consensus system in a safe way. This is accomplished by having the claimant node enable the consensus system. To avoid the issue where the claimant in multiple 1-node clusters enables consensus before being joined, this commit requires the cluster to have at least three nodes before the claimant will enable the consensus system.

To prevent a race during claimant changes, a claimant must first write a special ring metadata value that prevents future claimants from activating the consensus system. It is not until after the ring has converged cluster wide, and the claimant sees the appropriate metadata value, that the claimant activates the consensus system.

Resolves #571

Sibling pull-request: basho/riak_test#632

For testing purposes, the existing `riak_ensemble` tests from `riak_test` work well -- just make sure to use the sibling `riak_test` pull-request above.
