### PR TITLE
New CLI -  riak-admin handoff limit

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,5 +15,6 @@
   {folsom, "0.7.4p4", {git, "git://github.com/basho/folsom.git", {tag, "0.7.4p4"}}},
   {riak_ensemble, ".*", {git, "git://github.com/basho/riak_ensemble", {branch, "develop"}}},
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
-  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "develop"}}}
+  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "develop"}}},
+  {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "v0.4.3"}}}
 ]}.

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -19,6 +19,9 @@
 %% -------------------------------------------------------------------
 
 -module(riak_core_console).
+-export([command/1]).
+
+%% Legacy exports - unless needed by other modules, only expose functionality via command/1
 -export([member_status/1, ring_status/1, print_member_status/2,
          stage_leave/1, stage_remove/1, stage_replace/1, stage_resize_ring/1,
          stage_force_replace/1, print_staged/1, commit_staged/1,
@@ -30,37 +33,171 @@
          print_groups/1, print_group/1, print_grants/1,
          security_enable/1, security_disable/1, security_status/1, ciphers/1]).
 
-%% New API to be used by riak-admin transfers <X>
--export([transfers_limit/0, transfers_limit/1, rpc_transfers_limit/0,
-	rpc_transfers_limit/1]).
+%% @doc the command function is the entry point for node_tool to call in the
+%%      simplified (less BASH) CLI. Arguments are parsed in Erlang rather than
+%%      in bash scripts.
+-spec command([string()]) -> ok | error.
+command([Script, "handoff", "limit" | Args0]) ->
+    case getopt:parse(handoff_spec_list("handoff limit"), Args0) of
+        {ok, {Args, []}} ->
+            handoff_limit(Script, Args);
+        _ ->
+            handoff_limit_usage(Script)
+    end;
+
+command([Script, "handoff" | _Args]) ->
+    handoff_usage(Script).
+
+%% Specs are {Name, ShortOption, LongOption, Type, Description}
+handoff_spec_list(Cmd) ->
+    [
+     {action, undefined, undefined, atom, "The action to perform. One of [set, show]"},
+     %% Note that getopt can't accept negative numbers as non-flag values. We'll cross
+     %% that bridge when we get to it at this point, as we don't think this will be very common.
+     {value, undefined, undefined, string, "The value to which the " ++ Cmd ++" will be set."},
+     {node, $n, "node", atom,
+      "The node on which to view/change the " ++ Cmd ++ ".\n" ++ align()
+      ++ "If node is not provided, action applies cluster-wide."},
+     {force, $f, "force-rpc", undefined,
+      "Contact every node for the latest " ++ Cmd ++ ".\n" ++
+          align() ++ "WARNING: This can be very expensive."}
+    ].
+
+%% @doc Return a string of 24 spaces. This is the length required to align with
+%% the description part of the flags in the usage output.
+-spec align() -> list().
+align() ->
+    string:copies(" ",24).
+
+handoff_limit_usage(Script) ->
+    getopt:usage(handoff_spec_list("handoff limit"), Script ++ " handoff limit",
+                 standard_io).
+
+handoff_usage(Script) ->
+    io:format("Usage: ~s handoff [command], where command is one of:~n~n"
+              "    limit: show or set handoff concurrency limits~n~n", [Script]).
 
 %% @doc The following functions in this section are new commands intended to be
 %% visible in riak-admin transfer X commands. They are detailed in this RFC:
 %% https://docs.google.com/a/basho.com/document/d/1Qjbj6p4cppAxBkwp5yAnChVnBt8-J7HQXDKF879QaLQ
 %% Eventually they will replace the current riak-admin transfers command, but
 %% for now they are only accessible from the erlang shell.
