### PR TITLE
add fns and test to get active preflist w/ partition nums, annotated, by...

### DIFF
--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -71,6 +71,23 @@
   {commented, "$(platform_etc_dir)/cacertfile.pem"}
 ]}.
 
+%% @doc handoff.ip is the network address that Riak binds to for
+%% intra-cluster data handoff.
+{mapping, "handoff.ip", "riak_core.handoff_ip", [
+  {default, "{{handoff_ip}}" },
+  {datatype, string},
+  {validators, ["not_loopback_address"]},
+  hidden
+]}.
+
+{validator,
+  "not_loopback_address",
+  "IP address must not be a loopback interface",
+  fun(Address) -> Address /= "127.0.0.1"
+          andalso Address /= "0:0:0:0:0:0:0:1"
+          andalso Address /= "::1"
+  end}.
+
 %% @doc handoff.port is the TCP port that Riak uses for
 %% intra-cluster data handoff.
 {mapping, "handoff.port", "riak_core.handoff_port", [

--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -82,7 +82,7 @@
 
 {validator,
   "not_loopback_address",
-  "IP address must not be a loopback interface",
+  "must not be a loopback interface",
   fun(Address) -> Address /= "127.0.0.1"
           andalso Address /= "0:0:0:0:0:0:0:1"
           andalso Address /= "::1"

--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -76,16 +76,18 @@
 {mapping, "handoff.ip", "riak_core.handoff_ip", [
   {default, "{{handoff_ip}}" },
   {datatype, string},
-  {validators, ["not_loopback_address"]},
+  {validators, ["valid_ipaddr"]},
   hidden
 ]}.
 
 {validator,
-  "not_loopback_address",
-  "must not be a loopback interface",
-  fun(Address) -> Address /= "127.0.0.1"
-          andalso Address /= "0:0:0:0:0:0:0:1"
-          andalso Address /= "::1"
+  "valid_ipaddr",
+  "must be a valid IP address",
+  fun(AddrString) -> 
+    case inet_parse:address(AddrString) of
+      {ok, _} -> true;
+      {error, _} -> false
+    end
   end}.
 
 %% @doc handoff.port is the TCP port that Riak uses for

--- a/src/dvvset.erl
+++ b/src/dvvset.erl
@@ -2,7 +2,6 @@
 %%
 %% File:      dvvset.erl
 %%
-%% @title Dotted Version Vector Set
 %% @author    Ricardo Tomé Gonçalves <tome.wave@gmail.com>
 %% @author    Paulo Sérgio Almeida <pssalmeida@gmail.com>
 %

--- a/src/riak_core_bg_manager.erl
+++ b/src/riak_core_bg_manager.erl
@@ -318,7 +318,7 @@ token_info(Token) ->
 all_resources() ->
     all_resources(all).
 
-%% @doc Get a list of all resources named `Resource`
+%% @doc Get a list of all resources named `Resource'
 -spec all_resources(bg_token() | bg_lock() | all) -> [bg_stat_live()].
 all_resources(Resource) ->
     query_resource(Resource, [token, lock]).
@@ -328,7 +328,7 @@ all_resources(Resource) ->
 all_locks() ->
     all_locks(all).
 
-%% @doc Returns all locks named `Name`
+%% @doc Returns all locks named `Name'
 -spec all_locks(bg_lock() | all) -> [bg_stat_live()].
 all_locks(Lock) ->
     query_resource(Lock, [lock]).
@@ -338,7 +338,7 @@ all_locks(Lock) ->
 all_tokens() ->
     all_tokens(all).
 
-%% @doc Returns all tokens named `Name`
+%% @doc Returns all tokens named `Name'
 -spec all_tokens(bg_token() | all) -> [bg_stat_live()].
 all_tokens(Token) ->
     query_resource(Token, [token]).

--- a/src/riak_core_broadcast_handler.erl
+++ b/src/riak_core_broadcast_handler.erl
@@ -19,23 +19,23 @@
 %% -------------------------------------------------------------------
 -module(riak_core_broadcast_handler).
 
-%% @doc return a two-tuple of message id and payload from a given broadcast
+%% Return a two-tuple of message id and payload from a given broadcast
 -callback broadcast_data(any()) -> {any(), any()}.
 
-%% @doc given the message id and payload, merge the message in the local state.
+%% Given the message id and payload, merge the message in the local state.
 %% If the message has already been received return `false', otherwise return `true'
 -callback merge(any(), any()) -> boolean().
 
-%% @doc return true if the message (given the message id) has already been received.
+%% Return true if the message (given the message id) has already been received.
 %% `false' otherwise
 -callback is_stale(any()) -> boolean().
 
-%% @doc return the message associated with the given message id. In some cases a message
+%% Return the message associated with the given message id. In some cases a message
 %% has already been sent with information that subsumes the message associated with the given
 %% message id. In this case, `stale' is returned.
 -callback graft(any()) -> stale | {ok, any()} | {error, any()}.
 
-%% @doc trigger an exchange between the local handler and the handler on the given node.
+%% Trigger an exchange between the local handler and the handler on the given node.
 %% How the exchange is performed is not defined but it should be performed as a background
 %% process and ensure that it delivers any messages missing on either the local or remote node.
 %% The exchange does not need to account for messages in-flight when it is started or broadcast

--- a/src/riak_core_bucket_type.erl
+++ b/src/riak_core_bucket_type.erl
@@ -42,14 +42,14 @@
 %%   2. When the creation has propogated to all nodes, the type may be activated.
 %%      As the activation propogates, nodes will be able to use the type
 %%
-%% The first step is performed using {@see create/2}. The second by
-%% {@see activate/1}.  After the type has been activated, some
-%% properties may be updated using {@see update/2}. All operations are
+%% The first step is performed using {@link create/2}. The second by
+%% {@link activate/1}.  After the type has been activated, some
+%% properties may be updated using {@link update/2}. All operations are
 %% serialized through {@link riak_core_claimant} except reading bucket
-%% type properties with {@get/1}.
+%% type properties with {@link get/1}.
 %%
 %% Bucket types can be in one of four states. The
-%% state of a type can be queried using {@see status/1}.
+%% state of a type can be queried using {@link status/1}.
 %%
 %%   1. undefined - the type has not been created
 %%   2. created - the type has been created but has not propogated to all nodes
@@ -65,11 +65,11 @@
 %% {@link riak_core_claimant} to a new node -- ensuring concurrent
 %% updates do not break the invariant.
 %%
-%%   * calling {@see create/1} multiple times before a Bucket Type
+%%   * calling {@link create/1} multiple times before a Bucket Type
 %%     is active is allowed. The newer creation will supersede any
 %%     previous ones. In addition, the type will be "claimed" by the
 %%     {@link riak_core_claimant} node writing the property. Future
-%%     calls to {@see create/1} must be serialized through the same
+%%     calls to {@link create/1} must be serialized through the same
 %%     claimant node or the call will not succeed. In the case where
 %%     the claimed type fails to propogate to a new claimant during a
 %%     a failure the potential concurrent update is resolved with
@@ -77,9 +77,9 @@
 %%     safe.
 %%   * A type may only be activated if it is in the `ready' state. This means
 %%     all nodes must be reachable from the claimant
-%%   * {@see create/1} will fail if the type is active. Activation concurrent
+%%   * {@link create/1} will fail if the type is active. Activation concurrent
 %%     with creation is not possible due to the previous restriction
-%%   * {@see update/1} will fail unless the type is updated. {@see update/1} does
+%%   * {@link update/1} will fail unless the type is updated. {@link update/1} does
 %%     not allow modifications to properties for which the invariant must hold
 %%     (NOTE: this is up to the implementor of the riak_core bucket_validator).
 %%
@@ -145,7 +145,7 @@ defaults() ->
 %% function may be called arbitratily many times if the claimant does not change between
 %% calls and the type is not active. An error will also be returned if the properties
 %% are not valid. Properties not provided will be taken from those returned by
-%% {@see defaults/0}.
+%% @see defaults/0.
 -spec create(bucket_type(), bucket_type_props()) -> ok | {error, term()}.
 create(?DEFAULT_TYPE, _Props) ->
     {error, default_type};
@@ -186,7 +186,7 @@ get(BucketType) when is_binary(BucketType) ->
     riak_core_claimant:get_bucket_type(BucketType, undefined).
 
 %% @doc Reset the properties of the bucket. This only affects properties that
-%% can be set using {@see update/2} and can only be performed on an active
+%% can be set using {@link update/2} and can only be performed on an active
 %% type.
 -spec reset(bucket_type()) -> ok | {error, term()}.
 reset(BucketType) ->

--- a/src/riak_core_claimant.erl
+++ b/src/riak_core_claimant.erl
@@ -165,19 +165,19 @@ clear() ->
 ring_changed(Node, Ring) ->
     internal_ring_changed(Node, Ring).
 
-%% @doc {@see riak_core_bucket_type:create/2}
+%% @see riak_core_bucket_type:create/2
 -spec create_bucket_type(riak_core_bucket_type:bucket_type(), [{atom(), any()}]) ->
                                 ok | {error, term()}.
 create_bucket_type(BucketType, Props) ->
     gen_server:call(claimant(), {create_bucket_type, BucketType, Props}, infinity).
 
-%% @doc {@see riak_core_bucket_type:status/1}
+%% @see riak_core_bucket_type:status/1
 -spec bucket_type_status(riak_core_bucket_type:bucket_type()) ->
                                 undefined | created | ready | active.
 bucket_type_status(BucketType) ->
     gen_server:call(claimant(), {bucket_type_status, BucketType}, infinity).
 
-%% @doc {@see riak_core_bucket_type:activate/1}
+%% @see riak_core_bucket_type:activate/1
 -spec activate_bucket_type(riak_core_bucket_type:bucket_type()) ->
                                   ok | {error, undefined | not_ready}.
 activate_bucket_type(BucketType) ->
@@ -206,13 +206,13 @@ get_bucket_type(BucketType, Default, RequireActive) ->
         Props -> maybe_filter_inactive_type(RequireActive, Default, Props)
     end.
 
-%% @doc {@see riak_core_bucket_type:update/2}
+%% @see riak_core_bucket_type:update/2
 -spec update_bucket_type(riak_core_bucket_type:bucket_type(), [{atom(), any()}]) ->
                                 ok | {error, term()}.
 update_bucket_type(BucketType, Props) ->
     gen_server:call(claimant(), {update_bucket_type, BucketType, Props}).
 
-%% @doc {@see riak_core_bucket_type:iterator/0}
+%% @see riak_core_bucket_type:iterator/0
 -spec bucket_type_iterator() -> riak_core_metadata:iterator().
 bucket_type_iterator() ->
     riak_core_metadata:iterator(?BUCKET_TYPE_PREFIX, [{default, undefined},

--- a/src/riak_core_metadata.erl
+++ b/src/riak_core_metadata.erl
@@ -248,7 +248,7 @@ itr_values({It, Opts}) ->
 %% a resolver was specified in the options when creating this iterator, they will be
 %% resolved. Otherwise, and error is returned. If conflicts are resolved, the resolved
 %% value is written locally and a broadcast is performed to update other nodes
-%% in the cluster if `allow_put' is `true' (the default value). If `allow_put' is `false`,
+%% in the cluster if `allow_put' is `true' (the default value). If `allow_put' is `false',
 %% values are resolved but not written or broadcast.
 %%
 %% NOTE: if resolution may be performed this function must be called at most once

--- a/src/riak_core_metadata_exchange_fsm.erl
+++ b/src/riak_core_metadata_exchange_fsm.erl
@@ -248,7 +248,7 @@ merge(Peer, PKey, LocalObj) ->
     riak_core_metadata_manager:merge(Peer, {PKey, undefined}, LocalObj).
 
 
-%% @privarte
+%% @private
 repair_iterator(local, _, Prefix) when is_atom(Prefix) orelse is_binary(Prefix) ->
     riak_core_metadata_manager:iterator(Prefix);
 repair_iterator(local, _, Prefix) when is_tuple(Prefix) ->

--- a/src/riak_core_metadata_hashtree.erl
+++ b/src/riak_core_metadata_hashtree.erl
@@ -108,13 +108,15 @@ key_hashes(Node, Prefixes, Segment) ->
     gen_server:call({?SERVER, Node}, {key_hashes, Prefixes, Segment}, infinity).
 
 %% @doc Locks the tree on this node for updating on behalf of the
-%% calling process. {@see lock/2}
+%% calling process.
+%% @see lock/2
 -spec lock() -> ok | not_built | locked.
 lock() ->
     lock(node()).
 
 %% @doc Locks the tree on `Node' for updating on behalf of the calling
-%% process. {@see lock/2}.
+%% process.
+%% @see lock/2
 -spec lock(node()) -> ok | not_built | locked.
 lock(Node) ->
     lock(Node, self()).
@@ -128,7 +130,8 @@ lock(Node) ->
 lock(Node, Pid) ->
     gen_server:call({?SERVER, Node}, {lock, Pid}, infinity).
 
-%% @doc Updates the tree on this node. {@see update/1}.
+%% @doc Updates the tree on this node.
+%% @see update/1
 -spec update() -> ok | not_locked | not_built | ongoing_update.
 update() ->
     update(node()).
@@ -154,7 +157,7 @@ update(Node) ->
 %% found between the two trees. `HandlerAcc' is passed to the first
 %% invocation of `HandlerFun'. Subsequent calls are passed the return
 %% value from the previous call.  This function returns the return
-%% value from the last call to `HandlerFun'. {@see hashtree_tree} for
+%% value from the last call to `HandlerFun'. {@link hashtree_tree} for
 %% more details on `RemoteFun', `HandlerFun' and `HandlerAcc'.
 -spec compare(hashtree_tree:remote_fun(), hashtree_tree:handler_fun(X), X) -> X.
 compare(RemoteFun, HandlerFun, HandlerAcc) ->

--- a/src/riak_core_util.erl
+++ b/src/riak_core_util.erl
@@ -143,7 +143,7 @@ replace_file(FN, Data) ->
             {error, Err}
     end.
 
-%% @doc Similar to {@link file:read_file} but uses raw file I/O
+%% @doc Similar to {@link file:read_file/1} but uses raw file `I/O'
 read_file(FName) ->
     {ok, FD} = file:open(FName, [read, raw, binary]),
     IOList = read_file(FD, []),

--- a/src/vclock.erl
+++ b/src/vclock.erl
@@ -94,7 +94,9 @@ descends(Va, Vb) ->
 %% at least that of the given `dot()'. False otherwise. Call with a
 %% valid entry or you'll get an error.
 %%
-%% @see descends/2, get_entry/3, dominates/2
+%% @see descends/2
+%% @see get_entry/3
+%% @see dominates/2
 -spec descends_dot(vclock(), dot()) -> boolean().
 descends_dot(Vclock, Dot) ->
     descends(Vclock, [Dot]).

--- a/test/riak_core_schema_tests.erl
+++ b/test/riak_core_schema_tests.erl
@@ -36,7 +36,7 @@ basic_schema_test() ->
 %% in the schema are, in fact, reported as invalid.
 invalid_states_test() ->
     Conf = [
-        {["handoff", "ip"], "127.0.0.1"}
+        {["handoff", "ip"], "0.0.0.0.0"}
     ],
 
     Config = cuttlefish_unit:generate_templated_config("../priv/riak_core.schema", Conf, context()),
@@ -44,7 +44,7 @@ invalid_states_test() ->
     %% Confirm that we made it to validation and test that each expected failure
     %% message is present.
     cuttlefish_unit:assert_error_in_phase(Config, validation),
-    cuttlefish_unit:assert_error_message(Config, "handoff.ip invalid, must not be a loopback interface"),
+    cuttlefish_unit:assert_error_message(Config, "handoff.ip invalid, must be a valid IP address"),
     ok.
 
 

--- a/test/riak_core_schema_tests.erl
+++ b/test/riak_core_schema_tests.erl
@@ -18,6 +18,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_not_configured(Config, "riak_core.ssl.certfile"),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.ssl.keyfile"),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.ssl.cacertfile"),
+    cuttlefish_unit:assert_config(Config, "riak_core.handoff_ip", "0.0.0.0"),
     cuttlefish_unit:assert_config(Config, "riak_core.handoff_port", 8099 ),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.handoff_ssl_options"),
     cuttlefish_unit:assert_config(Config, "riak_core.dtrace_support", false),
@@ -53,6 +54,7 @@ override_schema_test() ->
         {["ssl", "certfile"], "/absolute/etc/cert.pem"},
         {["ssl", "keyfile"], "/absolute/etc/key.pem"},
         {["ssl", "cacertfile"], "/absolute/etc/cacertfile.pem"},
+        {["handoff", "ip"], "1.2.3.4"},
         {["handoff", "port"], 8888},
         {["handoff", "ssl", "certfile"], "/tmp/erlserver.pem"},
         {["handoff", "ssl", "keyfile"], "/tmp/erlkey/pem"},
@@ -77,6 +79,7 @@ override_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_core.ssl.certfile", "/absolute/etc/cert.pem"),
     cuttlefish_unit:assert_config(Config, "riak_core.ssl.keyfile", "/absolute/etc/key.pem"),
     cuttlefish_unit:assert_config(Config, "riak_core.ssl.cacertfile", "/absolute/etc/cacertfile.pem"),
+    cuttlefish_unit:assert_config(Config, "riak_core.handoff_ip", "1.2.3.4"),
     cuttlefish_unit:assert_config(Config, "riak_core.handoff_port", 8888),
     cuttlefish_unit:assert_config(Config, "riak_core.handoff_ssl_options.certfile", "/tmp/erlserver.pem"),
     cuttlefish_unit:assert_config(Config, "riak_core.handoff_ssl_options.keyfile", "/tmp/erlkey/pem"),
@@ -99,6 +102,7 @@ override_schema_test() ->
 %% in real life.
 context() ->
     [
+        {handoff_ip, "0.0.0.0"},
         {handoff_port, "8099"},
         {platform_bin_dir , "./bin"},
         {platform_data_dir, "./data"},

--- a/test/riak_core_schema_tests.erl
+++ b/test/riak_core_schema_tests.erl
@@ -32,6 +32,22 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_core.vnode_management_timer", 10000),
     ok.
 
+%% Tests that configurations which should be prohibited by validators defined
+%% in the schema are, in fact, reported as invalid.
+invalid_states_test() ->
+    Conf = [
+        {["handoff", "ip"], "127.0.0.1"}
+    ],
+
+    Config = cuttlefish_unit:generate_templated_config("../priv/riak_core.schema", Conf, context()),
+
+    %% Confirm that we made it to validation and test that each expected failure
+    %% message is present.
+    cuttlefish_unit:assert_error_in_phase(Config, validation),
+    cuttlefish_unit:assert_error_message(Config, "handoff.ip invalid, must not be a loopback interface"),
+    ok.
+
+
 default_bucket_properties_test() ->
     Conf = [
         {["buckets", "default", "n_val"], 5}

--- a/tools.mk
+++ b/tools.mk
@@ -1,5 +1,8 @@
 REBAR ?= ./rebar
 
+.PHONY: compile-no-deps test docs xref dialyzer-run dialyzer-quick dialyzer \
+		cleanplt
+
 compile-no-deps:
 	${REBAR} compile skip_deps=true
 


### PR DESCRIPTION
... bucket-key

Returns active preflist as 

``` erlang
[{{34,
  'dev5@127.0.0.1'},
  primary},
{{35,
  'dev6@127.0.0.1'},
  primary},
...]
```
### Description

Part of [RIAK-1481](https://bashoeng.atlassian.net/browse/RIAK-1481).

The active preflist will return primary/fallback partitions and nodes for the available nodes at the time of query. Primary/fallback will be annotated.
This involves updates to our RiakKV WB code, RiakPB, RiakCore, and RiakAPI.

*The impetus for adding this to the API started with a mailing list question answered by Charlie Voiselle, http://lists.basho.com/pipermail/riak-users_lists.basho.com/2015-January/016527.html, which involved a snippet of code that we've given clients multiple times. This was then discussed with Russell Brown on HipChat, https://basho.hipchat.com/history/room/867200/2015/01/13?q=enterprising&t=rid-867200#12:23:22.

Other PRs in the series:
- https://github.com/basho/riak_pb/pull/105
- https://github.com/basho/riak_api/pull/73
- https://github.com/basho/riak_kv/pull/1077
- https://github.com/basho/riak-erlang-http-client/pull/50
- https://github.com/basho/riak-erlang-client/pull/204
