### PR TITLE
Use unsized, typeless, tuple to fix OTP 18 compilation

### DIFF
--- a/src/chashbin.erl
+++ b/src/chashbin.erl
@@ -37,7 +37,7 @@
 
 -record(chashbin, {size   :: pos_integer(),
                    owners :: owners_bin(),
-                   nodes  :: tuple(node())}).
+                   nodes  :: tuple()}).
 
 -type chashbin() :: #chashbin{}.
 


### PR DESCRIPTION
This patch fixes compilation for OTP 18.

There's currently no method of specifying a tuple of arbitrary size of type T.