-%% ============================================================================ 
-transfers_limit() ->
+%% ============================================================================
+handoff_limit(Script, Args) ->
+    case handoff_limit_mode(Args) of
+        show ->
+            show_handoff_limit(Script, Args);
+        set ->
+            set_handoff_limits(Script, Args);
+        usage ->
+            handoff_limit_usage(Script)
+    end.
+
+handoff_limit_mode(Args) ->
+    Action = find_flag(action, Args),
+    Limit = find_flag(value, Args),
+    case {Action, Limit} of
+        {not_found, not_found} ->
+            usage;
+        {show, not_found} ->
+            show;
+        {set, _} ->
+            set;
+        _ ->
+            usage
+    end.
+
+find_flag(Flag, Args) ->
+    case lists:keyfind(Flag, 1, Args) of
+        false ->
+            %% Some flags don't have options and are returned as atoms.
+            case lists:member(Flag, Args) of
+                true -> Flag;
+                false -> not_found
+            end;
+        {Flag, Val} ->
+            Val
+    end.
+
+set_handoff_limits(Script, Args) ->
+                                                % We already check for 'value' in handoff_limit/2 so we know it's here
+    Limit = find_flag(value, Args),
+    check_and_set_handoff_limit(Script, Args, Limit).
+
+check_and_set_handoff_limit(Script, Args, Limit0) ->
+    case check_limit(Limit0) of
+        invalid ->
+            invalid_handoff_limit(Limit0);
+        Limit ->
+            set_handoff_limit(Script, Args, Limit)
+    end.
+
+invalid_handoff_limit(Limit) ->
+    io:format("Invalid limit: ~s~n", [Limit]).
+
+show_handoff_limit(_Script, Args) ->
+    Node = find_flag(node, Args),
+    Force = find_flag(force, Args),
+    case {Node, Force} of
+        {not_found, not_found} ->
+            show_handoff_limit();
+        {_, not_found} ->
+            show_handoff_limit(Node);
+        {not_found, force} ->
+            show_rpc_handoff_limit();
+        {_, force} ->
+            show_rpc_handoff_limit(Node)
+    end.
+
+show_handoff_limit() ->
     Status = riak_core_status:transfer_limit(),
-    print_transfers_limit(Status).
+    print_handoff_limit(Status).
 
-transfers_limit(Node) ->
+show_handoff_limit(Node) ->
     Status = riak_core_status:transfer_limit(Node),
-    print_transfers_limit(Status).
+    print_handoff_limit(Status).
 
-rpc_transfers_limit() ->
+show_rpc_handoff_limit() ->
     Status = riak_core_status:rpc_transfer_limit(),
-    print_transfers_limit(Status).
+    print_handoff_limit(Status).
 
-rpc_transfers_limit(Node) ->
+show_rpc_handoff_limit(Node) ->
     Status = riak_core_status:rpc_transfer_limit(Node),
-    print_transfers_limit(Status).
+    print_handoff_limit(Status).
 
-print_transfers_limit(Status) ->
+set_handoff_limit(_Script, Args, Limit) ->
+    Node = find_flag(node, Args),
+    case Node of
+        not_found ->
+            set_handoff_limit(Limit);
+        _ ->
+            set_handoff_limit(Node, Limit)
+    end.
+
+set_handoff_limit(Limit) ->
+    io:format("Setting transfer limit to ~b across the cluster~n", [Limit]),
+    {_, Down} = riak_core_util:rpc_every_member_ann(riak_core_handoff_manager,
+                                                    set_concurrency,
+                                                    [Limit], 5000),
+    (Down == []) orelse io:format("Failed to set limit for: ~p~n", [Down]),
+    ok.
+
+set_handoff_limit(Node, Limit) ->
+    case riak_core_util:safe_rpc(Node, riak_core_handoff_manager,
+                                 set_concurrency, [Limit]) of
+        {badrpc, _} ->
+            io:format("Failed to set transfer limit for ~p~n", [Node]);
+        _ ->
+            io:format("Set transfer limit for ~p to ~b~n",
+                      [Node, Limit])
+    end,
+    ok.
+
+print_handoff_limit(Status) ->
     Output = riak_core_console_writer:write(Status),
     io:format("~s", [Output]),
     ok.
