### PR TITLE
Add riak_core_ring_manager:is_stable_ring/0 public API [JIRA: RIAK-1598]

### DIFF
--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -639,7 +639,7 @@ is_stable_ring(#state{ring_changed_time=Then}) ->
     DeltaUS = erlang:max(0, timer:now_diff(os:timestamp(), Then)),
     DeltaMS = DeltaUS div 1000,
     IsStable = DeltaMS >= ?PROMOTE_TIMEOUT,
-    {IsStable,DeltaMS}.
+    {IsStable, DeltaMS}.
 
 %% ===================================================================
 %% Unit tests

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -84,7 +84,8 @@
          ring_trans/2,
          run_fixups/3,
          set_cluster_name/1,
-         stop/0]).
+         stop/0,
+         is_stable_ring/0]).
 
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
         terminate/2, code_change/3]).
@@ -211,6 +212,9 @@ ring_trans(Fun, Args) ->
 
 set_cluster_name(Name) ->
     gen_server:call(?MODULE, {set_cluster_name, Name}, infinity).
+
+is_stable_ring() ->
+    gen_server:call(?MODULE, is_stable_ring, infinity).
 
 %% @doc Exposed for support/debug purposes. Forces the node to change its
 %%      ring in a manner that will trigger reconciliation on gossip.
@@ -406,7 +410,10 @@ handle_call({ring_trans, Fun, Args}, _From, State=#state{raw_ring=Ring}) ->
 handle_call({set_cluster_name, Name}, _From, State=#state{raw_ring=Ring}) ->
     NewRing = riak_core_ring:set_cluster_name(Ring, Name),
     State2 = prune_write_notify_ring(NewRing, State),
-    {reply, ok, State2}.
+    {reply, ok, State2};
+handle_call(is_stable_ring, _From, State) ->
+    {IsStable,_DeltaMS} = is_stable_ring(State),
+    {reply, IsStable, State}.
 
 handle_cast(stop, State) ->
     {stop,normal,State};
@@ -431,16 +438,14 @@ handle_cast(write_ringfile, State=#state{raw_ring=Ring}) ->
     {noreply,State}.
 
 
-handle_info(inactivity_timeout, State=#state{ring_changed_time=Then}) ->
-    DeltaUS = erlang:max(0, timer:now_diff(os:timestamp(), Then)),
-    DeltaMS = DeltaUS div 1000,
-    case DeltaMS >= ?PROMOTE_TIMEOUT of
-        true ->
+handle_info(inactivity_timeout, State) ->
+    case is_stable_ring(State) of
+        {true,DeltaMS} ->
             lager:debug("Promoting ring after ~p", [DeltaMS]),
             promote_ring(),
             State2 = State#state{inactivity_timer=undefined},
             {noreply, State2};
-        false ->
+        {false,DeltaMS} ->
             Remaining = ?PROMOTE_TIMEOUT - DeltaMS,
             State2 = set_timer(Remaining, State),
             {noreply, State2}
@@ -629,6 +634,12 @@ prune_write_ring(Ring, State) ->
     _ = do_write_ringfile(Ring),
     State2 = set_ring(Ring, State),
     State2.
+
+is_stable_ring(_State=#state{ring_changed_time=Then}) ->
+    DeltaUS = erlang:max(0, timer:now_diff(os:timestamp(), Then)),
+    DeltaMS = DeltaUS div 1000,
+    IsStable = DeltaMS >= ?PROMOTE_TIMEOUT,
+    {IsStable,DeltaMS}.
 
 %% ===================================================================
 %% Unit tests

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -635,7 +635,7 @@ prune_write_ring(Ring, State) ->
     State2 = set_ring(Ring, State),
     State2.
 
-is_stable_ring(_State=#state{ring_changed_time=Then}) ->
+is_stable_ring(#state{ring_changed_time=Then}) ->
     DeltaUS = erlang:max(0, timer:now_diff(os:timestamp(), Then)),
     DeltaMS = DeltaUS div 1000,
     IsStable = DeltaMS >= ?PROMOTE_TIMEOUT,

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -412,7 +412,7 @@ handle_call({set_cluster_name, Name}, _From, State=#state{raw_ring=Ring}) ->
     State2 = prune_write_notify_ring(NewRing, State),
     {reply, ok, State2};
 handle_call(is_stable_ring, _From, State) ->
-    {IsStable,_DeltaMS} = is_stable_ring(State),
+    {IsStable, _DeltaMS} = is_stable_ring(State),
     {reply, IsStable, State}.
 
 handle_cast(stop, State) ->

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -732,5 +732,14 @@ do_write_ringfile_test() ->
     ?assertMatch({error,_}, do_write_ringfile(GenR(ring_perms), ?TEST_RINGFILE)),
     ok = file:change_mode(?TEST_RINGDIR, 8#00755).
 
--endif.
+is_stable_ring_test() ->
+    % This test is efferently coupled to the PROMOTE_TIMEOUT macro value
+    {A,B,C} = Now = os:timestamp(),
+    Within = {A,B-45,C},
+    Outside = {A,B-90,C},
+    ?assertMatch({true,_},is_stable_ring(#state{ring_changed_time={0,0,0}})),
+    ?assertMatch({true,_},is_stable_ring(#state{ring_changed_time=Outside})),
+    ?assertMatch({false,_},is_stable_ring(#state{ring_changed_time=Within})),
+    ?assertMatch({false,_},is_stable_ring(#state{ring_changed_time=Now})).
 
+-endif.

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -733,7 +733,7 @@ do_write_ringfile_test() ->
     ok = file:change_mode(?TEST_RINGDIR, 8#00755).
 
 is_stable_ring_test() ->
-    % This test is efferently coupled to the PROMOTE_TIMEOUT macro value
+    % This test is coupled to the PROMOTE_TIMEOUT macro value
     {A,B,C} = Now = os:timestamp(),
     Within = {A,B-45,C},
     Outside = {A,B-90,C},

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -733,10 +733,10 @@ do_write_ringfile_test() ->
     ok = file:change_mode(?TEST_RINGDIR, 8#00755).
 
 is_stable_ring_test() ->
-    % This test is coupled to the PROMOTE_TIMEOUT macro value
     {A,B,C} = Now = os:timestamp(),
-    Within = {A,B-45,C},
-    Outside = {A,B-90,C},
+    TimeoutSecs = ?PROMOTE_TIMEOUT div 1000,
+    Within = {A, B - (TimeoutSecs div 2), C},
+    Outside = {A, B - (TimeoutSecs + 1), C},
     ?assertMatch({true,_},is_stable_ring(#state{ring_changed_time={0,0,0}})),
     ?assertMatch({true,_},is_stable_ring(#state{ring_changed_time=Outside})),
     ?assertMatch({false,_},is_stable_ring(#state{ring_changed_time=Within})),


### PR DESCRIPTION
The status of a ring as stable (no topology change in a promotion period) or not is of general utility.
This patch proposes to refactor the predicate check into a public API so that it can be made more
generally useful.
