### PR TITLE
Support TS coverage requests

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -11,6 +11,7 @@ riak_core_console.erl:102: The pattern 'true' can never match the type 'false'
 riak_core_gossip.erl:214: The pattern 1 can never match the type 2
 riak_core_gossip.erl:229: The pattern 'true' can never match the type 'false'
 riak_core_gossip.erl:245: The pattern 'true' can never match the type 'false'
+riak_core_gossip_legacy.erl:106: Call to missing or unexported function riak_core_ring:legacy_reconcile/2
 riak_core_ring_handler.erl:73: The pattern {'true', _, _, _} can never match the type {'false',boolean(),[integer()],'down' | 'exiting' | 'invalid' | 'joining' | 'leaving' | 'valid'}
 riak_core_claimant.erl:407: The pattern {'legacy', _} can never match the type {'error','invalid_resize_claim'} | {'ok',{'chstate_v2',_,'undefined' | [any()],{_,_},'undefined' | dict:dict(_,_),'undefined' | {_,_},'undefined' | [any()],[any()],_,'undefined' | [any()],'undefined' | [any()]}}
 riak_core_claimant.erl:913: The pattern {'legacy', _} can never match the type {'error','invalid_resize_claim'} | {'ok',{'chstate_v2',_,'undefined' | [any()],{_,_},'undefined' | dict:dict(_,_),'undefined' | {_,_},'undefined' | [any()],[any()],_,'undefined' | [any()],'undefined' | [any()]}}

--- a/include/riak_core_vnode.hrl
+++ b/include/riak_core_vnode.hrl
@@ -46,7 +46,7 @@
 -record(vnode_coverage, {
           vnode_identifier = 0 :: non_neg_integer(),
           partition_filters = [] :: [non_neg_integer()],
-          subpartition = undefined :: subpartition()
+          subpartition = undefined :: undefined | subpartition()
          }).
 
 -type vnode_selector() :: all | allup.

--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -3,7 +3,7 @@
 %% riak_core_coverage_fsm: Distribute work to a covering set of VNodes.
 %%
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -223,15 +223,17 @@ find_plan(Mod, Target, NVal, PVC, ReqId, Service, Request) ->
 -spec interpret_plan(vnode_coverage()) ->
                             {list({index(), node()}),
                              list({index(), list(index())|tuple()})}.
-interpret_plan(#vnode_coverage{vnode_identifier=TargetHash,
-                               subpartition={Mask, BSL}}) ->
-    {[{TargetHash, node()}], [{TargetHash, {Mask, BSL}}]};
-interpret_plan(#vnode_coverage{vnode_identifier=TargetHash,
-                               partition_filters=[]}) ->
+interpret_plan(#vnode_coverage{vnode_identifier  = TargetHash,
+                               partition_filters = [],
+                               subpartition = undefined}) ->
     {[{TargetHash, node()}], []};
-interpret_plan(#vnode_coverage{vnode_identifier=TargetHash,
-                            partition_filters=HashFilters}) ->
-    {[{TargetHash, node()}], [{TargetHash, HashFilters}]}.
+interpret_plan(#vnode_coverage{vnode_identifier  = TargetHash,
+                               partition_filters = HashFilters,
+                               subpartition = undefined}) ->
+    {[{TargetHash, node()}], [{TargetHash, HashFilters}]};
+interpret_plan(#vnode_coverage{vnode_identifier = TargetHash,
+                               subpartition     = {Mask, BSL}}) ->
+    {[{TargetHash, node()}], [{TargetHash, {Mask, BSL}}]}.
 
 
 %% @private

--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -33,7 +33,7 @@
 %%      the module implementing this behavior.
 %%
 %%      Modules implementing this behavior should return
-%%      a 5 member tuple from their init function that looks
+%%      a 9 member tuple from their init function that looks
 %%      like this:
 %%
 %%         `{Request, VNodeSelector, NVal, PrimaryVNodeCoverage,
@@ -44,22 +44,22 @@
 %%      <ul>
 %%      <li>Request - An opaque data structure that is used by
 %%        the VNode to implement the specific coverage request.</li>
-%%      <li>VNodeSelector - Either the atom `all' to indicate that
-%%        enough VNodes must be available to achieve a minimal
-%%        covering set or `allup' to use whatever VNodes are
-%%        available even if they do not represent a fully covering
-%%        set or the tuple {colocated, Module} where Module is the name of
-%%        a module that exposes a function create_plan/5 for data that is
-%%        colocated in some way (eg a TimeSeries or Geohash).</li>
+%%      <li>VNodeSelector - If using the standard riak_core_coverage_plan
+%%          module, 'all' for all VNodes or 'allup' for all reachable.
+%%          If using an alternative coverage plan generator, whatever
+%%          value is useful to its `create_plan' function; will be passed
+%%          as the first argument.</li>
 %%      <li>NVal - Indicates the replication factor and is used to
 %%        accurately create a minimal covering set of VNodes.</li>
 %%      <li>PrimaryVNodeCoverage - The number of primary VNodes
 %%      from the preference list to use in creating the coverage
-%%      plan.</li>
+%%      plan. Typically just 1.</li>
 %%      <li>NodeCheckService - The service to use to check for available
 %%      nodes (e.g. riak_kv).</li>
 %%      <li>VNodeMaster - The atom to use to reach the vnode master module.</li>
 %%      <li>Timeout - The timeout interval for the coverage request.</li>
