### PR TITLE
log the missing bucket type name when returning {error, no_type}

### DIFF
--- a/src/riak_core_bucket.erl
+++ b/src/riak_core_bucket.erl
@@ -61,7 +61,9 @@ set_bucket({<<"default">>, Name}, BucketProps) ->
     set_bucket(Name, BucketProps);
 set_bucket({Type, _Name}=Bucket, BucketProps0) ->
     case riak_core_bucket_type:get(Type) of
-        undefined -> {error, no_type};
+        undefined -> 
+            lager:error("Attempt to set properties of non-existant bucket type ~p", [Bucket]),
+            {error, no_type};
         _ -> set_bucket(fun set_bucket_in_metadata/2, Bucket, BucketProps0)
     end;
 set_bucket(Name, BucketProps0) ->
@@ -114,7 +116,9 @@ get_bucket({Type, _Name}=Bucket) ->
     BucketMeta = riak_core_metadata:get(?METADATA_PREFIX, bucket_key(Bucket),
                                         [{resolver, fun riak_core_bucket_props:resolve/2}]),
     case merge_type_props(TypeMeta, BucketMeta) of
-        {error, _}=Error -> Error;
+        {error, _}=Error -> 
+            lager:error("~p getting properties of bucket ~p",[Error,Bucket]),
+            Error;
         Props -> [{name, Bucket} | Props]
     end;
 get_bucket(Name) ->


### PR DESCRIPTION
Adresses #815  

Manual test:

```
% tail -n1 log/console.log
2016-02-29 13:17:51.096 [info] <0.445.0>@riak_kv_entropy_manager:perhaps_log_throttle_change:853 Changing AAE throttle from undefined -> 0 msec/key, based on maximum vnode mailbox size 1 from 'riak@127.0.0.1'

% bin/riak-admin bucket-type list
default (active)
goodtype (active)

% bin/riak attach
Remote Shell: Use "Ctrl-C a" to quit. q() or init:stop() will terminate the riak node.
Eshell V5.10.3  (abort with ^G)

(riak@127.0.0.1)1> riak_kv_util:get_index_n({{<<"goodtype">>,<<"bucket">>},<<"key">>}).
{616571003248974668617179538802181898917346541568,4}

(riak@127.0.0.1)2> riak_kv_util:get_index_n({{<<"badtype">>,<<"bucket">>},<<"key">>}). 
** exception error: no function clause matching proplists:get_value(n_val,{error,no_type},undefined) (proplists.erl, line 225)
     in function  riak_kv_util:get_index_n/1 (src/riak_kv_util.erl, line 190)

(riak@127.0.0.1)3> 
^C%                                                                                                                                                                                                                                                        

% tail -n2 log/console.log     
2016-02-29 13:17:51.096 [info] <0.445.0>@riak_kv_entropy_manager:perhaps_log_throttle_change:853 Changing AAE throttle from undefined -> 0 msec/key, based on maximum vnode mailbox size 1 from 'riak@127.0.0.1'
2016-02-29 13:18:55.144 [error] <0.2626.0>@riak_core_bucket:get_bucket:124 {error,no_type} getting properties of bucket {<<"badtype">>,<<"bucket">>}
```
