### PR TITLE
Add optional timeout for handle_handoff_data callback and improve logging [JIRA: RIAK-1493]

### DIFF
--- a/src/riak_core_handoff_receiver.erl
+++ b/src/riak_core_handoff_receiver.erl
@@ -34,14 +34,17 @@
                 peer :: term(),
                 ssl_opts :: [] | list(),
                 tcp_mod :: atom(),
-                timeout_len :: non_neg_integer(),
+                recv_timeout_len :: non_neg_integer(),
+                vnode_timeout_len :: non_neg_integer(),
                 partition :: non_neg_integer(),
                 vnode_mod = riak_kv_vnode:: module(),
                 vnode :: pid(),
                 count = 0 :: non_neg_integer()}).
 
-%% set the timeout to five minutes to be conservative.
+%% set the TCP receive timeout to five minutes to be conservative.
 -define(RECV_TIMEOUT, 300000).
+%% set the timeout for the vnode to process the handoff_data msg to 60s
+-define(VNODE_TIMEOUT, 60000).
 
 start_link() ->
     start_link([]).
@@ -60,7 +63,8 @@ init([SslOpts]) ->
                 tcp_mod  = if SslOpts /= [] -> ssl;
                               true          -> gen_tcp
                            end,
-                timeout_len = app_helper:get_env(riak_core, handoff_receive_timeout, ?RECV_TIMEOUT)}}.
+                recv_timeout_len = app_helper:get_env(riak_core, handoff_receive_timeout, ?RECV_TIMEOUT),
+                vnode_timeout_len = app_helper:get_env(riak_core, handoff_receive_vnode_timeout, ?VNODE_TIMEOUT)}}.
 
 handle_call({set_socket, Socket0}, _From, State = #state{ssl_opts = SslOpts}) ->
     SockOpts = [{active, once}, {packet, 4}, {header, 1}],
@@ -98,7 +102,7 @@ handle_info({tcp, Socket, Data}, State) ->
                          true                          -> inet
                       end,
             InetMod:setopts(Socket, [{active, once}]),
-            {noreply, NewState, State#state.timeout_len}
+            {noreply, NewState, State#state.recv_timeout_len}
     end;
 handle_info({ssl_closed, Socket}, State) ->
     handle_info({tcp_closed, Socket}, State);
@@ -122,15 +126,19 @@ process_message(?PT_MSG_INIT, MsgData, State=#state{vnode_mod=VNodeMod,
     State#state{partition=Partition, vnode=VNode};
 
 process_message(?PT_MSG_BATCH, MsgData, State) ->
-    lists:foldl(fun(Obj, StateAcc) -> process_message(?PT_MSG_OBJ, Obj, StateAcc) end, 
+    lists:foldl(fun(Obj, StateAcc) -> process_message(?PT_MSG_OBJ, Obj, StateAcc) end,
                 State,
                 binary_to_term(MsgData));
 
-process_message(?PT_MSG_OBJ, MsgData, State=#state{vnode=VNode, count=Count}) ->
+process_message(?PT_MSG_OBJ, MsgData, State=#state{vnode=VNode, count=Count,
+                                                   vnode_timeout_len=VNodeTimeout}) ->
     Msg = {handoff_data, MsgData},
-    case gen_fsm:sync_send_all_state_event(VNode, Msg, 60000) of
+    case catch gen_fsm:sync_send_all_state_event(VNode, Msg, VNodeTimeout) of
         ok ->
             State#state{count=Count+1};
+        {'EXIT', {timeout, _}} ->
+            exit({error, {vnode_timeout, VNodeTimeout, size(MsgData),
+                          binary:part(MsgData, {0,min(size(MsgData),128)})}});
         E={error, _} ->
             exit(E)
     end;

--- a/src/riak_core_handoff_receiver.erl
+++ b/src/riak_core_handoff_receiver.erl
@@ -139,6 +139,8 @@ process_message(?PT_MSG_OBJ, MsgData, State=#state{vnode=VNode, count=Count,
         {'EXIT', {timeout, _}} ->
             exit({error, {vnode_timeout, VNodeTimeout, size(MsgData),
                           binary:part(MsgData, {0,min(size(MsgData),128)})}});
+        {'EXIT', E} -> % make sure we still do all the old exits
+            exit(E);
         E={error, _} ->
             exit(E)
     end;


### PR DESCRIPTION
New appenv is app_helper:get_env(riak_core, handoff_receive_vnode_timeout, ?VNODE_TIMEOUT), defaulting to the original 60s timeout.  Timeouts are read at the start of each individual handoff.

If the timeout is hit, responds with a cleaner error explaining it was the vnode timeout, how long the timeout is configured for, the size of the handoff data
(to look for smoking large object guns) and the first 128 bytes so a brave soul has a chance of digging out the key.

Do not want to decipher it as do not want to break layering abstraction with riak_kv.

Example when timeout overriden to 120s:

```
17:58:06.777 [error] Handoff receiver for partition 22835963083295358096932575511191922182123945984 exited abnormally after processing 0 objects from {"127.0.0.1",56562}: {error,{vnode_timeout,120000,154,<<131,104,2,100,0,10,101,110,99,111,100,101,95,114,97,119,104,3,109,0,0,0,7,115,121,115,116,101,115,116,109,0,0,0,4,0,0,0,123,109,0,0,0,110,53,1,0,0,0,34,131,108,0,0,0,1,104,2,109,0,0,0,8,197,82,177,11,182,77,60,181,104,2,97,1,110,5,0,174,65,207,205,14,106,0,0,0,1,0,0,0,5,1,0,0,0,123,0,0,0,53,0,0,5,135,0,3,149,238,0,1,38,108,22,52,70,102,78,84,120,112,54,107,68,81,102,110,113>>}}
```
