### PR TITLE
Centralize CLI registration

### DIFF
--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -101,6 +101,8 @@ start(_StartType, _StartArgs) ->
                                           [true, false],
                                           false),
 
+            riak_core_cli_registry:register_cli(),
+
             {ok, Pid};
         {error, Reason} ->
             {error, Reason}

--- a/src/riak_core_cli_registry.erl
+++ b/src/riak_core_cli_registry.erl
@@ -1,0 +1,33 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%% @doc This module tracks registrations for riak_cli integrations.
+
+-module(riak_core_cli_registry).
+
+-define(CLI_MODULES, [
+                     ]).
+
+-export([
+         register_cli/0
+]).
+
+-spec register_cli() -> ok.
+register_cli() ->
+   lists:foreach(fun(M) -> apply(M, register_cli, []) end, ?CLI_MODULES).

--- a/src/riak_core_cli_registry.erl
+++ b/src/riak_core_cli_registry.erl
@@ -21,8 +21,7 @@
 
 -module(riak_core_cli_registry).
 
--define(CLI_MODULES, [
-                     ]).
+-define(CLI_MODULES, []).
 
 -export([
          register_cli/0
@@ -30,4 +29,4 @@
 
 -spec register_cli() -> ok.
 register_cli() ->
-   lists:foreach(fun(M) -> apply(M, register_cli, []) end, ?CLI_MODULES).
+   riak_cli:register(?CLI_MODULES).


### PR DESCRIPTION
Provide a mechanism to centralize riak_cli command and usage registration.

Modules should implement their own `register_cli/0` functions and then
add the module name(s) to the list defined in the `?CLI_MODULES` 
macro.

The `riak_core_cli_registry:register_cli/0` function is called from
`riak_core_app:start/2` around line 104.
