### PR TITLE
Feature/riak cli handoff enable

### DIFF
--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -95,6 +95,24 @@
   hidden
 ]}.
 
+%% @doc Disables outbound handoff transfers for this node. If you
+%% turn this setting on at runtime with riak-admin, it will kill any
+%% outbound handoffs currently running.
+{mapping, "handoff.disable_outbound", "riak_core.disable_outbound_handoff", [
+  {default, off},
+  {datatype, flag},
+  hidden
+]}.
+
+%% @doc Disables inbound handoff transfers for this node. If you
+%% turn this setting on at runtime with riak-admin, it will kill any
+%% inbound handoffs currently running.
+{mapping, "handoff.disable_inbound", "riak_core.disable_inbound_handoff", [
+  {default, off},
+  {datatype, flag},
+  hidden
+]}.
+
 %% @doc DTrace support Do not enable 'dtrace' unless your Erlang/OTP
 %% runtime is compiled to support DTrace.  DTrace is available in
 %% R15B01 (supported by the Erlang/OTP official source package) and in

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -101,6 +101,7 @@ start(_StartType, _StartArgs) ->
                                           [true, false],
                                           false),
 
+            riak_core_cli_registry:register_node_finder(),
             riak_core_cli_registry:register_cli(),
 
             {ok, Pid};

--- a/src/riak_core_cli_registry.erl
+++ b/src/riak_core_cli_registry.erl
@@ -21,11 +21,23 @@
 
 -module(riak_core_cli_registry).
 
--define(CLI_MODULES, [riak_core_cluster_cli]).
+-define(CLI_MODULES, [
+                      riak_core_cluster_cli,
+                      riak_core_handoff_cli
+                     ]).
 
 -export([
+         register_node_finder/0,
          register_cli/0
 ]).
+
+-spec register_node_finder() -> true.
+register_node_finder() ->
+    F = fun() ->
+                {ok, MyRing} = riak_core_ring_manager:get_my_ring(),
+                riak_core_ring:all_members(MyRing)
+        end,
+    riak_cli:register_node_finder(F).
 
 -spec register_cli() -> ok.
 register_cli() ->

