### PR TITLE
Set dependency on eleveldb 2.1.0.0 tag.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
   {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon.git", {tag, "2.0.1"}}},
   {riak_ensemble, ".*", {git, "git://github.com/basho/riak_ensemble", {tag, "2.0.1"}}},
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
-  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.2"}}},
+  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.1.0.0"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho2"}}},
   {clique, "0.2.6", {git, "git://github.com/basho/clique.git", {tag, "0.2.6"}}}
 ]}.


### PR DESCRIPTION
This is to pull in the latest tagged version of eleveldb, which has the async_put operations for the write_once path.

Note that I left the rebar VsnRegex ".*".
