### PR TITLE
active preflist on bucket key

### DIFF
--- a/src/riak_core_bucket.erl
+++ b/src/riak_core_bucket.erl
@@ -38,11 +38,15 @@
          name/1,
          n_val/1]).
 
+-export_type([bucket/0]).
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
 -define(METADATA_PREFIX, {core, buckets}).
+
+-type bucket() :: binary() | {riak_core_bucket_type:bucket_type(), binary()}.
 
 %% @doc Add a list of defaults to global list of defaults for new
 %%      buckets.  If any item is in Items is already set in the
@@ -55,7 +59,7 @@ append_bucket_defaults(Items) when is_list(Items) ->
 
 %% @doc Set the given BucketProps in Bucket or {BucketType, Bucket}. If BucketType does not
 %% exist, or is not active, {error, no_type} is returned.
--spec set_bucket(binary() | {riak_core_bucket_type:bucket_type(), binary()}, [{atom(), any()}]) ->
+-spec set_bucket(bucket(), [{atom(), any()}]) ->
                         ok | {error, no_type | [{atom(), atom()}]}.
 set_bucket({<<"default">>, Name}, BucketProps) ->
     set_bucket(Name, BucketProps);

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -135,7 +135,7 @@
          vnode_type/2,
          deletion_complete/3]).
 
--export_type([riak_core_ring/0]).
+-export_type([riak_core_ring/0, ring_size/0, partition_id/0]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -156,7 +156,7 @@
     claimant :: term(),
     seen     :: [{term(), vclock:vclock()}],
     rvsn     :: vclock:vclock()
-}). 
+}).
 
 %% Legacy chstate
 -record(chstate, {
@@ -164,19 +164,19 @@
     vclock,   % for this chstate object, entries are {Node, Ctr}
     chring :: chash:chash(),   % chash ring of {IndexAsInt, Node} mappings
     meta      % dict of cluster-wide other data (primarily bucket N-value, etc)
-}). 
+}).
 
 -type member_status() :: joining | valid | invalid | leaving | exiting | down.
 
 %% type meta_entry(). Record for each entry in #chstate.meta
 -record(meta_entry, {
     value,    % The value stored under this entry
-    lastmod   % The last modified time of this entry, 
+    lastmod   % The last modified time of this entry,
               %  from calendar:datetime_to_gregorian_seconds(
-              %                             calendar:universal_time()), 
+              %                             calendar:universal_time()),
 }).
 
-%% riak_core_ring() is the opaque data type used for partition ownership
+%% @type riak_core_ring() is the opaque data type used for partition ownership
 -type riak_core_ring() :: ?CHSTATE{}.
 -type chstate() :: riak_core_ring().
 
@@ -186,6 +186,11 @@
                         | {undefined, undefined, undefined}.
 
 -type resize_transfer() :: {{integer(),term()}, ordsets:ordset(node()), awaiting | complete}.
+
+-type ring_size() :: non_neg_integer().
+%% @type partition_id() (or partition number) -
+%% This integer represents a value in the range [0, ring_size-1].
+-type partition_id() :: non_neg_integer().
 
 %% ===================================================================
 %% Public API
@@ -345,7 +350,7 @@ fresh(NodeName) ->
 
 %% @doc Equivalent to fresh/1 but allows specification of the ring size.
 %%      Called by fresh/1, and otherwise only intended for testing purposes.
--spec fresh(RingSize :: integer(), NodeName :: term()) -> chstate().
+-spec fresh(ring_size(), NodeName :: term()) -> chstate().
 fresh(RingSize, NodeName) ->
     VClock=vclock:increment(NodeName, vclock:fresh()),
     GossipVsn = riak_core_gossip:gossip_version(),
