### PR TITLE
Update riak_core to use clique 0.3.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,5 +18,5 @@
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.1.0"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho2"}}},
-  {clique, "0.2.6", {git, "git://github.com/basho/clique.git", {tag, "0.2.6"}}}
+  {clique, "0.3.0", {git, "git://github.com/basho/clique.git", {tag, "0.3.0"}}}
 ]}.

--- a/src/riak_core_cluster_cli.erl
+++ b/src/riak_core_cluster_cli.erl
@@ -91,7 +91,7 @@ claim_percent(Ring, Node) ->
     Indices = riak_core_ring:indices(Ring, Node),
     io_lib:format("~5.1f", [length(Indices) * 100 / RingSize]).
 
-status(_, [], []) ->
+status(_CmdBase, [], []) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     RingStatus = riak_core_status:ring_status(),
     %% {Claimant, RingReady, Down, MarkedDown, Changes} = RingStatus
@@ -153,12 +153,12 @@ partition_count_usage() ->
      "      This flag can currently take only one node and be used once\n"
     ].
 
-partition_count(_, [], [{node, Node}]) ->
+partition_count(_CmdBase, [], [{node, Node}]) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     Indices = riak_core_ring:indices(Ring, Node),
     Row = [[{node, Node}, {partitions, length(Indices)}, {pct, claim_percent(Ring, Node)}]],
     [clique_status:table(Row)];
-partition_count(_, [], []) ->
+partition_count(_CmdBase, [], []) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     [clique_status:text(
          io_lib:format("Cluster-wide partition-count: ~p",
@@ -186,9 +186,9 @@ partitions_usage() ->
      "      This flag can currently take only one node and be used once\n"
     ].
 
-partitions(_, [], [{node, Node}]) ->
+partitions(_CmdBase, [], [{node, Node}]) ->
     partitions_output(Node);
-partitions(_, [], []) ->
+partitions(_CmdBase, [], []) ->
     partitions_output(node()).
 
 partitions_output(Node) ->
@@ -229,14 +229,14 @@ partition_usage() ->
      "  Display the id for the provided index, or index for the ",
      "specified id.\n"].
 
-partition(_, [{index, Index}], []) when Index >= 0 ->
+partition(_CmdBase, [{index, Index}], []) when Index >= 0 ->
     id_out(index, Index);
-partition(_, [{id, Id}], []) when Id >= 0 ->
+partition(_CmdBase, [{id, Id}], []) when Id >= 0 ->
     id_out(id, Id);
-partition(_, [{Op, Value}], []) ->
+partition(_CmdBase, [{Op, Value}], []) ->
     [make_alert(["ERROR: The given value ", integer_to_list(Value),
                 " for ", atom_to_list(Op), " is invalid."])];
-partition(_, [], []) ->
+partition(_CmdBase, [], []) ->
     clique_status:usage().
 
 id_out(InputType, Number) ->

--- a/src/riak_core_handoff_cli.erl
+++ b/src/riak_core_handoff_cli.erl
@@ -143,13 +143,13 @@ details_usage() ->
      "      Display the handoffs on every node in the cluster\n"
     ].
 
-handoff_config(_, _Args, Flags) when length(Flags) > 1 ->
+handoff_config(_CmdBase, _Args, Flags) when length(Flags) > 1 ->
     [clique_status:text("Can't specify both --all and --node flags")];
-handoff_config(_, _Args, []) ->
+handoff_config(_CmdBase, _Args, []) ->
     clique_config:show(config_vars(), []);
-handoff_config(_, _Args, [{all, Val}]) ->
+handoff_config(_CmdBase, _Args, [{all, Val}]) ->
     clique_config:show(config_vars(), [{all, Val}]);
-handoff_config(_, _Args, [{node, Node}]) ->
+handoff_config(_CmdBase, _Args, [{node, Node}]) ->
     clique_config:show(config_vars(), [{node, Node}]).
 
 config_vars() ->

--- a/src/riak_core_handoff_cli.erl
+++ b/src/riak_core_handoff_cli.erl
@@ -34,12 +34,12 @@ register_cli() ->
 
 register_cli_cmds() ->
     register_enable_disable_commands(),
