### PR TITLE
Refactored handoff sender max_concurrency to reduce overloaded meanings.

### DIFF
--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -44,7 +44,8 @@
          set_concurrency/1,
          get_concurrency/0,
          set_recv_data/2,
-         kill_handoffs/0
+         kill_handoffs/0,
+         reschedule/2
         ]).
 
 -include("riak_core_handoff.hrl").
@@ -122,6 +123,13 @@ status(Filter) ->
 -spec status_update(mod_src_tgt(), ho_stats()) -> ok.
 status_update(ModSrcTgt, Stats) ->
     gen_server:cast(?MODULE, {status_update, ModSrcTgt, Stats}).
+
+%% @doc Permit the handoff identified by `ModSrcTgt' to be rescheduled
+%%      (assume it was unsuccessful on completion), and store the reason
+%%      why retrying is necessary.
+-spec reschedule(mod_src_tgt(), any()) -> ok.
+reschedule(ModSrcTgt, Reason) ->
+    gen_server:call(?MODULE, {reschedule, ModSrcTgt, Reason}, infinity).
 
 set_concurrency(Limit) ->
     gen_server:call(?MODULE,{set_concurrency,Limit}, infinity).
@@ -203,21 +211,34 @@ handle_call({set_concurrency,Limit},_From,State=#state{handoffs=HS}) ->
     application:set_env(riak_core,handoff_concurrency,Limit),
     case Limit < erlang:length(HS) of
         true ->
-            %% Note: we don't update the state with the handoffs that we're
-            %% keeping because we'll still get the 'DOWN' messages with
-            %% a reason of 'max_concurrency' and we want to be able to do
-            %% something with that if necessary.
-            {_Keep,Discard}=lists:split(Limit,HS),
-            _ = [erlang:exit(Pid,max_concurrency) ||
-                #handoff_status{transport_pid=Pid} <- Discard],
-            {reply, ok, State};
+            %% When the limit is lowered we have to kill enough currently in-
+            %% flight handoffs to get below the new cap (they won't be checked
+            %% against the limit again otherwise, once they've started).
+            {Keep, ToCancel}=lists:split(Limit,HS),
+            Canceled = lists:map(fun(Handoff) ->
+                erlang:exit(Handoff#handoff_status.transport_pid, {shutdown, normal}),
+                Handoff#handoff_status{status={rescheduled, concurrency_limit_lowered}}
+            end, ToCancel),
+            {reply, ok, State#state{handoffs=lists:append(Keep,Canceled)}};
         false ->
             {reply, ok, State}
     end;
 
 handle_call(get_concurrency, _From, State) ->
     Concurrency = get_concurrency_limit(),
-    {reply, Concurrency, State}.
+    {reply, Concurrency, State};
+
+handle_call({reschedule, ModSrcTgt, Reason}, _From, State=#state{handoffs=HS}) ->
+    case lists:keyfind(ModSrcTgt, #handoff_status.mod_src_tgt, HS) of
+        false ->
+            lager:error("Tried mark a nonexistent handoff as rescheduled: ~p~n", [ModSrcTgt]),
+            {reply, not_found, State};
+        HO ->
+            HO2 = HO#handoff_status{status={rescheduled, Reason}},
+            HS2 = lists:keyreplace(ModSrcTgt, #handoff_status.mod_src_tgt, HS, HO2),
+            erlang:kill(HO#handoff_status.transport_pid, {shutdown, normal}),
+            {reply, ok, State#state{handoffs=HS2}}
+    end.
 
 handle_cast({del_exclusion, {Mod, Idx}}, State=#state{excl=Excl}) ->
     Excl2 = sets:del_element({Mod, Idx}, Excl),
@@ -267,7 +288,7 @@ handle_info({'DOWN', Ref, process, _Pid, Reason}, State=#state{handoffs=HS}) ->
     case lists:keytake(Ref, #handoff_status.transport_mon, HS) of
         {value,
          #handoff_status{mod_src_tgt={M, S, I}, direction=Dir, vnode_pid=Vnode,
-                         vnode_mon=VnodeM, req_origin=Origin},
+                         vnode_mon=VnodeM, req_origin=Origin, status=Status},
          NewHS
         } ->
             WarnVnode =
@@ -276,11 +297,6 @@ handle_info({'DOWN', Ref, process, _Pid, Reason}, State=#state{handoffs=HS}) ->
                     %% than 'normal' we should log the reason why as an error
                     normal ->
                         false;
-                    X when X == max_concurrency orelse
-                           (element(1, X) == shutdown andalso
-                            element(2, X) == max_concurrency) ->
-                        lager:info("An ~w handoff of partition ~w ~w was terminated for reason: ~w~n", [Dir,M,I,Reason]),
-                        true;
                     _ ->
                         lager:error("An ~w handoff of partition ~w ~w was terminated for reason: ~w~n", [Dir,M,I,Reason]),
                         true
@@ -295,13 +311,28 @@ handle_info({'DOWN', Ref, process, _Pid, Reason}, State=#state{handoffs=HS}) ->
                     case Origin of
                         none -> ok;
                         _ ->
-                            %% Use proplist instead so it's more
-                            %% flexible in future, or does
-                            %% capabilities nullify that?
-                            Msg = {M, S, I},
-                            riak_core_vnode_manager:xfer_complete(Origin, Msg)
-                    end,
-                    ok
+                            case Status of
+                                {rescheduled, module_max_concurrency} ->
+                                    %% As of 2.0 this case only occurs when a
+                                    %% bg_manager lock can't be acquired, as
+                                    %% the first step of handoff (called by
+                                    %% the optional `handoff_started' on the
+                                    %% module handing off).
+                                    lager:info("An ~w handoff of partition ~w ~w was rescheduled because ~w failed to acquire a necessary resource (max_concurrency).~n", [Dir,M,I,M]);
+                                {rescheduled, remote_concurrency_exceeded} ->
+                                    lager:info("An ~w handoff of partition ~w ~w was rescheduled because the destination node's concurrency limit was already reached.~n", [Dir,M,I]);
+                                {rescheduled, concurrency_limit_lowered} ->
+                                    lager:info("An ~w handoff of partition ~w ~w was rescheduled because the handoff concurrency limit was lowered.~n", [Dir,M,I]);
+                                {rescheduled, RetryReason} ->
+                                    lager:debug("An ~w handoff of partition ~w ~w was rescheduled. Reason: ~w.~n", [Dir,M,I,RetryReason]);
+                                _ ->
+                                    %% Use proplist instead so it's more
+                                    %% flexible in future, or does
+                                    %% capabilities nullify that?
+                                    Msg = {M, S, I},
+                                    riak_core_vnode_manager:xfer_complete(Origin, Msg)
+                            end
+                    end
             end,
 
             %% No monitor on vnode for receiver

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -236,7 +236,7 @@ handle_call({reschedule, ModSrcTgt, Reason}, _From, State=#state{handoffs=HS}) -
         HO ->
             HO2 = HO#handoff_status{status={rescheduled, Reason}},
             HS2 = lists:keyreplace(ModSrcTgt, #handoff_status.mod_src_tgt, HS, HO2),
-            erlang:kill(HO#handoff_status.transport_pid, {shutdown, normal}),
+            erlang:exit(HO#handoff_status.transport_pid, {shutdown, normal}),
             {reply, ok, State#state{handoffs=HS2}}
     end.
 

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -312,13 +312,6 @@ handle_info({'DOWN', Ref, process, _Pid, Reason}, State=#state{handoffs=HS}) ->
                         none -> ok;
                         _ ->
                             case Status of
-                                {rescheduled, module_max_concurrency} ->
-                                    %% As of 2.0 this case only occurs when a
-                                    %% bg_manager lock can't be acquired, as
-                                    %% the first step of handoff (called by
-                                    %% the optional `handoff_started' on the
-                                    %% module handing off).
-                                    lager:info("An ~w handoff of partition ~w ~w was rescheduled because ~w failed to acquire a necessary resource (max_concurrency).~n", [Dir,M,I,M]);
                                 {rescheduled, remote_concurrency_exceeded} ->
                                     lager:info("An ~w handoff of partition ~w ~w was rescheduled because the destination node's concurrency limit was already reached.~n", [Dir,M,I]);
                                 {rescheduled, concurrency_limit_lowered} ->

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -231,7 +231,7 @@ handle_call(get_concurrency, _From, State) ->
 handle_call({reschedule, ModSrcTgt, Reason}, _From, State=#state{handoffs=HS}) ->
     case lists:keyfind(ModSrcTgt, #handoff_status.mod_src_tgt, HS) of
         false ->
-            lager:error("Tried mark a nonexistent handoff as rescheduled: ~p~n", [ModSrcTgt]),
+            lager:error("Tried to mark a nonexistent handoff as rescheduled: ~p~n", [ModSrcTgt]),
             {reply, not_found, State};
         HO ->
             HO2 = HO#handoff_status{status={rescheduled, Reason}},

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -263,9 +263,6 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
                  end
          end
      catch
-         exit:{shutdown, module_max_concurrency} ->
-             riak_core_handoff_manager:reschedule({Module, SrcPartition, TargetPartition}, module_max_concurrency),
-             exit(normal);
          exit:{shutdown, remote_concurrency_exceeded} ->
              riak_core_handoff_manager:reschedule({Module, SrcPartition, TargetPartition}, remote_concurrency_exceeded),
              exit(normal);
@@ -600,6 +597,8 @@ maybe_call_handoff_started(Module, SrcPartition) ->
                 {error, max_concurrency} ->
                     %% Handoff of that partition is busy or can't proceed. Stopping with
                     %% max_concurrency will cause this partition to be retried again later.
+                    %% NB. this isn't handled higher up as of 2.0; the process will
+                    %%     die noisily at the sup and be retried.
                     exit({shutdown, module_max_concurrency});
                 {error, Error} ->
                     exit({shutdown, Error})

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -144,7 +144,10 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
          case TcpMod:recv(Socket, 0, RecvTimeout) of
              {ok,[?PT_MSG_OLDSYNC|<<"sync">>]} -> ok;
              {error, timeout} -> exit({shutdown, timeout});
-             {error, closed} -> exit({shutdown, max_concurrency})
+             {error, closed} -> 
+                lager:debug("Handoff of ~p from ~p terminating because the destination, ~p, has reached its concurrency limit (inferred from socket closure).",
+                           [SrcPartition, SrcNode, TargetNode]),
+                exit({shutdown, remote_concurrency_exceeded})
          end,
 
          RemoteSupportsBatching = remote_supports_batching(TargetNode),
@@ -260,9 +263,12 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
                  end
          end
      catch
-         exit:{shutdown,max_concurrency} ->
-             %% Need to fwd the error so the handoff mgr knows
-             exit({shutdown, max_concurrency});
+         exit:{shutdown, module_max_concurrency} ->
+             riak_core_handoff_manager:reschedule({Module, SrcPartition, TargetPartition}, module_max_concurrency),
+             exit(normal);
+         exit:{shutdown, remote_concurrency_exceeded} ->
+             riak_core_handoff_manager:reschedule({Module, SrcPartition, TargetPartition}, remote_concurrency_exceeded),
+             exit(normal);
          exit:{shutdown, timeout} ->
              %% A receive timeout during handoff
              riak_core_stat:update(handoff_timeouts),
@@ -594,7 +600,7 @@ maybe_call_handoff_started(Module, SrcPartition) ->
                 {error, max_concurrency} ->
                     %% Handoff of that partition is busy or can't proceed. Stopping with
                     %% max_concurrency will cause this partition to be retried again later.
-                    exit({shutdown, max_concurrency});
+                    exit({shutdown, module_max_concurrency});
                 {error, Error} ->
                     exit({shutdown, Error})
             end;


### PR DESCRIPTION
Addresses #564 [JIRA](https://bashoeng.atlassian.net/browse/RIAK-1189) — still needs tests, just opening this to get review started.
- Separated handoffs terminated for concurrency limit violations from those
  terminated for real errors -- concurrency violations no longer cause
  abnormal process exits.
  - Split up the three sources of max_concurrency exits in handoff_sender:
    1. vnode lock max_concurrency
    2. remote node hitting its concurrency limit
    3. concurrency limit lowered after handoffs already started
  - Added a mechanism for marking a transfer as "rescheduled" -- considered
    failed on completion.
  
  This is used to notify the handoff manager that a given handoff, while
  exiting normal, should not signal xfer_complete to the corresponding
  vnode. NB this logic is basically working around the relatively tight
  coupling between handoff_manager and vnode_manager; while there's some
  groundwork laid for decoupling them in the form of the optional
  `handoff_started/2', the handoff manager still special-cases a bit
  just for vnode_manager.
