### PR TITLE
The default cli schema is located in riak_core/priv

### DIFF
--- a/src/riak_core_cli_registry.erl
+++ b/src/riak_core_cli_registry.erl
@@ -50,5 +50,5 @@ load_schema() ->
         {ok, Directories} ->
             ok = clique_config:load_schema(Directories);
         _ ->
-            ok = clique_config:load_schema([code:lib_dir()])
+            ok = clique_config:load_schema([code:priv_dir(riak_core)])
     end.


### PR DESCRIPTION
When not configuring schema_dirs the riak_core app can not start. The code that is suppose to handle the case seems to point to the wrong location. There is a riak_core.schema in riak_core/priv. I assumed that this is the one that should be used as a default.
