### PR TITLE
Implement key count estimation via AAE trees

### DIFF
--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -165,7 +165,8 @@
 
 -type keydiff() :: {missing | remote_missing | different, binary()}.
 
--type remote_fun() :: fun((get_bucket | key_hashes | start_exchange_level | start_exchange_segments | init | final,
+-type remote_fun() :: fun((get_bucket | key_hashes | start_exchange_level |
+                           start_exchange_segments | init | final,
                            {integer(), integer()} | integer() | term()) -> any()).
 
 -type acc_fun(Acc) :: fun(([keydiff()], Acc) -> Acc).
@@ -431,6 +432,19 @@ read_meta(Key, State) when is_binary(Key) ->
             undefined
     end.
 
+%% @doc
+%% Estimate number of keys stored in the AAE tree. This is determined
+%% by sampling segments to to calculate an estimated keys-per-segment
+%% value, which is then multiplied by the number of segments. Segments
+%% are sampled until either 1% of segments have been visited or 1000
+%% keys have been observed.
+%%
+%% Note: this function must be called on a tree with a valid iterator,
+%%       such as the snapshotted tree returned from update_snapshot/1
+%%       or a recently updated tree returned from update_tree/1 (which
+%%       internally creates a snapshot). Using update_tree/1 is the best
+%%       choice since that ensures segments are updated giving a better
+%%       estimate.
 -spec estimate_keys(hashtree()) -> {ok, integer()}.
 estimate_keys(State) ->
     estimate_keys(State, 0, 0, ?NUM_KEYS_REQUIRED).

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -1155,7 +1155,7 @@ local_compare(T1, T2) ->
                      [{_, KeyHashes2}] = key_hashes(T2, Segment),
                      KeyHashes2
              end,
-    AccFun = fun(Keys, KeyAcc, _Segment) ->
+    AccFun = fun(Keys, KeyAcc) ->
                      Keys ++ KeyAcc
              end,
     compare2(T1, Remote, AccFun, []).

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -452,7 +452,7 @@ estimate_keys(State) ->
 estimate_keys(#state{segments=Segments}, CurrentSegment, Keys, MaxKeys)
   when (CurrentSegment * 100) >= Segments;
        Keys >= MaxKeys ->
-    {ok, (Keys * Segments) div (CurrentSegment + 1)};
+    {ok, (Keys * Segments) div CurrentSegment};
 
 estimate_keys(State, CurrentSegment, Keys, MaxKeys) ->
     [{_, KeyHashes2}] = key_hashes(State, CurrentSegment),

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -435,11 +435,9 @@ read_meta(Key, State) when is_binary(Key) ->
 estimate_keys(State) ->
     estimate_keys(State, 0, 0, ?NUM_KEYS_REQUIRED).
 
-estimate_keys(#state{segments=Segments}, CurrentSegment, Keys, _MaxKeys)
-  when (CurrentSegment * 100) >= Segments ->
-    {ok, Keys*(Segments div CurrentSegment)};
-
-estimate_keys(#state{segments=Segments}, CurrentSegment, Keys, MaxKeys) when Keys >= MaxKeys ->
+estimate_keys(#state{segments=Segments}, CurrentSegment, Keys, MaxKeys)
+  when (CurrentSegment * 100) >= Segments;
+       Keys >= MaxKeys ->
     {ok, (Keys * Segments) div (CurrentSegment + 1)};
 
 estimate_keys(State, CurrentSegment, Keys, MaxKeys) ->


### PR DESCRIPTION
This pull-request adds `hashtree:estimate_keys/1` which can be used to estimate the number of keys in a partition by sampling the segments in the relevant AAE tree.

The estimation is calculated by computing a keys-per-segment estimate and then multiplying that estimate by the total number of segments.

The keys-per-segment estimate is determined by traversing over segments until either 1% of segments have been sampled or 1000 keys have been seen.

This key count estimation is used as part of an improvement to AAE-based fullsync replication.

Sibling pull-requests: basho/riak_kv#1030, basho/riak_repl#623
