### PR TITLE
Add handoff.ip to core cuttlefish schema [JIRA: RIAK-3058]

### DIFF
--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -71,6 +71,23 @@
   {commented, "$(platform_etc_dir)/cacertfile.pem"}
 ]}.
 
+%% @doc handoff.ip is the network address that Riak binds to for
+%% intra-cluster data handoff.
+{mapping, "handoff.ip", "riak_core.handoff_ip", [
+  {default, "{{handoff_ip}}" },
+  {datatype, string},
+  {validators, ["not_loopback_address"]},
+  hidden
+]}.
+
+{validator,
+  "not_loopback_address",
+  "IP address must not be a loopback interface",
+  fun(Address) -> Address /= "127.0.0.1"
+          andalso Address /= "0:0:0:0:0:0:0:1"
+          andalso Address /= "::1"
+  end}.
+
 %% @doc handoff.port is the TCP port that Riak uses for
 %% intra-cluster data handoff.
 {mapping, "handoff.port", "riak_core.handoff_port", [

--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -82,7 +82,7 @@
 
 {validator,
   "not_loopback_address",
-  "IP address must not be a loopback interface",
+  "must not be a loopback interface",
   fun(Address) -> Address /= "127.0.0.1"
           andalso Address /= "0:0:0:0:0:0:0:1"
           andalso Address /= "::1"

--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -76,16 +76,18 @@
 {mapping, "handoff.ip", "riak_core.handoff_ip", [
   {default, "{{handoff_ip}}" },
   {datatype, string},
-  {validators, ["not_loopback_address"]},
+  {validators, ["valid_ipaddr"]},
   hidden
 ]}.
 
 {validator,
-  "not_loopback_address",
-  "must not be a loopback interface",
-  fun(Address) -> Address /= "127.0.0.1"
-          andalso Address /= "0:0:0:0:0:0:0:1"
-          andalso Address /= "::1"
+  "valid_ipaddr",
+  "must be a valid IP address",
+  fun(AddrString) -> 
+    case inet_parse:address(AddrString) of
+      {ok, _} -> true;
+      {error, _} -> false
+    end
   end}.
 
 %% @doc handoff.port is the TCP port that Riak uses for

--- a/test/riak_core_schema_tests.erl
+++ b/test/riak_core_schema_tests.erl
@@ -36,7 +36,7 @@ basic_schema_test() ->
 %% in the schema are, in fact, reported as invalid.
 invalid_states_test() ->
     Conf = [
-        {["handoff", "ip"], "127.0.0.1"}
+        {["handoff", "ip"], "0.0.0.0.0"}
     ],
 
     Config = cuttlefish_unit:generate_templated_config("../priv/riak_core.schema", Conf, context()),
@@ -44,7 +44,7 @@ invalid_states_test() ->
     %% Confirm that we made it to validation and test that each expected failure
     %% message is present.
     cuttlefish_unit:assert_error_in_phase(Config, validation),
-    cuttlefish_unit:assert_error_message(Config, "handoff.ip invalid, must not be a loopback interface"),
+    cuttlefish_unit:assert_error_message(Config, "handoff.ip invalid, must be a valid IP address"),
     ok.
 
 

--- a/test/riak_core_schema_tests.erl
+++ b/test/riak_core_schema_tests.erl
@@ -18,6 +18,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_not_configured(Config, "riak_core.ssl.certfile"),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.ssl.keyfile"),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.ssl.cacertfile"),
+    cuttlefish_unit:assert_config(Config, "riak_core.handoff_ip", "0.0.0.0"),
     cuttlefish_unit:assert_config(Config, "riak_core.handoff_port", 8099 ),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.handoff_ssl_options"),
     cuttlefish_unit:assert_config(Config, "riak_core.dtrace_support", false),
@@ -53,6 +54,7 @@ override_schema_test() ->
         {["ssl", "certfile"], "/absolute/etc/cert.pem"},
         {["ssl", "keyfile"], "/absolute/etc/key.pem"},
         {["ssl", "cacertfile"], "/absolute/etc/cacertfile.pem"},
+        {["handoff", "ip"], "1.2.3.4"},
         {["handoff", "port"], 8888},
         {["handoff", "ssl", "certfile"], "/tmp/erlserver.pem"},
         {["handoff", "ssl", "keyfile"], "/tmp/erlkey/pem"},
@@ -77,6 +79,7 @@ override_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_core.ssl.certfile", "/absolute/etc/cert.pem"),
     cuttlefish_unit:assert_config(Config, "riak_core.ssl.keyfile", "/absolute/etc/key.pem"),
     cuttlefish_unit:assert_config(Config, "riak_core.ssl.cacertfile", "/absolute/etc/cacertfile.pem"),
+    cuttlefish_unit:assert_config(Config, "riak_core.handoff_ip", "1.2.3.4"),
     cuttlefish_unit:assert_config(Config, "riak_core.handoff_port", 8888),
     cuttlefish_unit:assert_config(Config, "riak_core.handoff_ssl_options.certfile", "/tmp/erlserver.pem"),
     cuttlefish_unit:assert_config(Config, "riak_core.handoff_ssl_options.keyfile", "/tmp/erlkey/pem"),
@@ -99,6 +102,7 @@ override_schema_test() ->
 %% in real life.
 context() ->
     [
+        {handoff_ip, "0.0.0.0"},
         {handoff_port, "8099"},
         {platform_bin_dir , "./bin"},
         {platform_data_dir, "./data"},

--- a/test/riak_core_schema_tests.erl
+++ b/test/riak_core_schema_tests.erl
@@ -32,6 +32,22 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_core.vnode_management_timer", 10000),
     ok.
 
+%% Tests that configurations which should be prohibited by validators defined
+%% in the schema are, in fact, reported as invalid.
+invalid_states_test() ->
+    Conf = [
+        {["handoff", "ip"], "127.0.0.1"}
+    ],
+
+    Config = cuttlefish_unit:generate_templated_config("../priv/riak_core.schema", Conf, context()),
+
+    %% Confirm that we made it to validation and test that each expected failure
+    %% message is present.
+    cuttlefish_unit:assert_error_in_phase(Config, validation),
+    cuttlefish_unit:assert_error_message(Config, "handoff.ip invalid, must not be a loopback interface"),
+    ok.
+
+
 default_bucket_properties_test() ->
     Conf = [
         {["buckets", "default", "n_val"], 5}


### PR DESCRIPTION
Items for discussion:
- Included a validator prohibiting loopback per issue report — seems like a sane choice to me since handoff on the loopback interface is only useful for devrels, and in that case 0.0.0.0 is fine too.
- I'm not clear on if/how validators are currently tested, so I've neglected to write a test for that as yet.
