### PR TITLE
Perf/remove module info

### DIFF
--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -164,13 +164,12 @@ test_link(Mod, From, RequestArgs, _Options, StateProps) ->
 init([Mod,
       From={_, ReqId, _},
       RequestArgs]) ->
-    Exports = Mod:module_info(exports),
     {Request, VNodeSelector, NVal, PrimaryVNodeCoverage,
      NodeCheckService, VNodeMaster, Timeout, PlannerMod, ModState} =
         Mod:init(From, RequestArgs),
     maybe_start_timeout_timer(Timeout),
-    PlanFun = plan_callback(Mod, Exports),
-    ProcessFun = process_results_callback(Mod, Exports),
+    PlanFun = plan_callback(Mod),
+    ProcessFun = process_results_callback(Mod),
     StateData = #state{mod=Mod,
                        mod_state=ModState,
                        node_check_service=NodeCheckService,
@@ -332,27 +331,26 @@ terminate(Reason, _StateName, _State) ->
 code_change(_OldVsn, StateName, State, _Extra) ->
     {ok, StateName, State}.
 
-plan_callback(Mod, Exports) ->
-    case exports(plan, Exports) of
-        true ->
+plan_callback(Mod) ->
+    try
+        Mod:plan(a, b)
+    catch
+        error:undef ->
+	    fun(_, ModState) ->
+		    {ok, ModState} end;
+        _:_ -> %% provided that Mod:plan(a, b) fails on atoms
             fun(CoverageVNodes, ModState) ->
-                    Mod:plan(CoverageVNodes, ModState) end;
-        _ -> fun(_, ModState) ->
-                     {ok, ModState} end
+                    Mod:plan(CoverageVNodes, ModState) end
     end.
 
-process_results_callback(Mod, Exports) ->
-    case exports_arity(process_results, 3, Exports) of
-        true ->
-            fun(VNode, Results, ModState) ->
-                    Mod:process_results(VNode, Results, ModState) end;
-        false ->
-            fun(_VNode, Results, ModState) ->
-                    Mod:process_results(Results, ModState) end
+process_results_callback(Mod) ->
+    try
+	Mod:process_results(a, b, c)
+    catch
+        error:undef ->
+	    fun(_VNode, Results, ModState) ->
+		    Mod:process_results(Results, ModState) end;
+	error:badarg -> %% or _:_ if Mod:process_results/3 isn't picky enough
+	    fun(VNode, Results, ModState) ->
+		    Mod:process_results(VNode, Results, ModState) end
     end.
-
-exports(Function, Exports) ->
-    proplists:is_defined(Function, Exports).
-
-exports_arity(Function, Arity, Exports) ->
-    lists:member(Arity, proplists:get_all_values(Function, Exports)).

--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -331,26 +331,42 @@ terminate(Reason, _StateName, _State) ->
 code_change(_OldVsn, StateName, State, _Extra) ->
     {ok, StateName, State}.
 
+%% This is to avoid expensive module_info calls, which were consuming
+%% 30% of the query-path time for small queries
+%%
+%% Instead we try Mod:plan/2, if undef, we define it.  On success or
+%% match error on atoms, we pass on Mod:plan/2 
+
 plan_callback(Mod) ->
     try
-        Mod:plan(a, b)
+        Mod:plan(a, b),
+	fun(CoverageVNodes, ModState) ->
+		Mod:plan(CoverageVNodes, ModState) end
     catch
         error:undef ->
 	    fun(_, ModState) ->
 		    {ok, ModState} end;
-        _:_ -> %% provided that Mod:plan(a, b) fails on atoms
+        _:_ -> %% If Mod:plan(a, b) fails on atoms
             fun(CoverageVNodes, ModState) ->
                     Mod:plan(CoverageVNodes, ModState) end
     end.
 
+%% This is to avoid expensive module_info calls, which were consuming
+%% 30% of the query-path time for small queries
+%%
+%% Instead we try Mod:process_results/3, if undef, we define it.  On success or
+%% match error on atoms, we pass on Mod:process_results/3
+
 process_results_callback(Mod) ->
     try
-	Mod:process_results(a, b, c)
+	Mod:process_results(a, b, c),
+	fun(VNode, Results, ModState) ->
+		Mod:process_results(VNode, Results, ModState) end
     catch
         error:undef ->
 	    fun(_VNode, Results, ModState) ->
 		    Mod:process_results(Results, ModState) end;
-	error:badarg -> %% or _:_ if Mod:process_results/3 isn't picky enough
+        _:_ -> %% If Mod:plan(a, b, c) fails on atoms
 	    fun(VNode, Results, ModState) ->
 		    Mod:process_results(VNode, Results, ModState) end
     end.

--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -340,12 +340,12 @@ code_change(_OldVsn, StateName, State, _Extra) ->
 plan_callback(Mod) ->
     try
         Mod:plan(a, b),
-	fun(CoverageVNodes, ModState) ->
-		Mod:plan(CoverageVNodes, ModState) end
+        fun(CoverageVNodes, ModState) ->
+                Mod:plan(CoverageVNodes, ModState) end
     catch
         error:undef ->
-	    fun(_, ModState) ->
-		    {ok, ModState} end;
+            fun(_, ModState) ->
+                    {ok, ModState} end;
         _:_ -> %% If Mod:plan(a, b) fails on atoms
             fun(CoverageVNodes, ModState) ->
                     Mod:plan(CoverageVNodes, ModState) end
