### PR TITLE
Upgrade to PoolBoy 1.3

### DIFF
--- a/src/riak_core_vnode_worker_pool.erl
+++ b/src/riak_core_vnode_worker_pool.erl
@@ -202,8 +202,7 @@ handle_info(_Info, StateName, State) ->
     {next_state, StateName, State}.
 
 terminate(_Reason, _StateName, #state{pool=Pool}) ->
-    %% stop poolboy
-    gen_fsm:sync_send_all_state_event(Pool, stop),
+    poolboy:stop(Pool),
     ok.
 
 code_change(_OldVsn, StateName, State, _Extra) ->


### PR DESCRIPTION
Our fork of Poolboy is woefully out of date, which makes building systems on top of riak_core difficult when the system in question wants to use a more up-to-date poolboy. This change is needed to incorporate the related Poolboy PR in https://github.com/basho/poolboy/pull/5.

NOTE: Before merging this PR, we'll need to merge the above Poolboy PR and tag the resulting merge as 1.3 (or some such) so that we can appropriately update the rebar.config on riak_core. This PR will be updated with that change once the poolboy PR is merged, but you can use this PR to test riak_core locally in the mean time.

Changes to riak_core are simple:
- Poolboy is now a gen_server - just call stop on the pool instead of using gen_fsm:*
