### PR TITLE
Prevent handoff.ip to be local [JIRA: RIAK-3060]

### DIFF
--- a/include/riak_core_handoff.hrl
+++ b/include/riak_core_handoff.hrl
@@ -10,6 +10,8 @@
 -define(PT_MSG_SYNC, 3).
 -define(PT_MSG_CONFIGURE, 4).
 -define(PT_MSG_BATCH, 5).
+-define(PT_MSG_VERIFY_NODE, 6).
+-define(PT_MSG_UNKNOWN, 255).
 
 -record(ho_stats,
         {

--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -76,15 +76,26 @@
 {mapping, "handoff.ip", "riak_core.handoff_ip", [
   {default, "{{handoff_ip}}" },
   {datatype, string},
-  {validators, ["valid_ipaddr"]},
+  {validators, ["valid_ipaddr", "not_localhost"]},
   hidden
 ]}.
 
 {validator,
   "valid_ipaddr",
   "must be a valid IP address",
-  fun(AddrString) -> 
+  fun(AddrString) ->
     case inet_parse:address(AddrString) of
+      {ok, _} -> true;
+      {error, _} -> false
+    end
+  end}.
+
+{validator,
+  "not_localhost",
+  "can't be a local ip",
+  fun(AddrString) ->
+    case inet_parse:address(AddrString) of
+      {ok, {127, _, _, _}} -> false;
       {ok, _} -> true;
       {error, _} -> false
     end

--- a/src/riak_core_handoff_receiver.erl
+++ b/src/riak_core_handoff_receiver.erl
@@ -153,13 +153,27 @@ process_message(?PT_MSG_SYNC, _MsgData, State=#state{sock=Socket,
                                                      tcp_mod=TcpMod}) ->
     TcpMod:send(Socket, <<?PT_MSG_SYNC:8, "sync">>),
     State;
+
+process_message(?PT_MSG_VERIFY_NODE, ExpectedName, State=#state{sock=Socket,
+                                                                tcp_mod=TcpMod,
+                                                                peer=Peer}) ->
+    case term_to_binary(ExpectedName) of
+        _Node when _Node =:= node() ->
+            TcpMod:send(Socket, <<?PT_MSG_VERIFY_NODE:8>>),
+            State;
+        Node ->
+            lager:error("Handoff from ~s expects us to be ~s but we are ~s.",
+                        [Peer, Node, node()]),
+            exit({error, {wrong_node, Node}})
+    end;
+
 process_message(?PT_MSG_CONFIGURE, MsgData, State) ->
     ConfProps = binary_to_term(MsgData),
     State#state{vnode_mod=proplists:get_value(vnode_mod, ConfProps),
                 partition=proplists:get_value(partition, ConfProps)};
 process_message(_, _MsgData, State=#state{sock=Socket,
                                           tcp_mod=TcpMod}) ->
-    TcpMod:send(Socket, <<255:8,"unknown_msg">>),
+    TcpMod:send(Socket, <<?PT_MSG_UNKNOWN:8,"unknown_msg">>),
     State.
 
 handle_cast(_Msg, State) -> {noreply, State}.


### PR DESCRIPTION
Horrible things happen when the handoff IP is set to localhost, and with horrible things I mean that monsters are going to eat all the data when nodes are being removed or added o.O
