### PR TITLE
use exometer_core instead of exometer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,6 @@ DIALYZER_APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto in
 	public_key mnesia syntax_tools compiler
 PULSE_TESTS = worker_pool_pulse
 
-EXOMETER_PACKAGES = "(basic)"
-export EXOMETER_PACKAGES
-
 .PHONY: deps test
 
 all: deps compile

--- a/rebar.config
+++ b/rebar.config
@@ -16,5 +16,5 @@
   {riak_ensemble, ".*", {git, "git://github.com/basho/riak_ensemble", {branch, "2.0"}}},
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "2.0"}}},
-  {exometer, ".*", {git, "git://github.com/Feuerlabs/exometer.git", {tag, "1.0"}}}
+  {exometer_core, ".*", {git, "git://github.com/Feuerlabs/exometer_core.git", {tag, "1.0"}}}
 ]}.

--- a/src/riak_core.app.src
+++ b/src/riak_core.app.src
@@ -19,7 +19,7 @@
                   eleveldb,
                   pbkdf2,
                   poolboy,
-                  exometer
+                  exometer_core
                  ]},
   {mod, {riak_core_app, []}},
   {env, [


### PR DESCRIPTION
Addresses RIAK-1292 and RIAK-1295

change app dependency to exometer_core

use exometer_alias for legacy names

remove obsolete code causing dialyzer warnings

use tag 1.0 for exometer_core
