### PR TITLE
Add transfer_limit config callback to handoff_cli

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,6 +16,5 @@
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "2.0"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho1"}}},
-  {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "626698975e63866156159661d100785d65eab6f9"}}},
   {riak_cli, ".*", {git, "git@github.com:basho/riak_cli.git", {branch, "master"}}} % XXX FIXME - should point to a real tag once released
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -17,5 +17,5 @@
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "2.0"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho1"}}},
   {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "626698975e63866156159661d100785d65eab6f9"}}},
-  {riak_cli, ".*", {git, "git://github.com/basho/riak_cli.git", {branch, "master"}}} % XXX FIXME - should point to a real tag once released
+  {riak_cli, ".*", {git, "git@github.com:basho/riak_cli.git", {branch, "master"}}} % XXX FIXME - should point to a real tag once released
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -16,5 +16,5 @@
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "2.0"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho1"}}},
-  {riak_cli, ".*", {git, "git@github.com:basho/riak_cli.git", {branch, "master"}}} % XXX FIXME - should point to a real tag once released
+  {riak_cli, ".*", {git, "git@github.com:basho/riak_cli.git", {branch, "develop"}}} % XXX FIXME - should point to a real tag once released
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -16,5 +16,6 @@
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "2.0"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho1"}}},
-  {riak_cli, ".*", {git, "git@github.com:basho/riak_cli.git", {branch, "develop"}}} % XXX FIXME - should point to a real tag once released
+  {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "626698975e63866156159661d100785d65eab6f9"}}},
+  {riak_cli, ".*", {git, "git://github.com/basho/riak_cli.git", {branch, "master"}}} % XXX FIXME - should point to a real tag once released
 ]}.


### PR DESCRIPTION
This ensures that when the limit is reduced processes exceeding the
limit get shut down. Uses already existing functionality in
riak_core_handoff_manager for the shutdown.
