### PR TITLE
register a ddl_req_version capability, needed for #ddl_v2{}

### DIFF
--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_core: Core Riak Application
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -100,6 +100,9 @@ start(_StartType, _StartArgs) ->
             riak_core_capability:register({riak_core, net_ticktime},
                                           [true, false],
                                           false),
+            riak_core_capability:register({riak_core, ddl_req_version},
+                                          [v2, v1],
+                                          v1),
 
             riak_core_cli_registry:load_schema(),
             riak_core_cli_registry:register_node_finder(),


### PR DESCRIPTION
RTS-865

Goes with https://github.com/basho/riak_kv/pull/1332.

The new version of the ddl record has an additional field, containing table/bucket type properties.
