### PR TITLE
Bump clique to version 0.3.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,5 +18,5 @@
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.1.0"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho2"}}},
-  {clique, "0.3.1", {git, "git://github.com/basho/clique.git", {tag, "0.3.1"}}}
+  {clique, "0.3.2", {git, "git://github.com/basho/clique.git", {tag, "0.3.2"}}}
 ]}.


### PR DESCRIPTION
The latest version of clique includes several bugfixes over 0.3.1.