--- a/src/riak_core_handoff_cli.erl
+++ b/src/riak_core_handoff_cli.erl
@@ -1,0 +1,129 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_core_handoff_cli).
+
+-behavior(riak_cli_handler).
+
+-export([register_cli/0]).
+
+-spec register_cli() -> ok.
+register_cli() ->
+    register_cli_usage(),
+    register_cli_cfg(),
+    register_cli_cmds().
+
+register_cli_cmds() ->
+    CmdList = [handoff_cmd_spec(EnOrDis, Dir) ||
+               EnOrDis <- [enable, disable],
+               Dir     <- [inbound, outbound, both]],
+    lists:foreach(fun(Args) -> apply(riak_cli, register_command, Args) end,
+                  CmdList).
+
+register_cli_cfg() ->
+    lists:foreach(fun(K) ->
+                          riak_cli:register_config(K, fun handoff_cfg_change_callback/3)
+                  end, [["handoff", "disable_inbound"], ["handoff", "disable_outbound"]]).
+
+register_cli_usage() ->
+    riak_cli:register_usage(["riak-admin", "handoff"], handoff_usage()),
+    riak_cli:register_usage(["riak-admin", "handoff", "enable"], handoff_enable_disable_usage()),
+    riak_cli:register_usage(["riak-admin", "handoff", "disable"], handoff_enable_disable_usage()).
+
+handoff_usage() ->
+    ["riak-admin handoff <subcommand> [args]\n\n",
+     "Currently implemented handoff commands are:\n",
+     "  enable   Enable handoffs for the specified node(s)\n",
+     "  disable  Disable handoffs for the specified node(s)\n"
+    ].
+
+handoff_enable_disable_usage() ->
+    ["riak-admin handoff <enable | disable> <inbound | outbound | both> ",
+     "[[--node | -n] <Node>] [--all]\n\n",
+     "  Enable or disable handoffs on the specified node(s).\n",
+     "  If handoffs are disabled in a direction, any currently\n",
+     "  running handoffs in that direction will be terminated.\n\n"
+     "Options\n",
+     "  -n <Node>, --node <Node>\n",
+     "      Modify the setting on the specified node (default: local node only)\n",
+     "  -a, --all\n",
+     "      Modify the setting on every node in the cluster\n"
+    ].
+
+handoff_cmd_spec(EnOrDis, Direction) ->
+    Cmd = ["riak-admin", "handoff", atom_to_list(EnOrDis), atom_to_list(Direction)],
+    Callback = fun([], Flags) ->
+                       handoff_change_enabled_setting(EnOrDis, Direction, Flags)
+               end,
+    [
+     Cmd,
+     [], % KeySpecs
+     [{all, [{shortname, "a"},
+             {longname, "all"}]},
+      {node, [{shortname, "n"},
+              {longname, "node"}]}], % FlagSpecs
+     Callback
+    ].
+
+handoff_change_enabled_setting(_EnOrDis, _Direction, Flags) when length(Flags) > 1 ->
+    [riak_cli_status:text("Can't specify both --all and --node flags")];
+handoff_change_enabled_setting(EnOrDis, Direction, [{all, _}]) ->
+    Nodes = riak_cli_nodes:nodes(),
+    {_, Down} = rpc:multicall(Nodes,
+                              riak_core_handoff_manager,
+                              handoff_change_enabled_setting,
+                              [EnOrDis, Direction],
+                              60000),
+
+    case Down of
+        [] ->
+            [riak_cli_status:text("All nodes successfully updated")];
+        _ ->
+            Output = io_lib:format("Handoff ~s failed on nodes: ~p", [EnOrDis, Down]),
+            [riak_cli_status:alert([riak_cli_status:text(Output)])]
+    end;
+handoff_change_enabled_setting(EnOrDis, Direction, [{node, NodeStr}]) ->
+    Node = riak_cli_typecast:to_node(NodeStr),
+    Result = riak_cli_nodes:safe_rpc(Node,
+                                     riak_core_handoff_manager, handoff_change_enabled_setting,
+                                     [EnOrDis, Direction]),
+    case Result of
+        {badrpc, Reason} ->
+            Output = io_lib:format("Failed to update handoff settings on node ~p. Reason: ~p",
+                                   [Node, Reason]),
+            [riak_cli_status:alert([riak_cli_status:text(Output)])];
+        _ ->
+            [riak_cli_status:text("Handoff setting successfully updated")]
+    end;
+
+handoff_change_enabled_setting(EnOrDis, Direction, []) ->
+    riak_core_handoff_manager:handoff_change_enabled_setting(EnOrDis, Direction),
+    [riak_cli_status:text("Handoff setting successfully updated")].
+
+handoff_cfg_change_callback(["handoff", Cmd], "off", _Flags) ->
+    case Cmd of
+        "disable_inbound" ->
+            riak_core_handoff_manager:kill_handoffs_in_direction(inbound);
+        "disable_outbound" ->
+            riak_core_handoff_manager:kill_handoffs_in_direction(outbound)
+    end;
+handoff_cfg_change_callback(_, _, _) ->
+    ok.
+

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -44,7 +44,9 @@
          set_concurrency/1,
          get_concurrency/0,
          set_recv_data/2,
-         kill_handoffs/0
+         kill_handoffs/0,
+         kill_handoffs_in_direction/1,
+         handoff_change_enabled_setting/2
         ]).
 
 -include("riak_core_handoff.hrl").
@@ -137,6 +139,10 @@ kill_xfer(SrcNode, ModSrcTarget, Reason) ->
 kill_handoffs() ->
     set_concurrency(0).
 
+-spec kill_handoffs_in_direction(inbound | outbound) -> ok.
+kill_handoffs_in_direction(Direction) ->
+    gen_server:call(?MODULE, {kill_in_direction, Direction}, infinity).
+
 add_exclusion(Module, Index) ->
     gen_server:cast(?MODULE, {add_exclusion, {Module, Index}}).
 