@@ -359,14 +359,14 @@ plan_callback(Mod) ->
 
 process_results_callback(Mod) ->
     try
-	Mod:process_results(a, b, c),
-	fun(VNode, Results, ModState) ->
-		Mod:process_results(VNode, Results, ModState) end
+        Mod:process_results(a, b, c),
+        fun(VNode, Results, ModState) ->
+                Mod:process_results(VNode, Results, ModState) end
     catch
         error:undef ->
-	    fun(_VNode, Results, ModState) ->
-		    Mod:process_results(Results, ModState) end;
+            fun(_VNode, Results, ModState) ->
+                    Mod:process_results(Results, ModState) end;
         _:_ -> %% If Mod:plan(a, b, c) fails on atoms
-	    fun(VNode, Results, ModState) ->
-		    Mod:process_results(VNode, Results, ModState) end
+            fun(VNode, Results, ModState) ->
+                    Mod:process_results(VNode, Results, ModState) end
     end.

--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -339,16 +339,16 @@ code_change(_OldVsn, StateName, State, _Extra) ->
 
 plan_callback(Mod) ->
     SuccessFun = fun(CoverageVNodes, ModState) ->
-			 Mod:plan(CoverageVNodes, ModState) end,
+                         Mod:plan(CoverageVNodes, ModState) end,
     try
         SuccessFun(a, b),
-	SuccessFun
+        SuccessFun
     catch
         error:undef ->
             fun(_, ModState) ->
                     {ok, ModState} end;
         _:_ -> %% If Mod:plan(a, b) fails on atoms
-	    SuccessFun
+            SuccessFun
     end.
 
 %% This is to avoid expensive module_info calls, which were consuming
@@ -359,14 +359,14 @@ plan_callback(Mod) ->
 
 process_results_callback(Mod) ->
     SuccessFun = fun(VNode, Results, ModState) ->
-			 Mod:process_results(VNode, Results, ModState) end,
+                         Mod:process_results(VNode, Results, ModState) end,
     try
-	SuccessFun(a,b,c),
+        SuccessFun(a,b,c),
         SuccessFun
     catch
         error:undef ->
             fun(_VNode, Results, ModState) ->
                     Mod:process_results(Results, ModState) end;
         _:_ -> %% If Mod:plan(a, b, c) fails on atoms
-	    SuccessFun
+            SuccessFun
     end.

--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -338,17 +338,17 @@ code_change(_OldVsn, StateName, State, _Extra) ->
 %% match error on atoms, we pass on Mod:plan/2 
 
 plan_callback(Mod) ->
+    SuccessFun = fun(CoverageVNodes, ModState) ->
+			 Mod:plan(CoverageVNodes, ModState) end,
     try
-        Mod:plan(a, b),
-        fun(CoverageVNodes, ModState) ->
-                Mod:plan(CoverageVNodes, ModState) end
+        SuccessFun(a, b),
+	SuccessFun
     catch
         error:undef ->
             fun(_, ModState) ->
                     {ok, ModState} end;
         _:_ -> %% If Mod:plan(a, b) fails on atoms
-            fun(CoverageVNodes, ModState) ->
-                    Mod:plan(CoverageVNodes, ModState) end
+	    SuccessFun
     end.
 
 %% This is to avoid expensive module_info calls, which were consuming
@@ -358,15 +358,15 @@ plan_callback(Mod) ->
 %% match error on atoms, we pass on Mod:process_results/3
 
 process_results_callback(Mod) ->
+    SuccessFun = fun(VNode, Results, ModState) ->
+			 Mod:process_results(VNode, Results, ModState) end,
     try
-        Mod:process_results(a, b, c),
-        fun(VNode, Results, ModState) ->
-                Mod:process_results(VNode, Results, ModState) end
+	SuccessFun(a,b,c),
+        SuccessFun
     catch
         error:undef ->
             fun(_VNode, Results, ModState) ->
                     Mod:process_results(Results, ModState) end;
         _:_ -> %% If Mod:plan(a, b, c) fails on atoms
-            fun(VNode, Results, ModState) ->
-                    Mod:process_results(VNode, Results, ModState) end
+	    SuccessFun
     end.


### PR DESCRIPTION
This PR represents a significant performance improvement for small queries.  On initialization of the riak_kv_index_fsm thread, riak_core_coverage_fsm:init() calls module_info to determine if riak_kv_index_fsm exports plan/2 and process_results/3.  This call has been determined to consume more than 15% of the total query-path time for small queries.

This PR removes the module_info call on riak_kv_index_fsm in favor of a much faster try/catch mechanism that accomplishes the same task.  

plan_callback tries Mod:plan(a,b).  On success or badmatch (on atoms), it passes Mod:plan/2 as the callback.  On error:undef, it passes an anonymous function that serves as the plan callback. _(c.f. existing code, which checks if Mod exports plan/2 and returns Mod:plan/2 if so, anonymous function if not)_

process_results_callback likewise tries Mod:process_results(a,b,c).  On success or badmatch (on atoms), it passes Mod:process_results/3 as the callback.  On error:undef, it passes Mod:process_results/2 as the callback. _(c.f. existing code, which checks if Mod exports process_results/3 and returns Mod:process_results/3 if so, Mod:process_results/2 if not)_

I've tested this version in riak_test for functional correctness.  I've also profiled this version against the module_info version and found that it removes almost all the excess query-path time consumed in the module_info call.
