### PR TITLE
Implicitly load bear app when loading riak_core

### DIFF
--- a/src/riak_core.app.src
+++ b/src/riak_core.app.src
@@ -6,7 +6,7 @@
   {vsn, git},
   {modules, []},
   {registered, []},
-  {included_applications, [folsom, riak_ensemble]},
+  {included_applications, [bear, folsom, riak_ensemble]},
   {applications, [
                   kernel,
                   stdlib,


### PR DESCRIPTION
Apparently, `riak_core` depends on an old version of `folsom` which does not include `bear` in its app file.

``` erlang
{application, folsom,
 [
  {description, ""},
  {vsn, git},
  {registered, [folsom_meter_timer_server,
                folsom_metrics_histogram_ets,
                folsom_sup]},
  {applications, [
                  kernel,
                  stdlib
                 ]},
  {env, []},
  {mod, {folsom, []}}
 ]}.
```

Newer versions of `folsom` already fix this problem (see https://github.com/boundary/folsom/blob/bc9912604d6e68f588b8e35ace21c91272722640/src/folsom.app.src).

``` erl
{application, folsom,
 [
  {description, "Erlang based metrics system"},
  {vsn, git},
  {registered, [folsom_meter_timer_server,
                folsom_metrics_histogram_ets,
                folsom_sup]},
  {applications, [
                  kernel,
                  stdlib,
                  bear
                 ]},
  {env, []},
  {mod, {folsom, []}}
 ]}.
```

The problem is that if `bear` is not loaded when riak_core is started, it will complain about riak_core not being able to calculate some stats:

``` erl
14:42:43.514 [warning] Failed to calculate stat {riak_core,rebalance_delay} with error:undef
14:42:44.520 [warning] Failed to calculate stat {riak_core,converge_delay} with error:undef
```

One way of fixing this is by **explicitly** adding bear as one of the dependencies of your riak_core-based application. However, riak_core end-users shouldn't be required to know what applications riak_core depends on.

Alternatively, riak_core could be updated to use a newer version of folsom where this problem has already been fixed.

Finally, another option (which is the one implemented in this PR), is to add `bear` to riak_core's app file, so that riak_core users don't have to bother about fixing this. 
