### PR TITLE
Update riak_core to use clique 0.3.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,5 +18,5 @@
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.1.0"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho2"}}},
-  {clique, "0.3.0", {git, "git://github.com/basho/clique.git", {tag, "0.3.0"}}}
+  {clique, "0.3.1", {git, "git://github.com/basho/clique.git", {tag, "0.3.1"}}}
 ]}.


### PR DESCRIPTION
We don't currently need to use the new features of clique 0.3.1, but it won't hurt to preemptively update the develop branch, and we'll definitely want the latest version at some point. We also need the latest clique version for the data platform so this will help prevent version conflicts.