-%% ============================================================================ 
+%% ============================================================================
 
 %% @doc Return for a given ring and node, percentage currently owned and
 %% anticipated after the transitions have been completed.
@@ -237,12 +374,12 @@ transfers([]) ->
             _  -> io:format("Nodes ~p are currently down.\n", [DownNodes])
         end,
         F = fun({waiting_to_handoff, Node, Count}, Acc) ->
-                io:format("~p waiting to handoff ~p partitions\n", [Node, Count]),
-                Acc + 1;
-            ({stopped, Node, Count}, Acc) ->
-                io:format("~p does not have ~p primary partitions running\n", [Node, Count]),
-                Acc + 1
-        end,
+                    io:format("~p waiting to handoff ~p partitions\n", [Node, Count]),
+                    Acc + 1;
+               ({stopped, Node, Count}, Acc) ->
+                    io:format("~p does not have ~p primary partitions running\n", [Node, Count]),
+                    Acc + 1
+            end,
         case lists:foldl(F, 0, Pending) of
             0 ->
                 io:format("No transfers active\n"),
@@ -253,7 +390,7 @@ transfers([]) ->
     catch
         Exception:Reason ->
             lager:error("Transfers failed ~p:~p", [Exception,
-                    Reason]),
+                                                   Reason]),
             io:format("Transfers failed, see log for details~n"),
             error
     end,
@@ -664,32 +801,32 @@ print_plan(Changes, Ring, NextRings) ->
     io:format("~79..-s~n", [""]),
 
     lists:foreach(fun({Node, join}) ->
-                      io:format("join           ~p~n", [Node]);
-                 ({Node, leave}) ->
-                      io:format("leave          ~p~n", [Node]);
-                 ({Node, remove}) ->
-                      io:format("force-remove   ~p~n", [Node]);
-                 ({Node, {replace, NewNode}}) ->
-                      io:format("replace        ~p with ~p~n", [Node, NewNode]);
-                 ({Node, {force_replace, NewNode}}) ->
-                      io:format("force-replace  ~p with ~p~n", [Node, NewNode]);
-                 ({_, {resize, NewRingSize}}) ->
-                      CurrentSize = riak_core_ring:num_partitions(Ring),
-                      io:format("resize-ring    ~p to ~p partitions~n",[CurrentSize,NewRingSize]);
-                 ({_, abort_resize}) ->
-                      CurrentSize = riak_core_ring:num_partitions(Ring),
-                      io:format("resize-ring    abort. current size: ~p~n", [CurrentSize])
-              end, Changes),
+                          io:format("join           ~p~n", [Node]);
+                     ({Node, leave}) ->
+                          io:format("leave          ~p~n", [Node]);
+                     ({Node, remove}) ->
+                          io:format("force-remove   ~p~n", [Node]);
+                     ({Node, {replace, NewNode}}) ->
+                          io:format("replace        ~p with ~p~n", [Node, NewNode]);
+                     ({Node, {force_replace, NewNode}}) ->
+                          io:format("force-replace  ~p with ~p~n", [Node, NewNode]);
+                     ({_, {resize, NewRingSize}}) ->
+                          CurrentSize = riak_core_ring:num_partitions(Ring),
+                          io:format("resize-ring    ~p to ~p partitions~n",[CurrentSize,NewRingSize]);
+                     ({_, abort_resize}) ->
+                          CurrentSize = riak_core_ring:num_partitions(Ring),
+                          io:format("resize-ring    abort. current size: ~p~n", [CurrentSize])
+                  end, Changes),
     io:format("~79..-s~n", [""]),
     io:format("~n"),
 
     lists:foreach(fun({Node, remove}) ->
-                      io:format("WARNING: All of ~p replicas will be lost~n", [Node]);
-                 ({Node, {force_replace, _}}) ->
-                      io:format("WARNING: All of ~p replicas will be lost~n", [Node]);
-                 (_) ->
-                      ok
-              end, Changes),
+                          io:format("WARNING: All of ~p replicas will be lost~n", [Node]);
+                     ({Node, {force_replace, _}}) ->
+                          io:format("WARNING: All of ~p replicas will be lost~n", [Node]);
+                     (_) ->
+                          ok
+                  end, Changes),
     io:format("~n"),
 
     Transitions = length(NextRings),