@@ -217,7 +223,17 @@ handle_call({set_concurrency,Limit},_From,State=#state{handoffs=HS}) ->
 
 handle_call(get_concurrency, _From, State) ->
     Concurrency = get_concurrency_limit(),
-    {reply, Concurrency, State}.
+    {reply, Concurrency, State};
+
+handle_call({kill_in_direction, Direction}, _From, State=#state{handoffs=HS}) ->
+    %% TODO (atb): Refactor this to comply with max_concurrency logspam PR's exit codes
+    %% NB. As-is this handles worker termination the same way as set_concurrency;
+    %%     no state update is performed here, we let the worker DOWNs mark them
+    %%     as dead rather than trimming here.
+    Kill = [H || H=#handoff_status{direction=D} <- HS, D =:= Direction],
+    _ = [erlang:exit(Pid, max_concurrency) ||
+         #handoff_status{transport_pid=Pid} <- Kill],
+    {reply, ok, State}.
 
 handle_cast({del_exclusion, {Mod, Idx}}, State=#state{excl=Excl}) ->
     Excl2 = sets:del_element({Mod, Idx}, Excl),
@@ -606,22 +622,55 @@ kill_xfer_i(ModSrcTarget, Reason, HS) ->
             kill_xfer_i(ModSrcTarget, Reason, HS2)
     end.
 
+handoff_change_enabled_setting(EnOrDis, Direction) ->
+    SetFun = case EnOrDis of
+                 enable  -> fun handoff_enable/1;
+                 disable -> fun handoff_disable/1
+             end,
+    case Direction of
+        inbound ->
+            SetFun(inbound);
+        outbound ->
+            SetFun(outbound);
+        both ->
+            SetFun(inbound),
+            SetFun(outbound)
+    end.
+
+handoff_enable(inbound) ->
+    application:set_env(riak_core, disable_inbound_handoff, false);
+handoff_enable(outbound) ->
+    application:set_env(riak_core, disable_outbound_handoff, false).
+
+handoff_disable(inbound) ->
+    application:set_env(riak_core, disable_inbound_handoff, true),
+    kill_handoffs_in_direction(inbound);
+handoff_disable(outbound) ->
+    application:set_env(riak_core, disable_outbound_handoff, true),
+    kill_handoffs_in_direction(outbound).
+
 %%%===================================================================
 %%% Tests
 %%%===================================================================
 
--ifdef (TEST_BROKEN_AZ_TICKET_1042).
+-ifdef (TEST).
 
 handoff_test_ () ->
     {spawn,
      {setup,
 
       %% called when the tests start and complete...
-      fun () -> {ok,Pid}=start_link(), Pid end,
-      fun (Pid) -> exit(Pid,kill) end,
+      fun () ->
+              {ok, ManPid} = start_link(),
+              {ok, RSupPid} = riak_core_handoff_receiver_sup:start_link(),
+              {ok, SSupPid} = riak_core_handoff_sender_sup:start_link(),
+              [ManPid, RSupPid, SSupPid]
+      end,
+      fun (PidList) -> lists:foreach(fun(Pid) -> exit(Pid, kill) end, PidList) end,
 
       %% actual list of test
-      [?_test(simple_handoff())
+      [?_test(simple_handoff()),
+       ?_test(config_disable())
       ]}}.
 
 simple_handoff () ->
@@ -638,5 +687,63 @@ simple_handoff () ->
 
     %% done
     ok.
+
+config_disable () ->
+    ?assertEqual(ok, handoff_enable(inbound)),
+    ?assertEqual(ok, handoff_enable(outbound)),
+    ?assertEqual(ok, set_concurrency(2)),
+
+    ?assertEqual([], status()),
+
+    Res = add_inbound([]),
+    ?assertMatch({ok, _}, Res),
+    {ok, Pid} = Res,
+
+    ?assertEqual(1, length(status())),
+
+    Ref = monitor(process, Pid),
+
+    CatchDownFun = fun() ->
+                           receive
+                               {'DOWN', Ref, process, Pid, max_concurrency} ->
+                                   ok;
+                               Other ->
+                                   {error, unexpected_message, Other}
+                           after
+                               1000 ->
+                                   {error, timeout_waiting_for_down_msg}
+                           end
+                   end,
+
+    ?assertEqual(ok, handoff_disable(inbound)),
+    ?assertEqual(ok, CatchDownFun()),
+    %% We use wait_until because it's possible that the handoff manager process
+    %% could get our call to status/0 before it receives the 'DOWN' message,
+    %% so we periodically retry the call for a while until we get the answer we
+    %% expect, or until we time out.
+    Status0 = fun() -> length(status()) =:= 0 end,
+    ?assertEqual(ok, wait_until(Status0, 500, 1)),
+
+    ?assertEqual({error, max_concurrency}, add_inbound([])),
+
+    ?assertEqual(ok, handoff_enable(inbound)),
+    ?assertEqual(ok, handoff_enable(outbound)),
+    ?assertEqual(0, length(status())),
+
+    ?assertMatch({ok, _}, add_inbound([])),
+    ?assertEqual(1, length(status())).
+
+%% Copied from riak_test's rt.erl:
+wait_until(Fun, Retry, Delay) when Retry > 0 ->
+    Res = Fun(),
+    case Res of
+        true ->
+            ok;
+        _ when Retry == 1 ->
+            {fail, Res};
+        _ ->
+            timer:sleep(Delay),
+            wait_until(Fun, Retry-1, Delay)
+    end.
 
 -endif.


### PR DESCRIPTION
This adds CLI commands to enable/disable handoffs:

riak-admin <enable | disable> <inbound | outbound | both> [--node <NODE>] [--all]

If handoffs are disabled, any currently active handoffs in the specified direction will be terminated.

If the riak-admin "set" command is used to disable handoffs in a given direction via the newly exposed handoff.disable_inbound or handoff.disable_outbound settings, corresponding handoffs will also be automatically terminated.

This PR also includes some additional unit testing in riak_core_handoff_manager.
