### PR TITLE
Bump clique to 0.2.6

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,5 +18,5 @@
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.2"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho2"}}},
-  {clique, ".*", {git, "git://github.com/basho/clique.git", {tag, "0.2.5"}}}
+  {clique, "0.2.6", {git, "git://github.com/basho/clique.git", {tag, "0.2.6"}}}
 ]}.


### PR DESCRIPTION
This pulls in the JSON writer, proportional table resizing, and a type spec fix.
