### PR TITLE
Improve handoff enable/disable config naming

### DIFF
--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -95,21 +95,21 @@
   hidden
 ]}.
 
-%% @doc Disables outbound handoff transfers for this node. If you
-%% turn this setting on at runtime with riak-admin, it will kill any
+%% @doc Enables/disables outbound handoff transfers for this node. If you
+%% turn this setting off at runtime with riak-admin, it will kill any
 %% outbound handoffs currently running.
-{mapping, "handoff.disable_outbound", "riak_core.disable_outbound_handoff", [
-  {default, off},
-  {datatype, flag},
+{mapping, "handoff.outbound", "riak_core.disable_outbound_handoff", [
+  {default, on},
+  {datatype, {flag, off, on}},
   hidden
 ]}.
 
-%% @doc Disables inbound handoff transfers for this node. If you
-%% turn this setting on at runtime with riak-admin, it will kill any
+%% @doc Enables/disables inbound handoff transfers for this node. If you
+%% turn this setting off at runtime with riak-admin, it will kill any
 %% inbound handoffs currently running.
-{mapping, "handoff.disable_inbound", "riak_core.disable_inbound_handoff", [
-  {default, off},
-  {datatype, flag},
+{mapping, "handoff.inbound", "riak_core.disable_inbound_handoff", [
+  {default, on},
+  {datatype, {flag, off, on}},
   hidden
 ]}.
 

--- a/src/riak_core_handoff_cli.erl
+++ b/src/riak_core_handoff_cli.erl
@@ -56,7 +56,7 @@ register_enable_disable_commands() ->
 register_cli_cfg() ->
     lists:foreach(fun(K) ->
                           clique:register_config(K, fun handoff_cfg_change_callback/3)
-                  end, [["handoff", "disable_inbound"], ["handoff", "disable_outbound"]]),
+                  end, [["handoff", "inbound"], ["handoff", "outbound"]]),
     clique:register_config(["transfer_limit"], fun set_transfer_limit/3).
 
 register_config_whitelist() ->
@@ -192,9 +192,9 @@ handoff_change_enabled_setting(EnOrDis, Direction, []) ->
 
 handoff_cfg_change_callback(["handoff", Cmd], "off", _Flags) ->
     case Cmd of
-        "disable_inbound" ->
+        "inbound" ->
             riak_core_handoff_manager:kill_handoffs_in_direction(inbound);
-        "disable_outbound" ->
+        "outbound" ->
             riak_core_handoff_manager:kill_handoffs_in_direction(outbound)
     end;
 handoff_cfg_change_callback(_, _, _) ->


### PR DESCRIPTION
This avoids the confusing double-negative situation where you have to turn off the disabling of handoff in order to enable it. Now you just say e.g. "set handoff.inbound=on" to enable inbound handoff, and "set handoff.inbound=off" to disable it.
