### PR TITLE
RIAK-2130 fix incorrect dependencies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_first_files, ["src/gen_nb_server.erl", "src/riak_core_gen_server.erl",
-		   "src/riak_core_stat_xform"]}.
+       "src/riak_core_stat_xform"]}.
 {cover_enabled, true}.
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform},
             debug_info, {platform_define, "^[0-9]+", namespaced_types},
@@ -13,10 +13,12 @@
   {lager, "2.0.3", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
   {poolboy, ".*", {git, "git://github.com/basho/poolboy.git", {tag, "0.8.1p3"}}},
   {basho_stats, ".*", {git, "git://github.com/basho/basho_stats.git", {tag, "1.0.3"}}},
-  {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon.git", {branch, "develop"}}},
-  {riak_ensemble, ".*", {git, "git://github.com/basho/riak_ensemble", {branch, "develop"}}},
+  {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon.git", {tag, "2.1.0"}}},
+  {riak_ensemble, ".*", {git, "git://github.com/basho/riak_ensemble", {tag, "2.1.0"}}},
+  {cluster_info, ".*", {git, "git://github.com/basho/cluster_info.git", {tag, "2.0.4"}}},
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.1.0"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho2"}}},
-  {clique, "0.3.2", {git, "git://github.com/basho/clique.git", {tag, "0.3.2"}}}
+  {clique, "0.3.2", {git, "git://github.com/basho/clique.git", {tag, "0.3.2"}}},
+  {folsom, "0.7.4p5", {git, "git://github.com/basho/folsom.git", {tag, "0.7.4p5"}}}
 ]}.

--- a/relx.config
+++ b/relx.config
@@ -1,0 +1,16 @@
+{lib_dirs, ["./deps"]}.
+
+{release, {riak_core, "2.1.2"},
+          ["eleveldb>=2.1.0",
+           "lager>=2.0.3",
+           "runtime_tools>=1.8.12",
+           "riak_sysmon>=1.0.3",
+           "riak_ensemble=2.1.0",
+           "cluster_info=2.0.4",
+           "pbkdf2=2.0.0",
+           "exometer_core=1.0.0-basho2",
+           "clique=0.3.2",
+           "folsom=0.7.4p5",
+           "basho_stats=1.0.3",
+           "poolboy=0.8.1p3"
+           ]}.

--- a/src/riak_core.app.src
+++ b/src/riak_core.app.src
@@ -16,11 +16,15 @@
                   riak_sysmon,
                   os_mon,
                   basho_stats,
+                  riak_ensemble,
                   eleveldb,
                   pbkdf2,
                   poolboy,
                   exometer_core,
-                  clique
+                  clique,
+                  cluster_info,
+                  folsom,
+                  runtime_tools
                  ]},
   {mod, {riak_core_app, []}},
   {env, [
@@ -67,13 +71,13 @@
          {dist_send_buf_size, 393216},
          {dist_recv_buf_size, 786432},
 
-	 %% Exometer defaults
-	 {exometer_defaults,
-	  [
-	   {['_'], histogram, [{options,
-				[{histogram_module, exometer_slot_slide},
-				 {keep_high, 500}]}
-			    ]}
-	  ]}
+     %% Exometer defaults
+     {exometer_defaults,
+      [
+       {['_'], histogram, [{options,
+                [{histogram_module, exometer_slot_slide},
+                 {keep_high, 500}]}
+                ]}
+      ]}
         ]}
  ]}.


### PR DESCRIPTION
All dependencies are now in rebar.config and in .app.src.

The relax file uses "riak_sysmon>=1.0.3" due to some version requirement that I cannot figure out right now. rebar3's tree command could probably help out with this.
