### PR TITLE
Vnode proxy stuck in overload state

### DIFF
--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -814,8 +814,8 @@ handle_sync_event(core_status, _From, StateName, State=#state{index=Index,
         end,
     {reply, {Mode, Status}, StateName, State, State#state.inactivity_timeout}.
 
-handle_info({'$vnode_proxy_ping', From, Msgs}, StateName, State) ->
-    riak_core_vnode_proxy:cast(From, {vnode_proxy_pong, self(), Msgs}),
+handle_info({'$vnode_proxy_ping', From, Ref, Msgs}, StateName, State) ->
+    riak_core_vnode_proxy:cast(From, {vnode_proxy_pong, Ref, Msgs}),
     {next_state, StateName, State, State#state.inactivity_timeout};
 
 handle_info({'EXIT', Pid, Reason},

--- a/src/riak_core_vnode_proxy.erl
+++ b/src/riak_core_vnode_proxy.erl
@@ -380,7 +380,7 @@ overload_test_() ->
       fun({_VnodePid, ProxyPid}) ->
               {"should not discard in normal operation", timeout, 60,
                fun() ->
-                       ToSend = ?DEFAULT_OVERLOAD_THRESHOLD * 2,
+                       ToSend = ?DEFAULT_OVERLOAD_THRESHOLD,
                        [ProxyPid ! hello || _ <- lists:seq(1, ToSend)],
 
                        %% synchronize on the proxy and the mailbox


### PR DESCRIPTION
Fix for https://github.com/basho/riak_core/issues/760 ([RIAK-1914](https://bashoeng.atlassian.net/browse/RIAK-1914)).

Previously, if a heavily loaded vnode received more than `check_threshold` msgs after it hit the direct mailbox check, the ping/pong would leave it in overload state.  In cases where the load was removed (e.g. primary recovered) the vnode proxy would stay in overload state until enough messages were received to trigger pinging the vnode or rechecking the mailbox.

This PR does a couple of things
1) Stops counting messages skipped due to overload in the mailbox estimate.
2) Changes the ping/pong mechanism to use a reference so we can be resubmit safely.
3) After doing a direct check, immediately trigger a ping/pong so that once the mailbox is cleared the proxy will be immediately notified.
4) Adds an `overloaded/1` function to make testing easier.

There is corresponding riak_test on branch bugfix/jdm/vnode-proxy-stuck-in-overload-v2

Customer ticket zd://11440
