### PR TITLE
Be more tolerant of lager dependency version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
 {xref_queries, [{"(XC - UC) || (XU - X - B - \"(cluster_info|dtrace)\" : Mod)", []}]}.
 
 {deps, [
-  {lager, "2.0.3", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
+  {lager, "2.*", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
   {poolboy, ".*", {git, "git://github.com/basho/poolboy.git", {tag, "0.8.1p3"}}},
   {basho_stats, ".*", {git, "git://github.com/basho/basho_stats.git", {tag, "1.0.3"}}},
   {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon.git", {tag, "2.0.1"}}},


### PR DESCRIPTION
Currently riak_core enforces lager 2.0.3 and projects needing lager 2.1.0 have to go through workarounds.
The main benefit of the newer version is the support of maps, which riak_core currently doesn't use much, so there is little need in changing the source tag version.
