### PR TITLE
Fix/az/assorted dialyzer issues

### DIFF
--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -3,7 +3,7 @@
 %% riak_core_coverage_fsm: Distribute work to a covering set of VNodes.
 %%
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -67,8 +67,6 @@
 -behaviour(gen_fsm).
 
 %% API
--export([behaviour_info/1]).
-
 -export([start_link/3]).
 
 -ifdef(TEST).
@@ -87,15 +85,16 @@
          terminate/3,
          code_change/4]).
 
--spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
-behaviour_info(callbacks) ->
-    [
-     {init, 2},
-     {process_results, 2},
-     {finish, 2}
-    ];
-behaviour_info(_) ->
-    undefined.
+-callback init(from(), Args::list()) -> State::term().
+%% In the several riak_kv_*_fsm where this behaviour is used,
+%% process_results has arity 2 or 3, with all but the last arg being
+%% too specific for particular modules, so let's not legislate what
+%% types those args should be.
+-callback process_results(Arg1::term(), State::term()) ->
+    {done, State::term()} | {error, term()} | {ok, State::term()}.
+-callback finish({error, term()}|clean, State::term()) ->
+    {stop, normal, State::term()}.
+
 
 -define(DEFAULT_TIMEOUT, 60000*8).
 

--- a/src/riak_core_vnode_worker.erl
+++ b/src/riak_core_vnode_worker.erl
@@ -1,5 +1,5 @@
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -20,10 +20,11 @@
 
 -behaviour(gen_server).
 
--export([behaviour_info/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
         code_change/3]).
 -export([start_link/1, handle_work/3, handle_work/4]).
+
+-include("riak_core_vnode.hrl").
 
 -ifdef(PULSE).
 -compile(export_all).
@@ -37,12 +38,14 @@
         modstate :: any()
     }).
 
--spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
-behaviour_info(callbacks) ->
-    [{init_worker,3},
-     {handle_work,3}];
-behaviour_info(_Other) ->
-    undefined.
+-callback init_worker(VNodeIndex::partition(),
+                      Args::list(), Props::proplists:proplist()) ->
+    {ok, State::term()}.
+-callback handle_work({Op::atom(),
+                       FoldFun::function(), FinishFun::function()},
+                      _Sender::pid(), State::term()) ->
+    {noreply, State::term()}.
+
 
 start_link(Args) ->
     WorkerMod = proplists:get_value(worker_callback_mod, Args),


### PR DESCRIPTION
A trivial clean-up work to squelch some of the dialyzer warnings. The first two commits replace the old-style `behaviour_info/1` with a series of `-callback`s, and a third one adds `cluster_info` as a dependency in `rebar.config`.

In the newly added mention of `cluster_info` in `rebar.config`, I pinned it to tag 2.0.3, which as of this writing, is the latest tag it has. 