-    clique:register_command(["riak-admin", "handoff", "summary"], [], [],
-                             fun riak_core_handoff_status:handoff_summary/2),
-    clique:register_command(["riak-admin", "handoff", "details"], [],
-                             node_and_all_flags(), fun riak_core_handoff_status:handoff_details/2),
-    clique:register_command(["riak-admin", "handoff", "config"], [],
-                              node_and_all_flags(), fun handoff_config/2).
+    ok = clique:register_command(["riak-admin", "handoff", "summary"], [], [],
+                                 fun riak_core_handoff_status:handoff_summary/3),
+    ok = clique:register_command(["riak-admin", "handoff", "details"], [],
+                                 node_and_all_flags(), fun riak_core_handoff_status:handoff_details/3),
+    ok = clique:register_command(["riak-admin", "handoff", "config"], [],
+                                 node_and_all_flags(), fun handoff_config/3).
 
 node_and_all_flags() ->
     [{node, [{shortname, "n"}, {longname, "node"},
@@ -112,7 +112,7 @@ handoff_enable_disable_usage() ->
 
 handoff_cmd_spec(EnOrDis, Direction) ->
     Cmd = ["riak-admin", "handoff", atom_to_list(EnOrDis), atom_to_list(Direction)],
-    Callback = fun([], Flags) ->
+    Callback = fun(_, [], Flags) ->
                        handoff_change_enabled_setting(EnOrDis, Direction, Flags)
                end,
     [
@@ -143,13 +143,13 @@ details_usage() ->
      "      Display the handoffs on every node in the cluster\n"
     ].
 
-handoff_config(_Args, Flags) when length(Flags) > 1 ->
+handoff_config(_, _Args, Flags) when length(Flags) > 1 ->
     [clique_status:text("Can't specify both --all and --node flags")];
-handoff_config(_Args, []) ->
+handoff_config(_, _Args, []) ->
     clique_config:show(config_vars(), []);
-handoff_config(_Args, [{all, Val}]) ->
+handoff_config(_, _Args, [{all, Val}]) ->
     clique_config:show(config_vars(), [{all, Val}]);
-handoff_config(_Args, [{node, Node}]) ->
+handoff_config(_, _Args, [{node, Node}]) ->
     clique_config:show(config_vars(), [{node, Node}]).
 
 config_vars() ->

--- a/src/riak_core_handoff_status.erl
+++ b/src/riak_core_handoff_status.erl
@@ -21,8 +21,8 @@
 
 -include("riak_core_handoff.hrl").
 
--export([handoff_summary/2,
-         handoff_details/2,
+-export([handoff_summary/3,
+         handoff_details/3,
          collect_node_transfer_data/0]).
 
 -define(ORDERED_TRANSFERS_FOR_DISPLAY,
@@ -32,18 +32,18 @@
 %%%%%%
 %% clique callbacks
 
--spec handoff_summary([tuple()], [tuple()]) -> clique_status:status().
-handoff_summary([], []) ->
+-spec handoff_summary([string()], [tuple()], [tuple()]) -> clique_status:status().
+handoff_summary(_, [], []) ->
     node_summary().
 
--spec handoff_details([tuple()], [tuple()]) -> clique_status:status().
-handoff_details([], []) ->
+-spec handoff_details([string()], [tuple()], [tuple()]) -> clique_status:status().
+handoff_details(_, [], []) ->
     build_handoff_details(node());
-handoff_details([], [{node, Node}]) ->
+handoff_details(_, [], [{node, Node}]) ->
     build_handoff_details(Node);
-handoff_details([], [{all, _Value}]) ->
+handoff_details(_, [], [{all, _Value}]) ->
     build_handoff_details(all);
-handoff_details([], _) ->
+handoff_details(_, [], _) ->
     [clique_status:alert([clique_status:text("Cannot use both --all and --node flags at the same time.")])].
 
 %% end of clique callbacks

--- a/src/riak_core_handoff_status.erl
+++ b/src/riak_core_handoff_status.erl
@@ -33,17 +33,17 @@
 %% clique callbacks
 
 -spec handoff_summary([string()], [tuple()], [tuple()]) -> clique_status:status().
-handoff_summary(_, [], []) ->
+handoff_summary(_CmdBase, [], []) ->
     node_summary().
 
 -spec handoff_details([string()], [tuple()], [tuple()]) -> clique_status:status().
-handoff_details(_, [], []) ->
+handoff_details(_CmdBase, [], []) ->
     build_handoff_details(node());
-handoff_details(_, [], [{node, Node}]) ->
+handoff_details(_CmdBase, [], [{node, Node}]) ->
     build_handoff_details(Node);
-handoff_details(_, [], [{all, _Value}]) ->
+handoff_details(_CmdBase, [], [{all, _Value}]) ->
     build_handoff_details(all);
-handoff_details(_, [], _) ->
+handoff_details(_CmdBase, [], _) ->
     [clique_status:alert([clique_status:text("Cannot use both --all and --node flags at the same time.")])].
 
 %% end of clique callbacks


### PR DESCRIPTION
Clique 0.3.0 introduces an extra argument that's passed to the command callbacks. The existing code in riak_core that uses clique doesn't need this extra argument, so we can just ignore it, but we still need to add an extra _ argument at the beginning of each command callback.
