### PR TITLE
Cache the regnames created in the vnode proxy in an ets table

### DIFF
--- a/src/riak_core_vnode_proxy_sup.erl
+++ b/src/riak_core_vnode_proxy_sup.erl
@@ -31,6 +31,11 @@ init([]) ->
     VMods = riak_core:vnode_modules(),
     Proxies = [proxy_ref(Mod, Index) || {_, Mod} <- VMods,
                                         Index <- Indices],
+    %% Create ets table for caching the proxy process registered
+    %% names. See riak_core_vnode_proxy:reg_name/2,3.
+    riak_core_vnode_proxy = ets:new(riak_core_vnode_proxy,
+                                    [set, public, named_table,
+                                     {read_concurrency, true}]),
     {ok, {{one_for_one, 5, 10}, Proxies}}.
 
 start_proxy(Mod, Index) ->


### PR DESCRIPTION
Identified as a hotspot in the write-once path for riak_kv. Even in the 
previously optimized version, calling reg_name often enough to identify vnode
proxy processes can consume more time per-call than an ets lookup on a public
table. This amortizes the cost by caching the computed atom in ets, making the
penalty on miss higher than the original computation but names will be
computed fewer times overall.
