### PR TITLE
Replaces feuerlabs/exometer with basho/exometer

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,9 +12,8 @@
   {poolboy, ".*", {git, "git://github.com/basho/poolboy.git", {tag, "0.8.1p2"}}},
   {basho_stats, ".*", {git, "git://github.com/basho/basho_stats.git", {tag, "1.0.3"}}},
   {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon.git", {branch, "2.0"}}},
-  {folsom, "0.7.4p4", {git, "git://github.com/basho/folsom.git", {tag, "0.7.4p4"}}},
   {riak_ensemble, ".*", {git, "git://github.com/basho/riak_ensemble", {branch, "2.0"}}},
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "2.0"}}},
-  {exometer_core, ".*", {git, "git://github.com/Feuerlabs/exometer_core.git", {tag, "1.0"}}}
+  {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho1"}}}
 ]}.


### PR DESCRIPTION
Removes the folsom dependency and replaces feuerlabs/exometer with basho/exometer to sync bear, meck, and folsom dependencies with the rest of the Riak stack.

/cc @engelsanchez
