### PR TITLE
Silence output from core_vnode_eqc and log to file instead

### DIFF
--- a/test/core_vnode_eqc.erl
+++ b/test/core_vnode_eqc.erl
@@ -60,6 +60,10 @@ simple_test_() ->
       ?_assertEqual(true, quickcheck(?QC_OUT(numtests(100, prop_simple()))))}}.
 
 setup_simple() ->
+    error_logger:tty(false),
+    application:set_env(sasl, sasl_error_logger, {file, "core_vnode_eqc_sasl.log"}),
+    error_logger:logfile({open, "core_vnode_eqc.log"}),
+
     Vars = [{ring_creation_size, 8},
             {ring_state_dir, "<nostore>"},
             {cluster_name, "test"},
@@ -447,4 +451,3 @@ filter_work(Work, Pid) ->
         end, Work).
 
 -endif.
-


### PR DESCRIPTION
This is much nicer:

```
==> riak_core (eunit)
Compiled src/riak_core_vnode_proxy.erl
Compiled test/core_vnode_eqc.erl
======================== EUnit ========================
module 'core_vnode_eqc'
  core_vnode_eqc:60: simple_test_.......................................................................................................
OK, passed 100 tests
```

than this:

```
=ERROR REPORT==== 20-Jun-2014::10:30:11 ===
** State machine <0.844.0> terminating
** Last message in was {'EXIT',<0.836.0>,killed}
** When State == active
**      Data  == {state,1096126227998177188652763624537212264741949407232,
                        mock_vnode,
                        {state,1096126227998177188652763624537212264741949407232,
                               2,undefined},
                        undefined,none,undefined,undefined,undefined,
                        undefined,undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:11 ===
** State machine <0.841.0> terminating
** Last message in was {'EXIT',<0.836.0>,killed}
** When State == active
**      Data  == {state,548063113999088594326381812268606132370974703616,
                        mock_vnode,
                        {state,548063113999088594326381812268606132370974703616,
                               4,undefined},
                        undefined,none,undefined,undefined,undefined,
                        undefined,undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:11 ===
** State machine <0.851.0> terminating
** Last message in was {'EXIT',<0.836.0>,killed}
** When State == active
**      Data  == {state,182687704666362864775460604089535377456991567872,
                        mock_vnode,
                        {state,182687704666362864775460604089535377456991567872,
                               0,undefined},
                        undefined,none,undefined,undefined,undefined,
                        undefined,undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:11 ===
** State machine <0.849.0> terminating
** Last message in was {'EXIT',<0.836.0>,killed}
** When State == active
**      Data  == {state,913438523331814323877303020447676887284957839360,
                        mock_vnode,
                        {state,913438523331814323877303020447676887284957839360,
                               0,undefined},
                        undefined,none,undefined,undefined,undefined,
                        undefined,undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:13 ===
** State machine <0.879.0> terminating
** Last message in was {'EXIT',<0.859.0>,killed}
** When State == active
**      Data  == {state,182687704666362864775460604089535377456991567872,
                        mock_vnode,
                        {state,182687704666362864775460604089535377456991567872,
                               1,undefined},
                        undefined,none,undefined,undefined,<0.880.0>,
                        {pool,mock_vnode,10,myargs},
                        undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:13 ===
** State machine <0.881.0> terminating
** Last message in was {'EXIT',<0.880.0>,killed}
** When State == ready
**      Data  == {state,<0.882.0>,
                        {[<0.892.0>,<0.891.0>,<0.890.0>,<0.889.0>,<0.888.0>,
                          <0.887.0>,<0.886.0>,<0.885.0>,<0.884.0>],
                         [<0.883.0>]},
                        {[],[]},
                        933920,10,0,0}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:13 ===
** Generic server <0.882.0> terminating
** Last message in was {'EXIT',<0.881.0>,killed}
** When Server state == {state,
                         {<0.882.0>,poolboy_sup},
                         simple_one_for_one,
                         [{child,undefined,riak_core_vnode_worker,
                           {riak_core_vnode_worker,start_link,
                            [[{worker_module,riak_core_vnode_worker},
                              {worker_args,
                               [182687704666362864775460604089535377456991567872,
                                myargs,worker_props,<0.880.0>]},
                              {worker_callback_mod,mock_vnode},
                              {size,10},
                              {max_overflow,0}]]},
                           temporary,5000,worker,
                           [riak_core_vnode_worker]}],
                         {set,10,16,16,8,80,48,
                          {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},
                          {{[<0.885.0>],
                            [<0.886.0>],
                            [<0.887.0>],
                            [<0.888.0>],
                            [<0.889.0>],
                            [<0.890.0>],
                            [<0.891.0>],
                            [<0.892.0>],
                            [],[],[],[],[],[],
                            [<0.883.0>],
                            [<0.884.0>]}}},
                         0,1,[],poolboy_sup,
                         {riak_core_vnode_worker,
                          [{worker_module,riak_core_vnode_worker},
                           {worker_args,
                            [182687704666362864775460604089535377456991567872,
                             myargs,worker_props,<0.880.0>]},
                           {worker_callback_mod,mock_vnode},
                           {size,10},
                           {max_overflow,0}]}}
** Reason for termination ==
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:14 ===
** State machine <0.900.0> terminating
** Last message in was {'EXIT',<0.895.0>,killed}
** When State == active
**      Data  == {state,182687704666362864775460604089535377456991567872,
                        mock_vnode,
                        {state,182687704666362864775460604089535377456991567872,
                               1,undefined},
                        undefined,none,undefined,undefined,undefined,
                        undefined,undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:15 ===
** Generic server <0.913.0> terminating
** Last message in was {'$gen_cast',
                           {work,
                               {crash,<0.906.0>},
                               {raw,{asynccrash,#Ref<0.0.0.22833>},<0.906.0>},
                               <0.909.0>}}
** When Server state == {state,mock_vnode,
                            {wstate,
                                182687704666362864775460604089535377456991567872,
                                myargs,worker_props,undefined,undefined}}
** Reason for termination ==
** {bad_return_value,deliberate_async_crash}

=ERROR REPORT==== 20-Jun-2014::10:30:16 ===
** Generic server <0.915.0> terminating
** Last message in was {'$gen_cast',
                           {work,
                               {crash,<0.906.0>},
                               {raw,{asynccrash,#Ref<0.0.0.22844>},<0.906.0>},
                               <0.909.0>}}
** When Server state == {state,mock_vnode,
                            {wstate,
                                182687704666362864775460604089535377456991567872,
                                myargs,worker_props,undefined,undefined}}
** Reason for termination ==
** {bad_return_value,deliberate_async_crash}

=ERROR REPORT==== 20-Jun-2014::10:30:20 ===
** State machine <0.944.0> terminating
** Last message in was {'EXIT',<0.939.0>,killed}
** When State == active
**      Data  == {state,365375409332725729550921208179070754913983135744,
                        mock_vnode,
                        {state,365375409332725729550921208179070754913983135744,
                               0,
                               365375409332725729550921208179070754913983135744},
                        undefined,none,undefined,undefined,undefined,
                        undefined,undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:21 ===
** State machine <0.960.0> terminating
** Last message in was {'EXIT',<0.949.0>,killed}
** When State == active
**      Data  == {state,1096126227998177188652763624537212264741949407232,
                        mock_vnode,
                        {state,1096126227998177188652763624537212264741949407232,
                               2,
                               1096126227998177188652763624537212264741949407232},
                        undefined,none,undefined,undefined,undefined,
                        undefined,undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:21 ===
** State machine <0.956.0> terminating
** Last message in was {'EXIT',<0.949.0>,killed}
** When State == active
**      Data  == {state,913438523331814323877303020447676887284957839360,
                        mock_vnode,
                        {state,913438523331814323877303020447676887284957839360,
                               1,
                               913438523331814323877303020447676887284957839360},
                        undefined,none,undefined,undefined,undefined,
                        undefined,undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:21 ===
** State machine <0.968.0> terminating
** Last message in was {'EXIT',<0.949.0>,killed}
** When State == active
**      Data  == {state,0,mock_vnode,
                        {state,0,0,undefined},
                        undefined,none,undefined,undefined,undefined,
                        undefined,undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:21 ===
** State machine <0.975.0> terminating
** Last message in was {'EXIT',<0.949.0>,killed}
** When State == active
**      Data  == {state,1278813932664540053428224228626747642198940975104,
                        mock_vnode,
                        {state,1278813932664540053428224228626747642198940975104,
                               0,undefined},
                        undefined,none,undefined,undefined,undefined,
                        undefined,undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:21 ===
** State machine <0.973.0> terminating
** Last message in was {'EXIT',<0.949.0>,killed}
** When State == active
**      Data  == {state,182687704666362864775460604089535377456991567872,
                        mock_vnode,
                        {state,182687704666362864775460604089535377456991567872,
                               0,undefined},
                        undefined,none,undefined,undefined,undefined,
                        undefined,undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:21 ===
** State machine <0.965.0> terminating
** Last message in was {'EXIT',<0.949.0>,killed}
** When State == active
**      Data  == {state,730750818665451459101842416358141509827966271488,
                        mock_vnode,
                        {state,730750818665451459101842416358141509827966271488,
                               0,undefined},
                        undefined,none,undefined,undefined,undefined,
                        undefined,undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:22 ===
** State machine <0.983.0> terminating
** Last message in was {'EXIT',<0.978.0>,killed}
** When State == active
**      Data  == {state,548063113999088594326381812268606132370974703616,
                        mock_vnode,
                        {state,548063113999088594326381812268606132370974703616,
                               2,
                               548063113999088594326381812268606132370974703616},
                        undefined,none,undefined,undefined,undefined,
                        undefined,undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:22 ===
** State machine <0.995.0> terminating
** Last message in was {'EXIT',<0.990.0>,killed}
** When State == active
**      Data  == {state,0,mock_vnode,
                        {state,0,0,undefined},
                        undefined,none,undefined,undefined,undefined,
                        undefined,undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:23 ===
** State machine <0.1003.0> terminating
** Last message in was {'EXIT',<0.998.0>,killed}
** When State == active
**      Data  == {state,0,mock_vnode,
                        {state,0,4,undefined},
                        undefined,none,undefined,undefined,<0.1004.0>,
                        {pool,mock_vnode,10,myargs},
                        undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:23 ===
** State machine <0.1036.0> terminating
** Last message in was {'EXIT',<0.998.0>,killed}
** When State == active
**      Data  == {state,365375409332725729550921208179070754913983135744,
                        mock_vnode,
                        {state,365375409332725729550921208179070754913983135744,
                               0,undefined},
                        undefined,none,undefined,undefined,<0.1037.0>,
                        {pool,mock_vnode,10,myargs},
                        undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:23 ===
** State machine <0.1019.0> terminating
** Last message in was {'EXIT',<0.998.0>,killed}
** When State == active
**      Data  == {state,730750818665451459101842416358141509827966271488,
                        mock_vnode,
                        {state,730750818665451459101842416358141509827966271488,
                               3,
                               730750818665451459101842416358141509827966271488},
                        undefined,none,undefined,undefined,<0.1020.0>,
                        {pool,mock_vnode,10,myargs},
                        undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:23 ===
** State machine <0.1005.0> terminating
** Last message in was {'EXIT',<0.1004.0>,killed}
** When State == ready
**      Data  == {state,<0.1006.0>,
                        {[<0.1007.0>,<0.1016.0>,<0.1015.0>,<0.1014.0>,
                          <0.1013.0>,<0.1012.0>],
                         [<0.1008.0>,<0.1009.0>,<0.1010.0>,<0.1011.0>]},
                        {[],[]},
                        942110,10,0,0}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:23 ===
** State machine <0.1038.0> terminating
** Last message in was {'EXIT',<0.1037.0>,killed}
** When State == ready
**      Data  == {state,<0.1039.0>,
                        {[<0.1049.0>,<0.1048.0>,<0.1047.0>,<0.1046.0>,
                          <0.1045.0>,<0.1044.0>,<0.1043.0>,<0.1042.0>,
                          <0.1041.0>],
                         [<0.1040.0>]},
                        {[],[]},
                        950305,10,0,0}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:23 ===
** State machine <0.1021.0> terminating
** Last message in was {'EXIT',<0.1020.0>,killed}
** When State == ready
**      Data  == {state,<0.1022.0>,
                        {[<0.1032.0>,<0.1031.0>,<0.1030.0>,<0.1029.0>,
                          <0.1028.0>,<0.1027.0>,<0.1026.0>,<0.1025.0>,
                          <0.1024.0>],
                         [<0.1023.0>]},
                        {[],[]},
                        946207,10,0,0}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:23 ===
** Generic server <0.1006.0> terminating
** Last message in was {'EXIT',<0.1005.0>,killed}
** When Server state == {state,
                         {<0.1006.0>,poolboy_sup},
                         simple_one_for_one,
                         [{child,undefined,riak_core_vnode_worker,
                           {riak_core_vnode_worker,start_link,
                            [[{worker_module,riak_core_vnode_worker},
                              {worker_args,[0,myargs,worker_props,<0.1004.0>]},
                              {worker_callback_mod,mock_vnode},
                              {size,10},
                              {max_overflow,0}]]},
                           temporary,5000,worker,
                           [riak_core_vnode_worker]}],
                         {set,10,16,16,8,80,48,
                          {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},
                          {{[<0.1013.0>],
                            [<0.1014.0>],
                            [<0.1015.0>],
                            [<0.1016.0>],
                            [],[],[],[],[],[],
                            [<0.1007.0>],
                            [<0.1008.0>],
                            [<0.1009.0>],
                            [<0.1010.0>],
                            [<0.1011.0>],
                            [<0.1012.0>]}}},
                         0,1,[],poolboy_sup,
                         {riak_core_vnode_worker,
                          [{worker_module,riak_core_vnode_worker},
                           {worker_args,[0,myargs,worker_props,<0.1004.0>]},
                           {worker_callback_mod,mock_vnode},
                           {size,10},
                           {max_overflow,0}]}}
** Reason for termination ==
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:23 ===
** Generic server <0.1039.0> terminating
** Last message in was {'EXIT',<0.1038.0>,killed}
** When Server state == {state,
                         {<0.1039.0>,poolboy_sup},
                         simple_one_for_one,
                         [{child,undefined,riak_core_vnode_worker,
                           {riak_core_vnode_worker,start_link,
                            [[{worker_module,riak_core_vnode_worker},
                              {worker_args,
                               [365375409332725729550921208179070754913983135744,
                                myargs,worker_props,<0.1037.0>]},
                              {worker_callback_mod,mock_vnode},
                              {size,10},
                              {max_overflow,0}]]},
                           temporary,5000,worker,
                           [riak_core_vnode_worker]}],
                         {set,10,16,16,8,80,48,
                          {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},
                          {{[],[],[],[],
                            [<0.1040.0>],
                            [<0.1041.0>],
                            [<0.1042.0>],
                            [<0.1043.0>],
                            [<0.1044.0>],
                            [<0.1045.0>],
                            [<0.1046.0>],
                            [<0.1047.0>],
                            [<0.1048.0>],
                            [<0.1049.0>],
                            [],[]}}},
                         0,1,[],poolboy_sup,
                         {riak_core_vnode_worker,
                          [{worker_module,riak_core_vnode_worker},
                           {worker_args,
                            [365375409332725729550921208179070754913983135744,
                             myargs,worker_props,<0.1037.0>]},
                           {worker_callback_mod,mock_vnode},
                           {size,10},
                           {max_overflow,0}]}}
** Reason for termination ==
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:23 ===
** Generic server <0.1022.0> terminating
** Last message in was {'EXIT',<0.1021.0>,killed}
** When Server state == {state,
                         {<0.1022.0>,poolboy_sup},
                         simple_one_for_one,
                         [{child,undefined,riak_core_vnode_worker,
                           {riak_core_vnode_worker,start_link,
                            [[{worker_module,riak_core_vnode_worker},
                              {worker_args,
                               [730750818665451459101842416358141509827966271488,
                                myargs,worker_props,<0.1020.0>]},
                              {worker_callback_mod,mock_vnode},
                              {size,10},
                              {max_overflow,0}]]},
                           temporary,5000,worker,
                           [riak_core_vnode_worker]}],
                         {set,10,16,16,8,80,48,
                          {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},
                          {{[],[],[],[],
                            [<0.1024.0>],
                            [<0.1025.0>],
                            [<0.1026.0>],
                            [<0.1027.0>],
                            [<0.1028.0>],
                            [<0.1029.0>],
                            [<0.1030.0>,<0.1023.0>],
                            [<0.1031.0>],
                            [<0.1032.0>],
                            [],[],[]}}},
                         0,1,[],poolboy_sup,
                         {riak_core_vnode_worker,
                          [{worker_module,riak_core_vnode_worker},
                           {worker_args,
                            [730750818665451459101842416358141509827966271488,
                             myargs,worker_props,<0.1020.0>]},
                           {worker_callback_mod,mock_vnode},
                           {size,10},
                           {max_overflow,0}]}}
** Reason for termination ==
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:27 ===
** State machine <0.1078.0> terminating
** Last message in was {'EXIT',<0.1054.0>,killed}
** When State == active
**      Data  == {state,730750818665451459101842416358141509827966271488,
                        mock_vnode,
                        {state,730750818665451459101842416358141509827966271488,
                               0,undefined},
                        undefined,none,undefined,undefined,undefined,
                        undefined,undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:28 ===
** State machine <0.1086.0> terminating
** Last message in was {'EXIT',<0.1081.0>,killed}
** When State == active
**      Data  == {state,1096126227998177188652763624537212264741949407232,
                        mock_vnode,
                        {state,1096126227998177188652763624537212264741949407232,
                               2,undefined},
                        undefined,none,undefined,undefined,<0.1087.0>,
                        {pool,mock_vnode,10,myargs},
                        undefined,86616}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:28 ===
** State machine <0.1088.0> terminating
** Last message in was {'EXIT',<0.1087.0>,killed}
** When State == ready
**      Data  == {state,<0.1089.0>,
                        {[<0.1090.0>,<0.1099.0>,<0.1098.0>,<0.1097.0>,
                          <0.1096.0>,<0.1095.0>],
                         [<0.1091.0>,<0.1092.0>,<0.1093.0>,<0.1094.0>]},
                        {[],[]},
                        954401,10,0,0}
** Reason for termination =
** killed

=ERROR REPORT==== 20-Jun-2014::10:30:28 ===
** Generic server <0.1089.0> terminating
** Last message in was {'EXIT',<0.1088.0>,killed}
** When Server state == {state,
                         {<0.1089.0>,poolboy_sup},
                         simple_one_for_one,
                         [{child,undefined,riak_core_vnode_worker,
                           {riak_core_vnode_worker,start_link,
                            [[{worker_module,riak_core_vnode_worker},
                              {worker_args,
                               [1096126227998177188652763624537212264741949407232,
                                myargs,worker_props,<0.1087.0>]},
                              {worker_callback_mod,mock_vnode},
                              {size,10},
                              {max_overflow,0}]]},
                           temporary,5000,worker,
                           [riak_core_vnode_worker]}],
                         {set,10,16,16,8,80,48,
                          {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},
                          {{[],[],[],[],[],[],
                            [<0.1090.0>],
                            [<0.1091.0>],
                            [<0.1092.0>],
                            [<0.1093.0>],
                            [<0.1094.0>],
                            [<0.1095.0>],
                            [<0.1096.0>],
                            [<0.1097.0>],
                            [<0.1098.0>],
                            [<0.1099.0>]}}},
                         0,1,[],poolboy_sup,
                         {riak_core_vnode_worker,
                          [{worker_module,riak_core_vnode_worker},
                           {worker_args,
                            [1096126227998177188652763624537212264741949407232,
                             myargs,worker_props,<0.1087.0>]},
                           {worker_callback_mod,mock_vnode},
                           {size,10},
                           {max_overflow,0}]}}
** Reason for termination ==
** killed
...
```

All of the output is logged to `core_vnode_eqc.log` if needed.
