### PR TITLE
Make DDL distribution more robust

### DIFF
--- a/src/riak_core_bucket_props.erl
+++ b/src/riak_core_bucket_props.erl
@@ -77,6 +77,16 @@ validate_core_prop(create, {_Bucket, undefined}, Existing, {claimant, Claimant})
 validate_core_prop(update, {_Bucket, _BucketName}, _Existing, {claimant, _Claimant}) ->
     %% cannot update claimant
     {claimant, "Cannot update claimant property"};
+validate_core_prop(update, {_Bucket, _BucketName}, _Existing, {ddl, _DDL}) ->
+    %% cannot update time series DDL
+    {ddl, "Cannot update time series data definition"};
+validate_core_prop(update, {_Bucket, _BucketName}, _Existing, {table_def, _DDL}) ->
+    %% cannot update time series DDL (or, if it slips past riak_kv_console,
+    %% the table_def SQL(ish) code that is parsed to make a DDL)
+    %%
+    %% Defining the table_def atom here also sidesteps occasional
+    %% errors from existing_atom functions
+    {ddl, "Cannot update time series data definition"};
 validate_core_prop(create, {_Bucket, undefined}, undefined, {active, false}) ->
     %% first creation call that sets active to false is always valid
     true;

--- a/src/riak_core_claimant.erl
+++ b/src/riak_core_claimant.erl
@@ -723,15 +723,15 @@ get_remote_type_status(BucketType) ->
                   riak_core_metadata,
                   get, [?BUCKET_TYPE_PREFIX, BucketType, [{default, []}]]).
 
-%% 
+%%
 get_remote_ddl_compiled_status(BucketType, Props) ->
-    case proplists:is_defined(ddl, Props) of
-        true ->
+    case proplists:get_value(ddl, Props) of
+        undefined ->
+            no_ddl_to_compile;
+        DDL ->
             rpc:multicall(all_members(),
                           riak_core_metadata_evt_sup,
-                          is_type_compiled, [BucketType]);
-        false ->
-            no_ddl_to_compile
+                          is_type_compiled, [BucketType, DDL])
     end.
 
 %% Checks if the result of the call to is_type_compiled across the cluster.

--- a/src/riak_core_metadata_evt_sup.erl
+++ b/src/riak_core_metadata_evt_sup.erl
@@ -27,7 +27,7 @@
 -behaviour(supervisor).
 
 -export([init/1]).
--export([is_type_compiled/1]).
+-export([is_type_compiled/2]).
 -export([start_link/0]).
 -export([swap_notification_handler/3]).
 -export([sync_notify/2]).
@@ -74,12 +74,12 @@ sync_notify(FullPrefix, Key) ->
 %% that do not handle this should return false, or any value that is not true.
 %%
 %% This should only be called if the bucket type has the ddl property.
--spec is_type_compiled(BucketType :: binary()) -> boolean().
-is_type_compiled(BucketType) when is_binary(BucketType) ->
+-spec is_type_compiled(BucketType :: binary(), DDL :: term()) -> boolean().
+is_type_compiled(BucketType, DDL) when is_binary(BucketType) ->
     case ets:lookup(?TABLE, ?BUCKET_TYPE_PREFIX) of
         [{?BUCKET_TYPE_PREFIX, Pid}] ->
             Handlers = gen_event:which_handlers(Pid),
-            Req = {is_type_compiled, BucketType},
+            Req = {is_type_compiled, [BucketType, DDL]},
             Results = [gen_event:call(Pid, H, Req) || H <- Handlers],
             lists:member(true, Results);
         [] ->


### PR DESCRIPTION
- Do not allow DDL to be updated post-activation
- Include a DDL comparison as part of the claimant-driven activation process so that if messages are delayed the claimant doesn't accidentally validate a node who has compiled an earlier version of the DDL but has yet to receive the later version