@@ -703,13 +840,13 @@ print_plan(Changes, Ring, NextRings) ->
     end,
 
     _ = lists:foldl(fun({Ring1, Ring2}, I) ->
-                           io:format("~79..#s~n", [""]),
-                           io:format("~24.. s After cluster transition ~b/~b~n",
-                                     ["", I, Transitions]),
-                           io:format("~79..#s~n~n", [""]),
-                           output(Ring1, Ring2),
-                           I+1
-                   end, 1, NextRings),
+                            io:format("~79..#s~n", [""]),
+                            io:format("~24.. s After cluster transition ~b/~b~n",
+                                      ["", I, Transitions]),
+                            io:format("~79..#s~n~n", [""]),
+                            output(Ring1, Ring2),
+                            I+1
+                    end, 1, NextRings),
     ok.
 
 output(Ring, NextRing) ->
@@ -819,48 +956,34 @@ transfer_limit([]) ->
               "      and 'riak-admin transfer_limit <node> <limit>'~n"),
     ok;
 transfer_limit([LimitStr]) ->
-    {Valid, Limit} = check_limit(LimitStr),
-    case Valid of
-        false ->
+    case check_limit(LimitStr) of
+        invalid ->
             io:format("Invalid limit: ~s~n", [LimitStr]),
             error;
-        true ->
-            io:format("Setting transfer limit to ~b across the cluster~n",
-                      [Limit]),
-            {_, Down} =
-                riak_core_util:rpc_every_member_ann(riak_core_handoff_manager,
-                                                    set_concurrency,
-                                                    [Limit], 5000),
-            (Down == []) orelse
-                io:format("Failed to set limit for: ~p~n", [Down]),
-            ok
+        Limit ->
+            set_handoff_limit(Limit)
     end;
+
 transfer_limit([NodeStr, LimitStr]) ->
     Node = list_to_atom(NodeStr),
-    {Valid, Limit} = check_limit(LimitStr),
-    case Valid of
-        false ->
+    case check_limit(LimitStr) of
+        invalid ->
             io:format("Invalid limit: ~s~n", [LimitStr]),
             error;
-        true ->
-            case riak_core_util:safe_rpc(Node, riak_core_handoff_manager,
-                          set_concurrency, [Limit]) of
-                {badrpc, _} ->
-                    io:format("Failed to set transfer limit for ~p~n", [Node]);
-                _ ->
-                    io:format("Set transfer limit for ~p to ~b~n",
-                              [Node, Limit])
-            end,
-            ok
+        Limit ->
+            set_handoff_limit(Node, Limit)
     end.
 
 check_limit(Str) ->
     try
         Int = list_to_integer(Str),
-        {Int >= 0, Int}
+        case Int >= 0 of
+            true -> Int;
+            false -> invalid
+        end
     catch
         _:_ ->
-            {false, 0}
+            invalid
     end.
 
 security_error_xlate({errors, Errors}) ->
