### PR TITLE
Format string for human size formatted data was incorrect. [JIRA: RIAK-2390]

### DIFF
--- a/src/riak_core_handoff_status.erl
+++ b/src/riak_core_handoff_status.erl
@@ -133,7 +133,7 @@ format_transfer_type(repair) ->
 format_transfer_size({Num, objects}) ->
     io_lib:format("~B Objs", [Num]);
 format_transfer_size({Num, bytes}) ->
-    riak_core_format:human_size_fmt("~B", Num);
+    riak_core_format:human_size_fmt("~.1f", Num);
 format_transfer_size(_) ->
     "--".
 


### PR DESCRIPTION
`riak_core_format:human_size_fmt` produces a float.

Before the fix, running `riak-admin handoff details` returned

```
RPC to 'riak@riak105.aws' failed: {'EXIT',
                                   {badarg,
                                    [{io_lib,format,
                                      ["~B ~s",[69.43440246582031,"MB"]],
                                      [{file,"io_lib.erl"},{line,155}]},
                                     {riak_core_format,fmt,2,
                                      [{file,"src/riak_core_format.erl"},
                                       {line,37}]},
                                     {riak_core_handoff_status,row_details,2,
                                      [{file,
                                        "src/riak_core_handoff_status.erl"},
                                       {line,104}]},
                                     {riak_core_handoff_status,
                                      '-build_handoff_details/1-lc$^0/1-0-',2,
                                      [{file,
                                        "src/riak_core_handoff_status.erl"},
                                       {line,87}]},
                                     {riak_core_handoff_status,
                                      build_handoff_details,1,
                                      [{file,
                                        "src/riak_core_handoff_status.erl"},
                                       {line,87}]},
                                     {clique_command,run,1,
                                      [{file,"src/clique_command.erl"},
                                       {line,59}]},
                                     {clique,run,1,
                                      [{file,"src/clique.erl"},{line,117}]},
                                     {rpc,'-handle_call_call/6-fun-0-',5,
                                      [{file,"rpc.erl"},{line,205}]}]}}
```

after the fix

```
Type Key: O = Ownership, H = Hinted, Rz = Resize, Rp = Repair
+----+-------------------+-------------------+-------+-----------+------+----------------+
|Type|     Source:ID     |     Target:ID     | Size  |Rate (KB/s)|  %   |     Sender     |
+----+-------------------+-------------------+-------+-----------+------+----------------+
| O  |riak@riak101.aws:16|riak@riak105.aws:16|22.5 MB|  408.41   |113.88|<25835.18131.80>|
+----+-------------------+-------------------+-------+-----------+------+----------------+
```

Fixes basho/riak_kv#1128 (RIAK-1835) (RIAK-1835)
Fixed RIAK-1835

PS. enjoy the % complete estimate above.