@@ -363,7 +368,7 @@ fresh(RingSize, NodeName) ->
 %% @doc change the size of the ring to `NewRingSize'. If the ring
 %%      is larger than the current ring any new indexes will be owned
 %%      by a dummy host
--spec resize(chstate(), pos_integer()) -> chstate().
+-spec resize(chstate(), ring_size()) -> chstate().
 resize(State, NewRingSize) ->
     NewRing = lists:foldl(fun({Idx,Owner}, RingAcc) ->
                                   chash:update(Idx, Owner, RingAcc)
@@ -373,9 +378,9 @@ resize(State, NewRingSize) ->
     set_chash(State, NewRing).
 
 % @doc Return a value from the cluster metadata dict
--spec get_meta(Key :: term(), State :: chstate()) -> 
+-spec get_meta(Key :: term(), State :: chstate()) ->
     {ok, term()} | undefined.
-get_meta(Key, State) -> 
+get_meta(Key, State) ->
     case dict:find(Key, State?CHSTATE.meta) of
         error -> undefined;
         {ok, '$removed'} -> undefined;
@@ -495,7 +500,7 @@ reconcile(ExternState, MyState) ->
     check_tainted(ExternState,
                   "Error: riak_core_ring/reconcile :: "
                   "reconciling tainted external ring"),
-    check_tainted(MyState, 
+    check_tainted(MyState,
                   "Error: riak_core_ring/reconcile :: "
                   "reconciling tainted internal ring"),
     case internal_reconcile(MyState, ExternState) of
@@ -515,7 +520,7 @@ rename_node(State=?CHSTATE{chring=Ring, nodename=ThisNode, members=Members,
       chring=lists:foldl(
                fun({Idx, Owner}, AccIn) ->
                        case Owner of
-                           OldNode -> 
+                           OldNode ->
                                chash:update(Idx, NewNode, AccIn);
                            _ -> AccIn
                        end
@@ -639,7 +644,7 @@ update_meta(Key, Val, State) ->
                      true
              end,
     if Change ->
-            M = #meta_entry { 
+            M = #meta_entry {
               lastmod = calendar:datetime_to_gregorian_seconds(
                           calendar:universal_time()),
               value = Val
@@ -726,7 +731,7 @@ get_member_meta(State, Member, Key) ->
                     Value
             end
     end.
-    
+
 %% @doc Set a key in the member metadata orddict
 update_member_meta(Node, State, Member, Key, Val) ->
     VClock = vclock:increment(Node, State?CHSTATE.vclock),
@@ -1241,7 +1246,7 @@ ring_ready_info(State0) ->
                                    and lists:member(Node, Members)
                        end, Seen),
     Outdated.
-    
+
 %% @doc Marks a pending transfer as completed.
 -spec handoff_complete(State :: chstate(), Idx :: integer(),
                        Mod :: module()) -> chstate().
@@ -1363,7 +1368,7 @@ cancel_transfers(Ring) ->
 %% @doc Incorporate another node's state into our view of the Riak world.
 legacy_reconcile(ExternState, MyState) ->
     case vclock:equal(MyState#chstate.vclock, vclock:fresh()) of
-        true -> 
+        true ->
             {new_ring, #chstate{nodename=MyState#chstate.nodename,
                                 vclock=ExternState#chstate.vclock,
                                 chring=ExternState#chstate.chring,
@@ -1381,7 +1386,7 @@ legacy_reconcile(ExternState, MyState) ->
                                       meta=ExternState#chstate.meta}};
                         false -> {no_change, MyState}
                     end;
-                [] -> 
+                [] ->
                     case legacy_equal_rings(ExternState,MyState) of
                         true -> {no_change, MyState};
                         false -> {new_ring,
@@ -1450,7 +1455,7 @@ pick_val(M1,M2) ->
     case M1#meta_entry.lastmod > M2#meta_entry.lastmod of
         true -> M1;
         false -> M2
-    end.                   
+    end.
 
 %% @private
 internal_reconcile(State, OtherState) ->
@@ -1852,7 +1857,7 @@ rename_test() ->
     ?assertEqual('new@new', owner_node(Ring)),
     ?assertEqual(['new@new'], all_members(Ring)).
 
-exclusion_test() ->    
+exclusion_test() ->
     Ring0 = fresh(2, node()),
     Ring1 = transfer_node(0,x,Ring0),
     ?assertEqual(0, random_other_index(Ring1,[730750818665451459101842416358141509827966271488])),
@@ -1877,7 +1882,7 @@ membership_test() ->
 
     RingA4 = remove_member(nodeA, RingA3, nodeC),
     ?assertEqual([nodeA, nodeB], all_members(RingA4)),
-    
+
     %% Node should stay removed
     {_, RingA5} = reconcile(RingA3, RingA4),
     ?assertEqual([nodeA, nodeB], all_members(RingA5)),
@@ -1926,7 +1931,7 @@ membership_test() ->
      end || {StatusA, _} <- Priority,
             {StatusB, _} <- Priority],
     ok.
-    
+
 ring_version_test() ->
     Ring1 = fresh(nodeA),
     Ring2 = add_member(node(), Ring1, nodeA),

--- a/src/riak_core_ring_util.erl
+++ b/src/riak_core_ring_util.erl
@@ -29,8 +29,6 @@
          partition_id_to_hash/2,
          hash_is_partition_boundary/2]).
 
--export_type([partition_id/0]).
-
 -ifdef(TEST).
 -ifdef(EQC).
 -export([prop_ids_are_boundaries/0, prop_reverse/0,
@@ -40,9 +38,6 @@
 -endif.
 -include_lib("eunit/include/eunit.hrl").
 -endif.
-
--type partition_id() :: non_neg_integer().
-%% This integer represents a value in the range [0, ring_size)
 
 %% @doc Forcibly assign a partition to a specific node
 assign(Partition, ToNode) ->
@@ -76,8 +71,8 @@ check_ring(Ring, Nval) ->
                 end, [], Preflists).
 
 -spec hash_to_partition_id(chash:index() | chash:index_as_int(),
-                           pos_integer()) ->
-                                  partition_id().
+                           riak_core_ring:ring_size()) ->
+                                  riak_core_ring:partition_id().
 %% @doc Map a key hash (as binary or integer) to a partition ID [0, ring_size)
 hash_to_partition_id(CHashKey, RingSize) when is_binary(CHashKey) ->
     <<CHashInt:160/integer>> = CHashKey,
@@ -85,7 +80,8 @@ hash_to_partition_id(CHashKey, RingSize) when is_binary(CHashKey) ->
 hash_to_partition_id(CHashInt, RingSize) ->
     CHashInt div chash:ring_increment(RingSize).
 
--spec partition_id_to_hash(partition_id(), pos_integer()) -> chash:index_as_int().
+-spec partition_id_to_hash(riak_core_ring:partition_id(), pos_integer()) ->
+                                  chash:index_as_int().
 %% @doc Identify the first key hash (integer form) in a partition ID [0, ring_size)
 partition_id_to_hash(Id, RingSize) ->
     Id * chash:ring_increment(RingSize).


### PR DESCRIPTION
Returns active preflist as 

``` erlang
[{{34,
  'dev5@127.0.0.1'},
  primary},
{{35,
  'dev6@127.0.0.1'},
  primary},
...]
```
### Description

Part of [RIAK-1481](https://bashoeng.atlassian.net/browse/RIAK-1481).

The active preflist will return primary/fallback partitions and nodes for the available nodes at the time of query. Primary/fallback will be annotated.
This involves updates to our RiakKV WB code, RiakPB, RiakCore, and RiakAPI.

*The impetus for adding this to the API started with a mailing list question answered by Charlie Voiselle, http://lists.basho.com/pipermail/riak-users_lists.basho.com/2015-January/016527.html, which involved a snippet of code that we've given clients multiple times. This was then discussed with Russell Brown on HipChat, https://basho.hipchat.com/history/room/867200/2015/01/13?q=enterprising&t=rid-867200#12:23:22.

Other PRs in the series:
- https://github.com/basho/riak_pb/pull/105
- https://github.com/basho/riak_api/pull/75
- https://github.com/basho/riak_kv/pull/1083
- https://github.com/basho/riak-erlang-http-client/pull/50
- https://github.com/basho/riak-erlang-client/pull/204
