### PR TITLE
Fix RIAK-2169, error with counter 'dropped_vnode_requests' -- was inc [JIRA: RIAK-2203]

### DIFF
--- a/src/riak_core_stat.erl
+++ b/src/riak_core_stat.erl
@@ -174,7 +174,7 @@ stats() ->
      {gossip_received, spiral, [], [{one, gossip_received}]},
      {rejected_handoffs, counter, [], [{value, rejected_handoffs}]},
      {handoff_timeouts, counter, [], [{value, handoff_timeouts}]},
-     {dropped_vnode_requests_total, counter, [], [{value,dropped_vnode_requests_total}]},
+     {dropped_vnode_requests, counter, [], [{value, dropped_vnode_requests_total}]},
      {converge_delay, duration, [], [{mean, converge_delay_mean},
                                      {min, converge_delay_min},
                                      {max, converge_delay_max},


### PR DESCRIPTION
…orrectly named dropped_vnode_requests_total, which is the stats projection
