### PR TITLE
Bugfix/hashtree delete reopen

### DIFF
--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -124,10 +124,12 @@
          levels/1,
          segments/1,
          width/1,
-         mem_levels/1]).
+         mem_levels/1,
+         path/1]).
 -export([compare2/4]).
-
+-export([multi_select_segment/3, safe_decode/1]).
 -ifdef(TEST).
+-compile([export_all]).
 -export([local_compare/2]).
 -export([run_local/0,
          run_local/1,
@@ -412,6 +414,10 @@ width(#state{width=W}) ->
 -spec mem_levels(hashtree()) -> integer().
 mem_levels(#state{mem_levels=M}) ->
     M.
+
+-spec path(hashtree()) -> string().
+path(#state{path=P}) ->
+    P.
 
 %% Note: meta is currently a one per file thing, even if there are multiple
 %%       trees per file. This is intentional. If we want per tree metadata

--- a/test/hashtree_eqc.erl
+++ b/test/hashtree_eqc.erl
@@ -1,3 +1,23 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2012-2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
 -module(hashtree_eqc).
 -compile([export_all]).
 
@@ -40,50 +60,78 @@ sha(Bin) ->
 -endif.
 
 key() ->
-    binary(4).  % original used ?LET(Key, int(), ?MODULE:integer_to_binary(Key)).
+    ?LET(Key, int(), ?MODULE:integer_to_binary(Key)).
 
-object(_S) ->
+object() ->
     {key(), sha(term_to_binary(make_ref()))}.
 
-command(S = #state{started = Started}) ->
+objects() ->
+    non_empty(list(object())).
+
+mark() ->
+    frequency([{1, mark_empty}, {5, mark_open}]).
+
+command(_S = #state{started = Started}) ->
     frequency(
-        [{1, {call, ?MODULE, start, [{oneof(?POWERS), oneof(?POWERS), choose(0, 4)}]}} || not Started] ++
+        [{1, {call, ?MODULE, start,
+              [{oneof(?POWERS), oneof(?POWERS), choose(0, 4)}, mark(), mark()]}} || not Started] ++
         [{1, {call, ?MODULE, update_tree, [t1]}} || Started] ++
         [{1, {call, ?MODULE, update_tree, [t2]}} || Started] ++
-        [{50, {call, ?MODULE, write, [t1, object(S)]}} || Started] ++
-        [{50, {call, ?MODULE, write, [t2, object(S)]}} || Started] ++
-        [{100,{call, ?MODULE, write_both, [object(S)]}} || Started] ++
-        %% [{50, {call, ?MODULE, delete, [t1, key()]}} || Started] ++
-        %% [{50, {call, ?MODULE, delete, [t2, key()]}} || Started] ++
-        %% [{100,{call, ?MODULE, delete_both, [key()]}} || Started] ++
-        %% [{1, {call, ?MODULE, reopen_tree, [S#state.params, t1]}} || Started] ++
-        %% [{1, {call, ?MODULE, reopen_tree, [S#state.params, t2]}} || Started] ++
-          [{1, {call, ?MODULE, reconcile, []}} || Started] ++
-          %% TODO: Add rehash_tree
+        [{50, {call, ?MODULE, write, [t1, objects()]}} || Started] ++
+        [{50, {call, ?MODULE, write, [t2, objects()]}} || Started] ++
+        [{100,{call, ?MODULE, write_both, [objects()]}} || Started] ++
+        [{50, {call, ?MODULE, delete, [t1, key()]}} || Started] ++
+        [{50, {call, ?MODULE, delete, [t2, key()]}} || Started] ++
+        [{100,{call, ?MODULE, delete_both, [key()]}} || Started] ++
+        [{1, {call, ?MODULE, reopen_tree, [t1]}} || Started] ++
+        [{1, {call, ?MODULE, reopen_tree, [t2]}} || Started] ++
+        [{1, {call, ?MODULE, unsafe_close, [t1]}} || Started] ++
+        [{1, {call, ?MODULE, unsafe_close, [t2]}} || Started] ++
+        [{1, {call, ?MODULE, rehash_tree, [t1]}} || Started] ++
+        [{1, {call, ?MODULE, rehash_tree, [t2]}} || Started] ++
+        [{1, {call, ?MODULE, reconcile, []}} || Started] ++
         []
     ).
 
-start(Params) ->
+start(Params, T1Mark, T2Mark) ->
     {Segments, Width, MemLevels} = Params,
     %% Return now so we can store symbolic value in procdict in next_state call
-    put(t1, hashtree:new({0,0}, [{segments, Segments},
-                                 {width, Width},
-                                 {mem_levels, MemLevels}])),
-    put(t2, hashtree:new({0,0}, [{segments, Segments},
-                                 {width, Width},
-                                 {mem_levels, MemLevels}])),
+    HT1 = hashtree:new({0,0}, [{segments, Segments},
+                               {width, Width},
+                               {mem_levels, MemLevels}]),
+
+    T1 = case T1Mark of
+        mark_empty -> hashtree:mark_open_empty({0,0}, HT1);
+        _ -> hashtree:mark_open_and_check({0,0}, HT1)
+    end,
+
+    put(t1, T1),
+
+    HT2 = hashtree:new({0,0}, [{segments, Segments},
+                               {width, Width},
+                               {mem_levels, MemLevels}]),
+
+    T2 = case T2Mark of
+        mark_empty -> hashtree:mark_open_empty({0,0}, HT2);
+        _ -> hashtree:mark_open_and_check({0,0}, HT2)
+    end,
+
+    put(t2, T2),
+
     ets:new(t1, [named_table, public, set]),
     ets:new(t2, [named_table, public, set]),
-    true.
-
-write(T, {Key, Hash}) ->
-    put(T, hashtree:insert(Key, Hash, get(T))), % write to tree and return previous state
-    ets:insert(T, {Key, Hash}),
     ok.
 
-write_both({_Key, _Hash}=KH) ->
-    write(t1, KH),
-    write(t2, KH),
+write(T, Objects) ->
+    lists:foreach(fun({Key, Hash}) ->
+                          put(T, hashtree:insert(Key, Hash, get(T))),
+                          ets:insert(T, {Key, Hash})
+                  end, Objects),
+    ok.
+
+write_both(Objects) ->
+    write(t1, Objects),
+    write(t2, Objects),
     ok.
 
 delete(T, Key) ->
@@ -100,17 +148,47 @@ update_tree(T) ->
     put(T, hashtree:update_tree(get(T))),
     ok.
 
-reopen_tree(Params, T) ->
-    {Segments, Width, MemLevels} = Params,
-    HT = hashtree:flush_buffer(get(T)),
-    Path = hashtree:path(HT),
-    hashtree:close(HT),
-    put(T, hashtree:new({0,0}, [{segments, Segments},
-                                {width, Width},
-                                {mem_levels, MemLevels},
-                                {segment_path, Path}])),
+rehash_tree(T) ->
+    put(T, hashtree:rehash_tree(get(T))),
     ok.
 
+reopen_tree(T) ->
+    HT = hashtree:flush_buffer(get(T)),
+    {Segments, Width, MemLevels} = {hashtree:segments(HT), hashtree:width(HT),
+                                    hashtree:mem_levels(HT)},
+    Path = hashtree:path(HT),
+
+    UpdatedHT = hashtree:update_tree(HT),
+    CleanClosedHT = hashtree:mark_clean_close({0,0}, UpdatedHT),
+    hashtree:close(CleanClosedHT),
+
+    T1 = hashtree:new({0,0}, [{segments, Segments},
+                              {width, Width},
+                              {mem_levels, MemLevels},
+                              {segment_path, Path}]),
+
+    put(T, hashtree:mark_open_and_check({0,0}, T1)),
+    ok.
+
+unsafe_close(T) ->
+    HT = get(T),
+    {Segments, Width, MemLevels} = {hashtree:segments(HT), hashtree:width(HT),
+                                    hashtree:mem_levels(HT)},
+    Path = hashtree:path(HT),
+    %% Although this is an unsafe close, it's unsafe in metadata/building
+    %% buckets.  Rather than model the queue behavior, flush those and just
+    %% check the buckets are correctly recomputed next compare.
+    hashtree:flush_buffer(HT),
+    hashtree:fake_close(HT),
+
+    T0 = hashtree:new({0,0}, [{segments, Segments},
+                              {width, Width},
+                              {mem_levels, MemLevels},
+                              {segment_path, Path}]),
+
+    put(T, hashtree:mark_open_and_check({0,0}, T0)),
+
+    ok.
 
 reconcile() ->
     put(t1, hashtree:update_tree(get(t1))),
@@ -121,11 +199,9 @@ reconcile() ->
     Different = [D || {different, D} <- KeyDiff],
 
     Insert = fun(T, Vals) ->
-                     lists:foldl(fun({Key, Hash}, Acc) ->
-                                         write(T, {Key, Hash}),
-                                         Acc
-                        end, T, Vals)
+                 write(T, Vals)
              end,
+
     %% Lazy reuse of existing code - could be changed to check ETS directly
     Only1 = ets:tab2list(t1),
     Only2 = ets:tab2list(t2),
@@ -138,11 +214,6 @@ reconcile() ->
                 Only1) /= false]),
     ok.
 
-
-%% write_differing(Tree1, Tree2, {Key, Hash1}, Hash2) ->
-%%     {{Key, Hash1}, {Key, Hash2}, hashtree:insert(Key, Hash1, Tree1),
-%%         hashtree:insert(Key, Hash2, Tree2)}.
-
 precondition(#state{started = Started}, {call, _, F, _A}) ->
     case F of
         start ->
@@ -151,21 +222,29 @@ precondition(#state{started = Started}, {call, _, F, _A}) ->
             Started == true
     end.
 
+postcondition(_S,{call,_,start, [_, T1Mark, T2Mark]},_R) ->
+    NextRebuildT1 = hashtree:next_rebuild(get(t1)),
+    NextRebuildT2 = hashtree:next_rebuild(get(t2)),
+    case T1Mark of
+        mark_empty -> eq(NextRebuildT1, incremental);
+        _ -> eq(NextRebuildT1, full)
+    end,
+    case T2Mark of
+        mark_empty -> eq(NextRebuildT2, incremental);
+        _ -> eq(NextRebuildT2, full)
+    end;
 postcondition(_S,{call,_,_,_},_R) ->
     true.
 
-next_state(S,_R,{call, _, start, [Params]}) ->
+next_state(S,_R,{call, _, start, [Params,_,_]}) ->
     S#state{started = true, params = Params};
-next_state(S,_V,{call, _, write, [t1, {Key, Val}]}) ->
-    S#state{only1=[{Key, Val}|lists:keydelete(Key, 1,
-                S#state.only1)]};
-next_state(S,_V,{call, _, write, [t2, {Key, Val}]}) ->
-    S#state{only2=[{Key, Val}|lists:keydelete(Key, 1,
-                S#state.only2)]};
-next_state(S,_R,{call, _, write_both, [{Key, Val}]}) ->
-    S#state{only1=[{Key, Val}|lists:keydelete(Key, 1, S#state.only1)],
-            only2=[{Key, Val}|lists:keydelete(Key, 1, S#state.only2)]
-    };
+next_state(S,_V,{call, _, write, [t1, Objects]}) ->
+    S#state{only1=keymerge(Objects, S#state.only1)};
+next_state(S,_V,{call, _, write, [t2, Objects]}) ->
+    S#state{only2=keymerge(Objects, S#state.only2)};
+next_state(S,_R,{call, _, write_both, [Objects]}) ->
+    S#state{only1=keymerge(Objects, S#state.only1),
+            only2=keymerge(Objects, S#state.only2)};
 next_state(S,_V,{call, _, delete, [t1, Key]}) ->
     S#state{only1=lists:keydelete(Key, 1, S#state.only1)};
 next_state(S,_V,{call, _, delete, [t2, Key]}) ->
@@ -173,20 +252,24 @@ next_state(S,_V,{call, _, delete, [t2, Key]}) ->
 next_state(S,_R,{call, _, delete_both, [Key]}) ->
     S#state{only1=lists:keydelete(Key, 1, S#state.only1),
             only2=lists:keydelete(Key, 1, S#state.only2)};
+next_state(S,_R,{call, _, reopen_tree, _A}) ->
+    S;
+next_state(S,_R,{call, _, unsafe_close, _A}) ->
+    S;
+next_state(S,_R,{call, _, rehash_tree, _A}) ->
+    S;
 next_state(S,_R,{call, _, reconcile, []}) ->
-    Keys = lists:ukeymerge(1, lists:ukeysort(1, S#state.only1),
-                           lists:ukeysort(1, S#state.only2)),
+    Keys = keymerge(S),
     S#state{only1 = Keys,
             only2 = Keys};
 next_state(S,_R,{call, _, update_tree, _A}) ->
     S.
 
-
 prop_correct() ->
     ?FORALL(Cmds,non_empty(commands(?MODULE, #state{})),
             aggregate(command_names(Cmds),
                 begin
-                    %io:format(user, "Starting in ~p\n", [self()]),
+                    %%io:format(user, "Starting in ~p\n", [self()]),
                     put(t1, undefined),
                     put(t2, undefined),
                     catch ets:delete(t1),
@@ -213,39 +296,42 @@ prop_correct() ->
                                                 sets:from_list([Key || {Key,_}
                                                     <- Unique2])))],
 
-                                %% io:format(user, "Checks in ~p\nS: ~p\nT1: ~p\nT2: ~p\n",
-                                %%           [self(), S, get(t1), get(t2)]),
-
                                 case S#state.started of
                                     false ->
                                         true;
                                     _ ->
-                                        T1 = hashtree:update_tree(get(t1)),
-                                        T2 = hashtree:update_tree(get(t2)),
+                                        %% io:format("\nFinal update tree1:\n"),
+                                        T10 = hashtree:update_tree(get(t1)),
+                                        %% io:format("\nFinal update tree2:\n"),
+                                        T20 = hashtree:update_tree(get(t2)),
 
-                                        KeyDiff = hashtree:local_compare(T1, T2),
+                                        %% io:format("\nFinal compare:\n"),
+                                        KeyDiff = hashtree:local_compare(T10, T20),
 
-                                        %io:format(user, "Expected: ~p\nKeyDiff: ~p\n", [Expected, KeyDiff]),
+                                        D1 = try dump(T10) catch _:Err1 -> Err1 end,
+                                        D2 = try dump(T20) catch _:Err2 -> Err2 end,
 
-                                        D1 = dump(T1),
-                                        D2 = dump(T2),
-                                        catch hashtree:destroy(hashtree:close(T1)),
-                                        catch hashtree:destroy(hashtree:close(T2)),
+                                        T11 = hashtree:mark_clean_close({0,0}, T10),
+                                        T21 = hashtree:mark_clean_close({0,0}, T20),
+                                        catch hashtree:destroy(hashtree:close(T11)),
+                                        catch hashtree:destroy(hashtree:close(T21)),
                                         {Segments, Width, MemLevels} = S#state.params,
 
                                         ?WHENFAIL(
                                            begin
+                                               eqc:format("only1:\n~p\n", [S#state.only1]),
+                                               eqc:format("only2:\n~p\n", [S#state.only2]),
                                                eqc:format("t1:\n~p\n", [D1]),
                                                eqc:format("t2:\n~p\n", [D2])
                                            end,
                                            collect(with_title(mem_levels), MemLevels,
                                            collect(with_title(segments), Segments,
                                            collect(with_title(width), Width,
-                                           collect(with_title(length), length(S#state.only1) +
-                                                      length(S#state.only2),
-                                                     conjunction([{cmds, equals(ok, Res)},
-                                                                  {diff, equals(lists:usort(Expected),
-                                                                                lists:usort(KeyDiff))}]))))))
+                                           collect(with_title(length),
+                                           length(S#state.only1) + length(S#state.only2),
+                                                   conjunction([{cmds, equals(ok, Res)},
+                                                                {diff, equals(lists:usort(Expected),
+                                                                              lists:usort(KeyDiff))}]))))))
                                 end
                             end
                                 ))
@@ -258,6 +344,12 @@ dump(Tree) ->
     {SnapTree, _Tree2} = hashtree:update_snapshot(Tree),
     hashtree:multi_select_segment(SnapTree, ['*','*'], Fun).
 
+keymerge(S) ->
+    keymerge(S#state.only1, S#state.only2).
+
+keymerge(SuccList, L) ->
+    lists:ukeymerge(1, lists:ukeysort(1, SuccList),
+                    lists:ukeysort(1, L)).
 
 -endif.
 -endif.


### PR DESCRIPTION
- Update hashtree.erl and the associated eqc test to account for deletes/reopenings across possible race conditions, crashes. 
- Correctly handle full vs incremental/partial segment update & rebuild.
- Force rehashing of tree to do a full rebuild.
- Handle leveldb iteration `invalid_iterator` errors correctly when running into '*' segments.

Related: https://github.com/basho/yokozuna/pull/578 + https://github.com/basho/riak_kv/pull/1242.

@jonmeredith please review.
