### PR TITLE
Bump exometer_core to 1.0.0-basho5

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,6 +15,6 @@
   {riak_ensemble, ".*", {git, "git://github.com/basho/riak_ensemble", {branch, "2.0"}}},
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.14"}}},
-  {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho2"}}},
+  {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho5"}}},
   {clique, ".*", {git, "git://github.com/basho/clique.git", {tag, "0.2.5"}}}
 ]}.


### PR DESCRIPTION
Picks up basho/exometer_core#10
