### PR TITLE
Pin eleveldb version to 2.0.7 for riak_core 2.0 branch

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
   {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon.git", {branch, "2.0"}}},
   {riak_ensemble, ".*", {git, "git://github.com/basho/riak_ensemble", {branch, "2.0"}}},
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
-  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "2.0"}}},
+  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.7"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho2"}}},
   {clique, ".*", {git, "git://github.com/basho/clique.git", {tag, "0.2.5"}}}
 ]}.


### PR DESCRIPTION
Previously the `eleveldb` library was linked to the 2.0 branch which meant that unintended features were being pulled into `riak_core` as dependencies.  Going forward we can pin to a fixed release and move to the next tag as needed.
