### PR TITLE
Introduce partition IDs

### DIFF
--- a/src/riak_core_ring_util.erl
+++ b/src/riak_core_ring_util.erl
@@ -200,8 +200,9 @@ prop_ids_are_boundaries() ->
                         BoundaryHash =
                             riak_core_ring_util:partition_id_to_hash(PartitionId,
                                                                      RingSize),
-                        true =:= riak_core_ring_util:hash_is_partition_boundary(BoundaryHash,
-                                                                                RingSize)
+                        equals(true,
+                               riak_core_ring_util:hash_is_partition_boundary(BoundaryHash,
+                                                                              RingSize))
                     end
                    )).
 
@@ -214,8 +215,9 @@ prop_reverse() ->
                         BoundaryHash =
                             riak_core_ring_util:partition_id_to_hash(PartitionId,
                                                                      RingSize),
-                        PartitionId =:= riak_core_ring_util:hash_to_partition_id(
-                                          BoundaryHash, RingSize)
+                        equals(PartitionId,
+                               riak_core_ring_util:hash_to_partition_id(
+                                 BoundaryHash, RingSize))
                     end
                    )).
 
@@ -260,7 +262,7 @@ prop_only_boundaries() ->
                          HashIsPartitionBoundary =
                              riak_core_ring_util:hash_is_partition_boundary(HashValue,
                                                                             RingSize),
-                         HashIsPartitionBoundary =:= HashIsInRing
+                         equals(HashIsPartitionBoundary, HashIsInRing)
                      end
                    )).
 

--- a/src/riak_core_ring_util.erl
+++ b/src/riak_core_ring_util.erl
@@ -24,7 +24,25 @@
 -export([assign/2,
          check_ring/0,
          check_ring/1,
-         check_ring/2]).
+         check_ring/2,
+         hash_to_partition_id/2,
+         partition_id_to_hash/2,
+         hash_is_partition_boundary/2]).
+
+-export_type([partition_id/0]).
+
+-ifdef(TEST).
+-ifdef(EQC).
+-export([prop_ids_are_boundaries/0, prop_reverse/0,
+         prop_monotonic/0, prop_only_boundaries/0]).
+
+-include_lib("eqc/include/eqc.hrl").
+-endif.
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-type partition_id() :: non_neg_integer().
+%% This integer represents a value in the range [0, ring_size)
 
 %% @doc Forcibly assign a partition to a specific node
 assign(Partition, ToNode) ->
@@ -56,3 +74,185 @@ check_ring(Ring, Nval) ->
                                 ordsets:add_element(PL, Acc)
                         end
                 end, [], Preflists).
