### PR TITLE
Allow schema loading with an environment variable

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,5 +16,5 @@
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "2.0"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho1"}}},
-  {clique, ".*", {git, "git@github.com:basho/clique.git", {tag, "0.2.3"}}}
+  {clique, ".*", {git, "git@github.com:basho/clique.git", {tag, "0.2.4"}}}
 ]}.

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -101,6 +101,7 @@ start(_StartType, _StartArgs) ->
                                           [true, false],
                                           false),
 
+            riak_core_cli_registry:load_schema(),
             riak_core_cli_registry:register_node_finder(),
             riak_core_cli_registry:register_cli(),
 

--- a/src/riak_core_cli_registry.erl
+++ b/src/riak_core_cli_registry.erl
@@ -28,7 +28,8 @@
 
 -export([
          register_node_finder/0,
-         register_cli/0
+         register_cli/0,
+         load_schema/0
         ]).
 
 -spec register_node_finder() -> true.
@@ -42,3 +43,12 @@ register_node_finder() ->
 -spec register_cli() -> ok.
 register_cli() ->
     clique:register(?CLI_MODULES).
+
+-spec load_schema() -> ok.
+load_schema() ->
+    case application:get_env(riak_core, schema_dirs) of
+        {ok, Directories} ->
+            ok = clique_config:load_schema(Directories);
+        _ ->
+            ok = clique_config:load_schema([code:lib_dir()])
+    end.


### PR DESCRIPTION
Allow tests to use alternate schema paths via an environment variable in
riak_core.

Bump Clique to 0.2.4 so that schema loading is done explicitly by the
caller and not automatically during application startup.
