### PR TITLE
Do not allow node to join cluster when still launching

### DIFF
--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -123,15 +123,25 @@ standard_join(Node, Rejoin, Auto) when is_atom(Node) ->
             {error, not_reachable}
     end.
 
+init_complete({started, _}) ->
+    true;
+init_complete(_) ->
+    false.
+
 standard_join(Node, Ring, Rejoin, Auto) ->
     {ok, MyRing} = riak_core_ring_manager:get_raw_ring(),
+
+    InitComplete = init_complete(init:get_status()),
+
     SameSize = (riak_core_ring:num_partitions(MyRing) =:=
                 riak_core_ring:num_partitions(Ring)),
     Singleton = ([node()] =:= riak_core_ring:all_members(MyRing)),
-    case {Rejoin or Singleton, SameSize} of
-        {false, _} ->
+    case {InitComplete, Rejoin or Singleton, SameSize} of
+        {false, _, _} ->
+            {error, retry_later};
+        {_, false, _} ->
             {error, not_single_node};
-        {_, false} ->
+        {_, _, false} ->
             {error, different_ring_sizes};
         _ ->
             GossipVsn = riak_core_gossip:gossip_version(),

--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -123,6 +123,11 @@ standard_join(Node, Rejoin, Auto) when is_atom(Node) ->
             {error, not_reachable}
     end.
 
+%% `init:get_status/0' will return a 2-tuple reflecting the init
+%% status on this node; the first element is one of `starting',
+%% `started', or `stopping'. We only want to allow join actions if all
+%% applications have finished starting to avoid ring status race
+%% conditions.
 init_complete({started, _}) ->
     true;
 init_complete(_) ->

--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -138,7 +138,7 @@ standard_join(Node, Ring, Rejoin, Auto) ->
     Singleton = ([node()] =:= riak_core_ring:all_members(MyRing)),
     case {InitComplete, Rejoin or Singleton, SameSize} of
         {false, _, _} ->
-            {error, retry_later};
+            {error, node_still_starting};
         {_, false, _} ->
             {error, not_single_node};
         {_, _, false} ->


### PR DESCRIPTION
@mrallen1 and @jonmeredith identified a race condition when nodes are being joined quickly during automated testing; nodes which are still busy starting applications can lead to divergent rings and a node can transition from being a member of a ring back to joining status with resulting deadlock.

The race condition only manifests itself during staged joins; this change checks the joining node's `init` status and blocks the join if the node is starting (or stopping).

Corresponding `riak_test` PR to follow.
