### PR TITLE
provide behaviour info for riak_core_vnode_worker with -callbacks

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -14,6 +14,3 @@ riak_core_gossip.erl:245: The pattern 'true' can never match the type 'false'
 riak_core_ring_handler.erl:73: The pattern {'true', _, _, _} can never match the type {'false',boolean(),[integer()],'down' | 'exiting' | 'invalid' | 'joining' | 'leaving' | 'valid'}
 riak_core_claimant.erl:407: The pattern {'legacy', _} can never match the type {'error','invalid_resize_claim'} | {'ok',{'chstate_v2',_,'undefined' | [any()],{_,_},'undefined' | dict:dict(_,_),'undefined' | {_,_},'undefined' | [any()],[any()],_,'undefined' | [any()],'undefined' | [any()]}}
 riak_core_claimant.erl:913: The pattern {'legacy', _} can never match the type {'error','invalid_resize_claim'} | {'ok',{'chstate_v2',_,'undefined' | [any()],{_,_},'undefined' | dict:dict(_,_),'undefined' | {_,_},'undefined' | [any()],[any()],_,'undefined' | [any()],'undefined' | [any()]}}
-Unknown functions:
-  cluster_info:format/3
-  cluster_info:register_app/1

--- a/rebar.config
+++ b/rebar.config
@@ -15,6 +15,7 @@
   {basho_stats, ".*", {git, "git://github.com/basho/basho_stats.git", {tag, "1.0.3"}}},
   {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon.git", {tag, "2.0.1"}}},
   {riak_ensemble, ".*", {git, "git://github.com/basho/riak_ensemble", {tag, "2.1.0"}}},
+  {cluster_info, ".*", {git, "git://github.com/basho/cluster_info.git", {branch, "develop"}}},
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.1.0"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho2"}}},

--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -3,7 +3,7 @@
 %% riak_core_coverage_fsm: Distribute work to a covering set of VNodes.
 %%
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -67,8 +67,6 @@
 -behaviour(gen_fsm).
 
 %% API
--export([behaviour_info/1]).
-
 -export([start_link/3]).
 
 -ifdef(TEST).
@@ -87,15 +85,16 @@
          terminate/3,
          code_change/4]).
 
--spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
-behaviour_info(callbacks) ->
-    [
-     {init, 2},
-     {process_results, 2},
-     {finish, 2}
-    ];
-behaviour_info(_) ->
-    undefined.
+-callback init(from(), Args::list()) -> State::term().
+%% In the several riak_kv_*_fsm where this behaviour is used,
+%% process_results has arity 2 or 3, with all but the last arg being
+%% too specific for particular modules, so let's not legislate what
+%% types those args should be.
+-callback process_results(Arg1::term(), State::term()) ->
+    {done, State::term()} | {error, term()} | {ok, State::term()}.
+-callback finish({error, term()}|clean, State::term()) ->
+    {stop, normal, State::term()}.
+
 
 -define(DEFAULT_TIMEOUT, 60000*8).
 

--- a/src/riak_core_vnode_worker.erl
+++ b/src/riak_core_vnode_worker.erl
@@ -1,5 +1,5 @@
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -20,10 +20,11 @@
 
 -behaviour(gen_server).
 
--export([behaviour_info/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
         code_change/3]).
 -export([start_link/1, handle_work/3, handle_work/4]).
+
+-include("riak_core_vnode.hrl").
 
 -ifdef(PULSE).
 -compile(export_all).
@@ -37,12 +38,14 @@
         modstate :: any()
     }).
 
--spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
-behaviour_info(callbacks) ->
-    [{init_worker,3},
-     {handle_work,3}];
-behaviour_info(_Other) ->
-    undefined.
+-callback init_worker(VNodeIndex::partition(),
+                      Args::list(), Props::proplists:proplist()) ->
+    {ok, State::term()}.
+-callback handle_work({Op::atom(),
+                       FoldFun::function(), FinishFun::function()},
+                      _Sender::pid(), State::term()) ->
+    {noreply, State::term()}.
+
 
 start_link(Args) ->
     WorkerMod = proplists:get_value(worker_callback_mod, Args),


### PR DESCRIPTION
For some reason, dialyzer fails to use exported behaviour_info/1 and
goes on to emit warnings in riak_kv.  But it works fine with callback
specs expressly provided.
