### PR TITLE
Revert typo.

### DIFF
--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -83,7 +83,7 @@ join(_, Node, Rejoin, Auto) ->
     end.
 
 get_other_ring(Node) ->
-    riak_core_util:safe_rpc(Node, riak_core_ring_manager, get_my_ring, []).
+    riak_core_util:safe_rpc(Node, riak_core_ring_manager, get_raw_ring, []).
 
 standard_join(Node, Rejoin, Auto) when is_atom(Node) ->
     case net_adm:ping(Node) of


### PR DESCRIPTION
Revert a typo introduced by 727fa776334e262b79eb38f2cd9ddca494b91565, where the wrong ring is selected and returned.  This results certain test configurations dumping hundreds of tainted ring errors into the log.

```
2015-06-03 14:02:04.865 [error] <0.135.0>@riak_core_ring:check_tainted:209 Error: riak_core_ring/ring_ready called on tainted ring 
2015-06-03 14:02:04.865 [info] <0.135.0>@riak_core_gossip:log_node_added:354 'dev2@127.0.0.1' joined cluster with status 'joining' 
2015-06-03 14:02:04.865 [error] <0.135.0>@riak_core_ring:check_tainted:209 Error: Persisting tainted ring
```