+
+-spec hash_to_partition_id(chash:index() | chash:index_as_int(),
+                           pos_integer()) ->
+                                  partition_id().
+%% @doc Map a key hash (as binary or integer) to a partition ID [0, ring_size)
+hash_to_partition_id(CHashKey, RingSize) when is_binary(CHashKey) ->
+    <<CHashInt:160/integer>> = CHashKey,
+    hash_to_partition_id(CHashInt, RingSize);
+hash_to_partition_id(CHashInt, RingSize) ->
+    CHashInt div chash:ring_increment(RingSize).
+
+-spec partition_id_to_hash(partition_id(), pos_integer()) -> chash:index_as_int().
+%% @doc Identify the first key hash (integer form) in a partition ID [0, ring_size)
+partition_id_to_hash(Id, RingSize) ->
+    Id * chash:ring_increment(RingSize).
+
+
+-spec hash_is_partition_boundary(chash:index() | chash:index_as_int(),
+                                 pos_integer()) ->
+                                        boolean().
+%% @doc For user-facing tools, indicate whether a specified hash value
+%% is a valid "boundary" value (first hash in some partition)
+hash_is_partition_boundary(CHashKey, RingSize) when is_binary(CHashKey) ->
+    <<CHashInt:160/integer>> = CHashKey,
+    hash_is_partition_boundary(CHashInt, RingSize);
+hash_is_partition_boundary(CHashInt, RingSize) ->
+    CHashInt rem chash:ring_increment(RingSize) =:= 0.
+
+
+%% ===================================================================
+%% EUnit tests
+%% ===================================================================
+-ifdef(TEST).
+
+%% The EQC properties below are more comprehensive tests for hashes as
+%% integers; use pure unit tests to make certain that binary hashes
+%% are handled.
+
+%% Partition boundaries are reversable.
+reverse_test() ->
+    IntIndex = riak_core_ring_util:partition_id_to_hash(31, 32),
+    HashIndex = <<IntIndex:160>>,
+    ?assertEqual(31, riak_core_ring_util:hash_to_partition_id(HashIndex, 32)),
+    ?assertEqual(0, riak_core_ring_util:hash_to_partition_id(<<0:160>>, 32)).
+
+%% Index values somewhere in the middle of a partition can be mapped
+%% to partition IDs.
+partition_test() ->
+    IntIndex = riak_core_ring_util:partition_id_to_hash(20, 32) +
+        chash:ring_increment(32) div 3,
+    HashIndex = <<IntIndex:160>>,
+    ?assertEqual(20, riak_core_ring_util:hash_to_partition_id(HashIndex, 32)).
+
+%% Index values divisible by partition size are boundary values, others are not
+boundary_test() ->
+    BoundaryIndex = riak_core_ring_util:partition_id_to_hash(15, 32),
+    ?assert(riak_core_ring_util:hash_is_partition_boundary(<<BoundaryIndex:160>>, 32)),
+    ?assertNot(riak_core_ring_util:hash_is_partition_boundary(<<(BoundaryIndex + 32):160>>, 32)),
+    ?assertNot(riak_core_ring_util:hash_is_partition_boundary(<<(BoundaryIndex - 32):160>>, 32)),
+    ?assertNot(riak_core_ring_util:hash_is_partition_boundary(<<(BoundaryIndex + 1):160>>, 32)),
+    ?assertNot(riak_core_ring_util:hash_is_partition_boundary(<<(BoundaryIndex - 1):160>>, 32)),
+    ?assertNot(riak_core_ring_util:hash_is_partition_boundary(<<(BoundaryIndex + 2):160>>, 32)),
+    ?assertNot(riak_core_ring_util:hash_is_partition_boundary(<<(BoundaryIndex + 10):160>>, 32)).
+
+-ifdef(EQC).
+
+-define(QC_OUT(P),
+        eqc:on_output(fun(Str, Args) ->
+                              io:format(user, Str, Args) end, P)).
+-define(TEST_TIME_SECS, 5).
+
+-define(HASHMAX, 1 bsl 160 - 1).
+-define(RINGSIZEEXPMAX, 11).
+-define(RINGSIZE(X), (1 bsl X)). %% We'll generate powers of 2 with choose() and convert that to a ring size with this macro
+-define(PARTITIONSIZE(X), ((1 bsl 160) div (X))).
+
+ids_are_boundaries_test_() ->
+    {timeout, ?TEST_TIME_SECS+5, [?_assert(test_ids_are_boundaries() =:= true)]}.
+
+test_ids_are_boundaries() ->
+    test_ids_are_boundaries(?TEST_TIME_SECS).
+
+test_ids_are_boundaries(TestTimeSecs) ->
+        eqc:quickcheck(eqc:testing_time(TestTimeSecs, ?QC_OUT(prop_ids_are_boundaries()))).
+
+reverse_test_() ->
+    {timeout, ?TEST_TIME_SECS+5, [?_assert(test_reverse() =:= true)]}.
+
+test_reverse() ->
+    test_reverse(?TEST_TIME_SECS).
+
+test_reverse(TestTimeSecs) ->
+        eqc:quickcheck(eqc:testing_time(TestTimeSecs, ?QC_OUT(prop_reverse()))).
+
+
+monotonic_test_() ->
+    {timeout, ?TEST_TIME_SECS+5, [?_assert(test_monotonic() =:= true)]}.
+
+test_monotonic() ->
+    test_monotonic(?TEST_TIME_SECS).
+
+test_monotonic(TestTimeSecs) ->
+        eqc:quickcheck(eqc:testing_time(TestTimeSecs, ?QC_OUT(prop_monotonic()))).
+
+
+only_boundaries_test_() ->
+    {timeout, ?TEST_TIME_SECS+5, [?_assert(test_only_boundaries() =:= true)]}.
+
+test_only_boundaries() ->
+    test_only_boundaries(?TEST_TIME_SECS).
+
+test_only_boundaries(TestTimeSecs) ->
+        eqc:quickcheck(eqc:testing_time(TestTimeSecs, ?QC_OUT(prop_only_boundaries()))).
+
+%% Partition IDs should map to hash values which are partition boundaries
+prop_ids_are_boundaries() ->
+    ?FORALL(RingPower, choose(2, ?RINGSIZEEXPMAX),
+            ?FORALL(PartitionId, choose(0, ?RINGSIZE(RingPower) - 1),
+                    riak_core_ring_util:hash_is_partition_boundary(
+                      riak_core_ring_util:partition_id_to_hash(PartitionId,
+                                                               ?RINGSIZE(RingPower)),
+                      ?RINGSIZE(RingPower)) =:= true)).
+
+%% Partition IDs should map to hash values which map back to the same partition IDs
+prop_reverse() ->
+    ?FORALL(RingPower, choose(2, ?RINGSIZEEXPMAX),
+            ?FORALL(PartitionId, choose(0, ?RINGSIZE(RingPower) - 1),
+                    riak_core_ring_util:hash_to_partition_id(
+                      riak_core_ring_util:partition_id_to_hash(PartitionId,
+                                                               ?RINGSIZE(RingPower)),
+                      ?RINGSIZE(RingPower)) =:= PartitionId)).
+
+%% For any given hash value, any larger hash value maps to a partition
+%% ID of greater or equal value.
+prop_monotonic() ->
+    ?FORALL(RingPower, choose(2, ?RINGSIZEEXPMAX),
+            ?FORALL(HashValue, choose(0, ?HASHMAX - 1),
+                    ?FORALL(GreaterHash, choose(HashValue + 1, ?HASHMAX),
+                            begin
+                                LowerPartition =
+                                    riak_core_ring_util:hash_to_partition_id(HashValue,
+                                                                             ?RINGSIZE(RingPower)),
+                                GreaterPartition =
+                                    riak_core_ring_util:hash_to_partition_id(GreaterHash,
+                                                                             ?RINGSIZE(RingPower)),
+                                LowerPartition =< GreaterPartition
+                            end
+                           ))).
+
+%% Using a dictionary lookup to identify partition boundaries is quite
+%% slow, especially given the large hash space we'd like to test.
+%%
+%% Replacing the use of `dict' with something based on `chashbin' may
+%% help significantly, but it's not vital.
+
+%% Hash values which are listed in the ring structure are boundary
+%% values
+boundary_helper(Hash, RingDict) ->
+    dict:is_key(Hash, RingDict).
+
+ring_to_dict({_RingSize, PropList}) ->
+    dict:from_list(lists:map(fun({Hash, dummy}) -> {Hash, dummy} end, PropList)).
+
+find_near_boundaries(RingSize, PartitionSize) ->
+    ?LET({Id, Offset}, {choose(1, RingSize-1), choose(-(RingSize*2), (RingSize*2))},
+         Id * PartitionSize + Offset).
+
+prop_only_boundaries() ->
+    ?FORALL(RingPower, choose(2, ?RINGSIZEEXPMAX),
+            ?FORALL({HashValue, RingDict},
+                    {frequency([
+                               {5, choose(0, ?HASHMAX)},
+                               {2, find_near_boundaries(?RINGSIZE(RingPower),
+                                                        ?PARTITIONSIZE(?RINGSIZE(RingPower)))}]),
+                     ring_to_dict(chash:fresh(?RINGSIZE(RingPower), dummy))},
+                    boundary_helper(HashValue, RingDict) =:=
+                        riak_core_ring_util:hash_is_partition_boundary(HashValue,
+                                                                       ?RINGSIZE(RingPower)))).
+
+
+-endif. % EQC
+-endif. % TEST


### PR DESCRIPTION
Partition IDs are particularly useful for user-facing code but may have value elsewhere.
- Translation functions from hash (integer or binary) to partition ID and back. Partition IDs are zero-based up to (but not including) ring
  size.
- For user-facing tools, hash_is_partition_boundary/2 can be used to verify whether a hash provided by the user is actually the first in a partition.
- EQC and unit tests.

Supersedes #632 (this is squashed and rebased to our integration branch).
