### PR TITLE
Track minimal set of ring transition info in cluster metadata

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,5 +16,7 @@
   {riak_ensemble, ".*", {git, "git://github.com/basho/riak_ensemble", {branch, "2.0"}}},
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "2.0"}}},
-  {exometer, ".*", {git, "git://github.com/Feuerlabs/exometer.git", {tag, "1.0"}}}
+  {exometer, ".*", {git, "git://github.com/Feuerlabs/exometer.git", {tag, "1.0"}}},
+  {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "626698975e63866156159661d100785d65eab6f9"}}},
+  {riak_cli, ".*", {git, "git://github.com/basho/riak_cli.git", {branch, "master"}}} % XXX FIXME - should point to a real tag once released
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -17,5 +17,5 @@
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "2.0"}}},
   {exometer, ".*", {git, "git://github.com/Feuerlabs/exometer.git", {tag, "1.0"}}},
-  {riak_cli, ".*", {git, "git@github.com:basho/riak_cli.git", {branch, "master"}}} % XXX FIXME - should point to a real tag once released
+  {riak_cli, ".*", {git, "git@github.com:basho/riak_cli.git", {branch, "develop"}}} % XXX FIXME - should point to a real tag once released
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -18,5 +18,5 @@
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "2.0"}}},
   {exometer, ".*", {git, "git://github.com/Feuerlabs/exometer.git", {tag, "1.0"}}},
   {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "626698975e63866156159661d100785d65eab6f9"}}},
-  {riak_cli, ".*", {git, "git://github.com/basho/riak_cli.git", {branch, "master"}}} % XXX FIXME - should point to a real tag once released
+  {riak_cli, ".*", {git, "git@github.com:basho/riak_cli.git", {branch, "master"}}} % XXX FIXME - should point to a real tag once released
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -17,6 +17,5 @@
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "2.0"}}},
   {exometer, ".*", {git, "git://github.com/Feuerlabs/exometer.git", {tag, "1.0"}}},
-  {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "626698975e63866156159661d100785d65eab6f9"}}},
   {riak_cli, ".*", {git, "git@github.com:basho/riak_cli.git", {branch, "master"}}} % XXX FIXME - should point to a real tag once released
 ]}.

--- a/src/riak_core.app.src
+++ b/src/riak_core.app.src
@@ -19,7 +19,8 @@
                   eleveldb,
                   pbkdf2,
                   poolboy,
-                  exometer
+                  exometer,
+                  riak_cli
                  ]},
   {mod, {riak_core_app, []}},
   {env, [

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -101,6 +101,8 @@ start(_StartType, _StartArgs) ->
                                           [true, false],
                                           false),
 
+            riak_core_cli_registry:register_cli(),
+
             {ok, Pid};
         {error, Reason} ->
             {error, Reason}

--- a/src/riak_core_claimant.erl
+++ b/src/riak_core_claimant.erl
@@ -386,7 +386,7 @@ commit_staged(State=#state{next_ring=undefined}) ->
 commit_staged(State) ->
     case maybe_commit_staged(State) of
         {ok, _} ->
-            riak_core_ring:update_cluster_metadata(State#state{next_ring}),
+            riak_core_ring:update_cluster_metadata(State#state.next_ring),
             State2 = State#state{next_ring=undefined,
                                  changes=[],
                                  seed=erlang:now()},

--- a/src/riak_core_claimant.erl
+++ b/src/riak_core_claimant.erl
@@ -386,6 +386,7 @@ commit_staged(State=#state{next_ring=undefined}) ->
 commit_staged(State) ->
     case maybe_commit_staged(State) of
         {ok, _} ->
+            riak_core_ring:update_cluster_metadata(State#state{next_ring}),
             State2 = State#state{next_ring=undefined,
                                  changes=[],
                                  seed=erlang:now()},

--- a/src/riak_core_cli_registry.erl
+++ b/src/riak_core_cli_registry.erl
@@ -1,0 +1,33 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%% @doc This module tracks registrations for riak_cli integrations.
+
+-module(riak_core_cli_registry).
+
+-define(CLI_MODULES, [
+                     ]).
+
+-export([
+         register_cli/0
+]).
+
+-spec register_cli() -> ok.
+register_cli() ->
+   lists:foreach(fun(M) -> apply(M, register_cli, []) end, ?CLI_MODULES).

--- a/src/riak_core_cli_registry.erl
+++ b/src/riak_core_cli_registry.erl
@@ -21,8 +21,7 @@
 
 -module(riak_core_cli_registry).
 
--define(CLI_MODULES, [
-                     ]).
+-define(CLI_MODULES, []).
 
 -export([
          register_cli/0
@@ -30,4 +29,4 @@
 
 -spec register_cli() -> ok.
 register_cli() ->
-   lists:foreach(fun(M) -> apply(M, register_cli, []) end, ?CLI_MODULES).
+   riak_cli:register(?CLI_MODULES).

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -19,6 +19,8 @@
 %% -------------------------------------------------------------------
 
 -module(riak_core_console).
+%% Legacy exports - unless needed by other modules, only expose
+%% functionality via command/1
 -export([member_status/1, ring_status/1, print_member_status/2,
          stage_leave/1, stage_remove/1, stage_replace/1, stage_resize_ring/1,
          stage_force_replace/1, print_staged/1, commit_staged/1,
@@ -30,6 +32,14 @@
          print_groups/1, print_group/1, print_grants/1,
          security_enable/1, security_disable/1, security_status/1, ciphers/1,
 	 stat_show/1, stat_info/1, stat_enable/1, stat_disable/1, stat_reset/1]).
+
+
+%% New CLI API
+-export([command/1]).
+
+-spec command([string()]) -> ok.
+command(Cmd) ->
+    riak_cli_manager:run(Cmd).
 
 %% @doc Return for a given ring and node, percentage currently owned and
 %% anticipated after the transitions have been completed.

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -39,7 +39,7 @@
 
 -spec command([string()]) -> ok.
 command(Cmd) ->
-    riak_cli_manager:run(Cmd).
+    riak_cli:run(Cmd).
 
 %% @doc Return for a given ring and node, percentage currently owned and
 %% anticipated after the transitions have been completed.


### PR DESCRIPTION
Today, we have no way of reporting on the completion percentage of a set of ring ownership transfers because the ring `next` field is winnowed down as each transfer completes.

This PR will update cluster metadata each time a ring ownership/resize transition is initiated to reflect the total number of transfers required and the new ring version. It is effectively experimental and deserves some tests.
