### PR TITLE
Bump clique to version 0.3.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,5 +18,5 @@
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.1.0"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho2"}}},
-  {clique, "0.3.1", {git, "git://github.com/basho/clique.git", {tag, "0.3.1"}}}
+  {clique, "0.3.2", {git, "git://github.com/basho/clique.git", {tag, "0.3.2"}}}
 ]}.


### PR DESCRIPTION
The new version of clique includes several bugfixes over 0.3.1.

To help make review easier, here are the changes between clique 0.3.1 and 0.3.2: https://github.com/basho/clique/compare/0.3.1...0.3.2

0.3.2 fixes some regressions that broke the set/show/describe commands, and also cleans up the code for generating error output if a command is not found and has no associated usage message.

The second bit isn't really relevant to riak_core, since any command that riak-admin can pass in will be a supported command with usage info already registered. But we definitely don't want to break riak-admin set/show/describe, so this is a fairly important PR for those fixes alone.

(This replaces PR#752 which was done against the develop branch, but subsequently canceled.)
