### PR TITLE
Update rebar versions of eleveldb, riak_sysmon and riak_ensemble

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,10 +13,10 @@
   {lager, "2.0.3", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
   {poolboy, ".*", {git, "git://github.com/basho/poolboy.git", {tag, "0.8.1p3"}}},
   {basho_stats, ".*", {git, "git://github.com/basho/basho_stats.git", {tag, "1.0.3"}}},
-  {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon.git", {branch, "develop"}}},
-  {riak_ensemble, ".*", {git, "git://github.com/basho/riak_ensemble", {branch, "develop"}}},
+  {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon.git", {tag, "2.0.1"}}},
+  {riak_ensemble, ".*", {git, "git://github.com/basho/riak_ensemble", {tag, "2.0.1"}}},
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
-  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "develop"}}},
+  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.2"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho2"}}},
   {clique, ".*", {git, "git://github.com/basho/clique.git", {tag, "0.2.5"}}}
 ]}.


### PR DESCRIPTION
Now `riak_sysmon` is tied to the **2.0.1** tag, `riak_ensemble` is tied to the **2.0.1** tag and `eleveldb` is tied to **2.0.2**
