### PR TITLE
Refresh the ring after activating a bucket type

### DIFF
--- a/src/riak_core_claimant.erl
+++ b/src/riak_core_claimant.erl
@@ -734,7 +734,9 @@ maybe_activate_type(_BucketType, active, _Props) ->
     ok;
 maybe_activate_type(BucketType, ready, Props) ->
     ActiveProps = lists:keystore(active, 1, Props, {active, true}),
-    riak_core_metadata:put(?BUCKET_TYPE_PREFIX, BucketType, ActiveProps).
+    riak_core_metadata:put(?BUCKET_TYPE_PREFIX, BucketType, ActiveProps),
+    riak_core_ring_manager:force_update(),
+    ok.
 
 %% @private
 type_active(Props) ->


### PR DESCRIPTION
This is a somewhat heavy hammer, but it is expected that bucket types
are created somewhat infrequently. It is required to notify other
applications on top of riak core that may need this changing
information. In particular it's required by riak_kv to bootstrap riak
ensembles.

Supercedes #617
Part of a fix for basho/riak_kv#1007
Requires basho/riak_kv#1008
