### PR TITLE
Alert riak_kv_ensembles server of possible change

### DIFF
--- a/src/riak_core_claimant.erl
+++ b/src/riak_core_claimant.erl
@@ -734,7 +734,9 @@ maybe_activate_type(_BucketType, active, _Props) ->
     ok;
 maybe_activate_type(BucketType, ready, Props) ->
     ActiveProps = lists:keystore(active, 1, Props, {active, true}),
-    riak_core_metadata:put(?BUCKET_TYPE_PREFIX, BucketType, ActiveProps).
+    riak_core_metadata:put(?BUCKET_TYPE_PREFIX, BucketType, ActiveProps),
+    riak_kv_ensembles:possible_change(),
+    ok.
 
 %% @private
 type_active(Props) ->


### PR DESCRIPTION
The riak_kv_ensembles gen_server determines which ensembles need to be
created based on the current ring and n_vals corresponding to both
existing buckets and active bucket types. It only runs this check on
ring changes though. We need to alert it to check again in case a
strongly consistent bucket type was activated.

Part of a fix for basho/riak_kv#1007
Requires https://github.com/basho/riak_kv/pull/1008

Corresponding riak_test coming soon