+%%      <li>PlannerMod - The module which defines `create_plan' and optionally
+%%          functions to support a coverage query API</li>
 %%      <li>State - The initial state for the module.</li>
 %%      </ul>
 -module(riak_core_coverage_fsm).
@@ -103,6 +103,7 @@ behaviour_info(_) ->
 
 -type req_id() :: non_neg_integer().
 -type from() :: {atom(), req_id(), pid()}.
+-type index() :: chash:index_as_int().
 
 -record(state, {coverage_vnodes :: [{non_neg_integer(), node()}],
                 mod :: atom(),
@@ -211,11 +212,27 @@ maybe_start_timeout_timer(Timeout) ->
     ok.
 
 %% @private
-%% It is the planner module's responsibility to determine whether this
-%% is a new request necessitating a new plan, or whether Target is in
-%% fact a predefined chunk of a coverage plan to be interpreted
+find_plan(_Mod, #vnode_coverage{}=Plan, _NVal, _PVC, _ReqId, _Service,
+          _Request) ->
+    interpret_plan(Plan);
 find_plan(Mod, Target, NVal, PVC, ReqId, Service, Request) ->
     Mod:create_plan(Target, NVal, PVC, ReqId, Service, Request).
+
+%% @private
+%% Take a `vnode_coverage' record and interpret it as a mini coverage plan
+-spec interpret_plan(vnode_coverage()) ->
+                            {list({index(), node()}),
+                             list({index(), list(index())|tuple()})}.
+interpret_plan(#vnode_coverage{vnode_identifier=TargetHash,
+                               subpartition={Mask, BSL}}) ->
+    {[{TargetHash, node()}], [{TargetHash, {Mask, BSL}}]};
+interpret_plan(#vnode_coverage{vnode_identifier=TargetHash,
+                               partition_filters=[]}) ->
+    {[{TargetHash, node()}], []};
+interpret_plan(#vnode_coverage{vnode_identifier=TargetHash,
+                            partition_filters=HashFilters}) ->
+    {[{TargetHash, node()}], [{TargetHash, HashFilters}]}.
+
 
 %% @private
 initialize(timeout, StateData0=#state{mod=Mod,

--- a/src/riak_core_coverage_plan.erl
+++ b/src/riak_core_coverage_plan.erl
@@ -149,8 +149,6 @@
                   pos_integer(),
                   req_id(), atom(), term()) ->
                          {error, term()} | coverage_plan().
-create_plan(#vnode_coverage{}=Plan, _NVal, _PVC, _ReqId, _Service, _Request) ->
-    interpret_plan(Plan);
 create_plan(VNodeTarget, NVal, PVC, ReqId, Service, _Request) ->
     {ok, CHBin} = riak_core_ring_manager:get_chash_bin(),
     create_traditional_plan(VNodeTarget, NVal, PVC, ReqId, Service,
@@ -217,22 +215,6 @@ replace_subpartition_chunk(VnodeIdx, Node, {Mask, Bits}, NVal,
     replace_subpartition_chunk(VnodeIdx, Node, {Mask, Bits}, NVal,
                                ReqId, DownNodes, Service, CHBin,
                                ?AVAIL_NODE_FUN).
-
-%% @doc Take a `vnode_coverage' record and interpret it as
-%%      needed by `riak_core_coverage_fsm:initialize'
--spec interpret_plan(vnode_coverage()) ->
-                            {list({index(), node()}),
-                             list({index(), list(index())|tuple()})}.
-interpret_plan(#vnode_coverage{vnode_identifier=TargetHash,
-                               subpartition={Mask, BSL}}) ->
-    {[{TargetHash, node()}], [{TargetHash, {Mask, BSL}}]};
-interpret_plan(#vnode_coverage{vnode_identifier=TargetHash,
-                               partition_filters=[]}) ->
-    {[{TargetHash, node()}], []};
-interpret_plan(#vnode_coverage{vnode_identifier=TargetHash,
-                            partition_filters=HashFilters}) ->
-    {[{TargetHash, node()}], [{TargetHash, HashFilters}]}.
-
 
 %% ====================================================================
 %% Internal functions

--- a/src/riak_core_coverage_plan.erl
+++ b/src/riak_core_coverage_plan.erl
@@ -766,14 +766,10 @@ data_bits(PartitionCount) ->
 
 %% @private
 
-%% Crimes against computerkind. Finds the next value of two greater
-%% than the requested value using string manipulation.
 next_power_of_two(X) ->
-    Next = 1 bsl length(hd(io_lib:format("~.2b", [X]))),
-    if X * 2 =:= Next -> X;
-       true -> Next
-    end.
+    round(math:pow(2, round(log2(X - 1) + 0.5))).
 
+log2(X) -> math:log(X) / math:log(2.0).
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_core_coverage_plan.erl
+++ b/src/riak_core_coverage_plan.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_core_coverage_plan: Create a plan to cover a minimal set of VNodes.
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file


### PR DESCRIPTION
WIP. @hmmr will be carrying this set of PRs forward.

This is a significant reworking of how coverage requests are handled, including a change to the `riak_core_coverage_fsm` behaviour to allow different Riak core apps to plug in different coverage plan modules (thus eliminating the `colocated` tuple).