@@ -898,8 +1021,8 @@ security_error_xlate({error, {unknown_roles, Names}}) ->
     io_lib:format("Name(s) not recognized: ~ts",
                   [
                    string:join(
-                    lists:map(fun(X) -> unicode:characters_to_list(X, utf8) end, Names),
-                    ", ")
+                     lists:map(fun(X) -> unicode:characters_to_list(X, utf8) end, Names),
+                     ", ")
                   ]);
 security_error_xlate({error, {duplicate_roles, Names}}) ->
     io_lib:format("Ambiguous names need to be prefixed with 'user/' or 'group/': ~ts",
@@ -983,16 +1106,16 @@ del_role(Name, Fun) ->
 
 add_source([Users, CIDR, Source | Options]) ->
     Unames = case string:tokens(Users, ",") of
-        ["all"] ->
-            all;
-        Other ->
-            Other
-    end,
+                 ["all"] ->
+                     all;
+                 Other ->
+                     Other
+             end,
     %% Unicode note: atoms are constrained to latin1 until R18, so our
     %% sources are as well
     try riak_core_security:add_source(Unames, parse_cidr(CIDR),
-                                  list_to_atom(string:to_lower(Source)),
-                                  parse_options(Options)) of
+                                      list_to_atom(string:to_lower(Source)),
+                                      parse_options(Options)) of
         ok ->
             io:format("Successfully added source~n"),
             ok;
@@ -1011,11 +1134,11 @@ add_source([Users, CIDR, Source | Options]) ->
 
 del_source([Users, CIDR]) ->
     Unames = case string:tokens(Users, ",") of
-        ["all"] ->
-            all;
-        Other ->
-            Other
-    end,
+                 ["all"] ->
+                     all;
+                 Other ->
+                     Other
+             end,
     riak_core_security:del_source(Unames, parse_cidr(CIDR)),
     io:format("Deleted source~n").
 

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -120,7 +120,7 @@ find_flag(Flag, Args) ->
     end.
 
 set_handoff_limits(Script, Args) ->
-                                                % We already check for 'value' in handoff_limit/2 so we know it's here
+    %% We already check for 'value' in handoff_limit/2 so we know it's here
     Limit = find_flag(value, Args),
     check_and_set_handoff_limit(Script, Args, Limit).
 

--- a/src/riak_core_console_writer.erl
+++ b/src/riak_core_console_writer.erl
@@ -38,6 +38,8 @@ write_status(done, Ctx) ->
     Ctx.
 
 -spec write_table([any()], [[any()]]) -> iolist().
+write_table(_Schema, []) ->
+    "";
 write_table(Schema, Rows) ->
     Table = riak_core_console_table:autosize_create_table(Schema, Rows),
     io_lib:format("~ts~n", [Table]).
@@ -58,6 +60,5 @@ write_column(Title, Items) when is_atom(hd(Items)) ->
 write_column(Title, Items) ->
     %% Todo: add bold/color for Title when supported
     lists:foldl(fun(Item, Acc) ->
-                    Acc++" "++Item
+                        Acc++" "++Item
                 end, Title++":", Items) ++ "\n".
-

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -137,11 +137,11 @@ get_configured_concurrency() ->
     app_helper:get_env(riak_core, handoff_concurrency, ?HANDOFF_CONCURRENCY).
 
 get_concurrency() ->
-    get_concurrency(node()).
+    Default = get_configured_concurrency(),
+    riak_core_metadata:get(?LIMIT_PREFIX, node(), [{default, Default}]).
 
 get_concurrency(Node) ->
-    Default = get_configured_concurrency(),
-    riak_core_metadata:get(?LIMIT_PREFIX, Node, [{default, Default}]).
+    riak_core_metadata:get(?LIMIT_PREFIX, Node).
 
 get_all_concurrency() ->
     riak_core_metadata:to_list(?LIMIT_PREFIX).


### PR DESCRIPTION
- Flag `--node` will operate on the given node
- Without passing `--node` all nodes operated upon
- Allow flag `--set N` where N is non-negative integer
- Allow flag `--show` to show limits
- `riak-admin handoff` lists subcommmands (limit only for now)
- `riak-admin handoff limit` shows usage for limit subcommand
- Add rpc versions of `riak-admin handoff limit --show` when using
  --force-rpc option.
