### PR TITLE
AAE canonical trees [JIRA: RIAK-2644]

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
   {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon.git", {branch, "2.0"}}},
   {riak_ensemble, ".*", {git, "git://github.com/basho/riak_ensemble", {branch, "2.0"}}},
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
-  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.15"}}},
+  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.18"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho5"}}},
   {clique, ".*", {git, "git://github.com/basho/clique.git", {tag, "0.2.5"}}}
 ]}.

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -410,6 +410,25 @@ update_tree(Segments, State=#state{next_rebuild=NextRebuild, width=Width,
                                    levels=Levels}) ->
     LastLevel = Levels,
     Hashes = orddict:from_list(hashes(State, Segments)),
+    %% Paranoia to make sure all of the hash entries are updated as expected
+    lager:debug("segments ~p -> hashes ~p\n", [Segments, Hashes]),
+    case {Segments, length(Segments), length(Hashes)} of
+	{?ALL_SEGMENTS, _, _} ->
+	    NextRebuild = full, % Paranoia to crash if ever here on incremental
+	    ok;
+	{_, Len, Len} ->
+	    ok;
+	{_, _SegLen, _HashLen} ->
+	    %% At this point the hashes are no longer sufficient to update
+	    %% the upper trees.  Alternative is to crash here, but that would
+	    %% lose updates and is the action taken on repair anyway.
+	    %% Save the customer some pain by doing that now and log.
+	    %% Enable lager debug tracing with lager:trace_file(hashtree, "/tmp/ht.trace"
+	    %% to get the detailed segment information.
+	    lager:warning("Incremental AAE hash was unable to find all required data, "
+			  "forcing full rebuild of ~p", [State#state.path]),
+	    update_perform(State#state{next_rebuild = full})
+    end,
     Groups = group(Hashes, Width),
     update_levels(LastLevel, Groups, State, NextRebuild).
 
@@ -707,6 +726,7 @@ update_levels(0, _, State, _) ->
     State;
 update_levels(Level, Groups, State, Type) ->
     {_, _, NewState, NewBuckets} = rebuild_fold(Level, Groups, State, Type),
+    lager:debug("level ~p hashes ~w\n", [Level, NewBuckets]),
     Groups2 = group(NewBuckets, State#state.width),
     update_levels(Level - 1, Groups2, NewState, Type).
 
@@ -868,10 +888,18 @@ multi_select_segment(#state{id=Id, itr=Itr}, Segments, F) ->
                    encode(Id, First, <<>>)
            end,
     IS2 = iterate(iterator_move(Itr, Seek), IS1),
-    #itr_state{current_segment=LastSegment,
+    #itr_state{remaining_segments = LeftOver,
+               current_segment=LastSegment,
                segment_acc=LastAcc,
                final_acc=FA} = IS2,
-    Result = [{LastSegment, F(LastAcc)} | FA],
+
+    %% iterate completes without processing the last entries in the state.  Compute
+    %% the final visited segment, and add calls to the F([]) for all of the segments
+    %% that do not exist at the end of the file (due to deleting the last entry in the
+    %% segment).
+    Result = [{LeftSeg, F([])} || LeftSeg <- lists:reverse(LeftOver),
+				  LeftSeg =/= '*'] ++
+	[{LastSegment, F(LastAcc)} | FA],
     case Result of
         [{'*', _}] ->
             %% Handle wildcard select when all segments are empty
@@ -966,13 +994,19 @@ iterate({ok, K, V}, IS=#itr_state{itr=Itr,
                                segment_acc=[{K,V}],
                                prefetch=true},
             iterate(iterator_move(Itr, prefetch), IS2);
-        {Id, _, [_NextSeg | _Remaining], true} ->
+        {Id, _, [NextSeg | Remaining], true} ->
             %% Pointing at uninteresting segment, but need to halt the
             %% prefetch to ensure the interator can be reused
-            IS2 = IS#itr_state{segment_acc=[],
+
+            %% Do not update segment/final_acc
+            IS2 = IS#itr_state{current_segment=NextSeg,
+                               segment_acc=[],
+                               remaining_segments=Remaining,
                                final_acc=[{Segment, F(Acc)} | FinalAcc],
-                               prefetch=false},
-            iterate(iterator_move(Itr, prefetch_stop), IS2);
+                               prefetch=true}, % will be after second move
+            _ = iterator_move(Itr, prefetch_stop), % ignore the pre-fetch,
+            Seek = encode(Id, NextSeg, <<>>),      % and risk wasting a reseek
+            iterate(iterator_move(Itr, Seek), IS2);% to get to the next segment
         {Id, _, [NextSeg | Remaining], false} ->
             %% Pointing at uninteresting segment, seek to next interesting one
             Seek = encode(Id, NextSeg, <<>>),
@@ -1025,6 +1059,9 @@ exchange_level(Level, Buckets, Local, Remote, _Opts) ->
                           B = Remote(get_bucket, {Level, Bucket}),
                           Delta = riak_ensemble_util:orddict_delta(lists:keysort(1, A),
                                                                    lists:keysort(1, B)),
+			  lager:debug("Exchange Level ~p Bucket ~p\nA=~p\nB=~p\nD=~p\n",
+				      [Level, Bucket, A, B, Delta]),
+
                           Diffs = Delta,
                           [BK || {BK, _} <- Diffs]
                   end, Buckets).
@@ -1036,6 +1073,8 @@ exchange_final(_Level, Segments, Local, Remote, AccFun, Acc0, _Opts) ->
                         B = Remote(key_hashes, Segment),
                         Delta = riak_ensemble_util:orddict_delta(lists:keysort(1, A),
                                                                  lists:keysort(1, B)),
+			lager:debug("Exchange Final\nA=~p\nB=~p\nD=~p\n",
+				    [A, B, Delta]),
                         Keys = [begin
                                     {_Id, Segment, Key} = decode(KBin),
                                     Type = key_diff_type(Diff),
@@ -1057,6 +1096,8 @@ compare(Level, Bucket, Tree, Remote, AccFun, KeyAcc) ->
     Inter = ordsets:intersection(ordsets:from_list(HL1),
                                  ordsets:from_list(HL2)),
     Diff = ordsets:subtract(Union, Inter),
+    lager:debug("Tree ~p level ~p bucket ~p\nL=~p\nR=~p\nD=\n",
+		[Tree, Level, Bucket, HL1, HL2, Diff]),
     KeyAcc3 =
         lists:foldl(fun({Bucket2, _}, KeyAcc2) ->
                             compare(Level+1, Bucket2, Tree, Remote, AccFun, KeyAcc2)
@@ -1070,6 +1111,8 @@ compare_segments(Segment, Tree=#state{id=Id}, Remote) ->
     HL1 = orddict:from_list(KeyHashes1),
     HL2 = orddict:from_list(KeyHashes2),
     Delta = orddict_delta(HL1, HL2),
+    lager:debug("Tree ~p segment ~p diff ~p\n",
+                [Tree, Segment, Delta]),
     Keys = [begin
                 {Id, Segment, Key} = decode(KBin),
                 Type = key_diff_type(Diff),

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -1061,8 +1061,6 @@ iterate({ok, K, V}, IS=#itr_state{itr=Itr,
         {Id, _, [NextSeg | Remaining], true} ->
             %% Pointing at uninteresting segment, but need to halt the
             %% prefetch to ensure the iterator can be reused
-
-            %% Do not update segment/final_acc
             IS2 = IS#itr_state{current_segment=NextSeg,
                                segment_acc=[],
                                remaining_segments=Remaining,

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -926,7 +926,7 @@ encode_meta(Key) ->
 
 -spec hashes(hashtree(), list('*'|integer())) -> [{integer(), binary()}].
 hashes(State, Segments) ->
-     multi_select_segment(State, Segments, fun hash/1).
+    multi_select_segment(State, Segments, fun hash/1).
 
 -spec snapshot(hashtree()) -> hashtree().
 snapshot(State) ->

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -1058,17 +1058,9 @@ iterate({ok, K, V}, IS=#itr_state{itr=Itr,
                                final_acc=[{Segment, F(Acc)} | FinalAcc],
                                prefetch=true},
             iterate(iterator_move(Itr, prefetch), IS2);
-        {Id, NextSeg, [NextSeg|Remaining], _} ->
-            %% A previous prefetch_stop left us at the start of the
-            %% next interesting segment.
-            IS2 = IS#itr_state{current_segment=NextSeg,
-                               remaining_segments=Remaining,
-                               segment_acc=[{K,V}],
-                               prefetch=true},
-            iterate(iterator_move(Itr, prefetch), IS2);
         {Id, _, [NextSeg | Remaining], true} ->
             %% Pointing at uninteresting segment, but need to halt the
-            %% prefetch to ensure the interator can be reused
+            %% prefetch to ensure the iterator can be reused
 
             %% Do not update segment/final_acc
             IS2 = IS#itr_state{current_segment=NextSeg,

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -137,7 +137,7 @@
 -define(BIN_TO_INT(B), list_to_integer(binary_to_list(B))).
 
 -ifdef(TEST).
--export([fake_close/1, local_compare/2]).
+-export([fake_close/1, local_compare/2, local_compare1/2]).
 -export([run_local/0,
          run_local/1,
          run_concurrent_build/0,
@@ -1435,6 +1435,23 @@ local_compare(T1, T2) ->
                      Keys ++ KeyAcc
              end,
     compare2(T1, Remote, AccFun, []).
+
+-spec local_compare1(hashtree(), hashtree()) -> [keydiff()].
+local_compare1(T1, T2) ->
+    Remote = fun(get_bucket, {L, B}) ->
+        get_bucket(L, B, T2);
+        (start_exchange_level, {_Level, _Buckets}) ->
+            ok;
+        (start_exchange_segments, _Segments) ->
+            ok;
+        (key_hashes, Segment) ->
+            [{_, KeyHashes2}] = key_hashes(T2, Segment),
+            KeyHashes2
+             end,
+    AccFun = fun(Keys, KeyAcc) ->
+        Keys ++ KeyAcc
+             end,
+    compare(T1, Remote, AccFun, []).
 
 -spec compare(hashtree(), remote_fun()) -> [keydiff()].
 compare(Tree, Remote) ->

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -970,8 +970,8 @@ multi_select_segment(#state{id=Id, itr=Itr}, Segments, F) ->
     %% that do not exist at the end of the file (due to deleting the last entry in the
     %% segment).
     Result = [{LeftSeg, F([])} || LeftSeg <- lists:reverse(LeftOver),
-				  LeftSeg =/= '*'] ++
-	[{LastSegment, F(LastAcc)} | FA],
+                  LeftSeg =/= '*'] ++
+    [{LastSegment, F(LastAcc)} | FA],
     case Result of
         [{'*', _}] ->
             %% Handle wildcard select when all segments are empty
@@ -1123,8 +1123,8 @@ exchange_level(Level, Buckets, Local, Remote, _Opts) ->
                           B = Remote(get_bucket, {Level, Bucket}),
                           Delta = riak_ensemble_util:orddict_delta(lists:keysort(1, A),
                                                                    lists:keysort(1, B)),
-			  lager:debug("Exchange Level ~p Bucket ~p\nA=~p\nB=~p\nD=~p\n",
-				      [Level, Bucket, A, B, Delta]),
+              lager:debug("Exchange Level ~p Bucket ~p\nA=~p\nB=~p\nD=~p\n",
+                      [Level, Bucket, A, B, Delta]),
 
                           Diffs = Delta,
                           [BK || {BK, _} <- Diffs]
@@ -1137,8 +1137,8 @@ exchange_final(_Level, Segments, Local, Remote, AccFun, Acc0, _Opts) ->
                         B = Remote(key_hashes, Segment),
                         Delta = riak_ensemble_util:orddict_delta(lists:keysort(1, A),
                                                                  lists:keysort(1, B)),
-			lager:debug("Exchange Final\nA=~p\nB=~p\nD=~p\n",
-				    [A, B, Delta]),
+            lager:debug("Exchange Final\nA=~p\nB=~p\nD=~p\n",
+                    [A, B, Delta]),
                         Keys = [begin
                                     {_Id, Segment, Key} = decode(KBin),
                                     Type = key_diff_type(Diff),
@@ -1161,7 +1161,7 @@ compare(Level, Bucket, Tree, Remote, AccFun, KeyAcc) ->
                                  ordsets:from_list(HL2)),
     Diff = ordsets:subtract(Union, Inter),
     lager:debug("Tree ~p level ~p bucket ~p\nL=~p\nR=~p\nD=\n",
-		[Tree, Level, Bucket, HL1, HL2, Diff]),
+        [Tree, Level, Bucket, HL1, HL2, Diff]),
     KeyAcc3 =
         lists:foldl(fun({Bucket2, _}, KeyAcc2) ->
                             compare(Level+1, Bucket2, Tree, Remote, AccFun, KeyAcc2)

--- a/test/hashtree_eqc.erl
+++ b/test/hashtree_eqc.erl
@@ -176,7 +176,7 @@ command(_S = #state{started = true, tree_id = TreeId,
 	[{10*SF, {call, ?MODULE, update_snapshot,  [t1, s1]}} || Snap1 == undefined, MemLevels == 0] ++
 	[{10*SF, {call, ?MODULE, update_perform,   [t1]}} || Snap1 == created, MemLevels == 0] ++
 	[{10*SF, {call, ?MODULE, set_next_rebuild, [t1]}} || Snap1 == updated] ++
-        [{10*SF, {call, ?MODULE, update_tree,  [t2, s2]}} || Snap1 == undefined] ++
+        [{10*SF, {call, ?MODULE, update_tree,  [t2, s2]}} || Snap2 == undefined] ++
 	[{10*SF, {call, ?MODULE, update_snapshot,  [t2, s2]}} || Snap2 == undefined, MemLevels == 0] ++
 	[{10*SF, {call, ?MODULE, update_perform,   [t2]}} || Snap2 == created, MemLevels == 0] ++
 	[{10*SF, {call, ?MODULE, set_next_rebuild, [t2]}} || Snap2 == updated] ++

--- a/test/hashtree_eqc.erl
+++ b/test/hashtree_eqc.erl
@@ -17,6 +17,28 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
+%%
+%% Hashtree EQC test.
+%%
+%% Generates a pair of logically identical AAE trees populated with data
+%% and some phantom trees in the same leveldb database to exercise all
+%% of the cases in iterate.
+%%
+%% Then runs commands to insert, delete, snapshot, update tree
+%% and compare.
+%%
+%% The expected values are stored in two ETS tables t1 and t2,
+%% with the most recently snapshotted values copied to tables s1 and s2.
+%% (the initial common seed data is not included in the ETS tables).
+%%
+%% The hashtree's themselves are stored in the process dictionary under
+%% key t1 and t2.  This helps with shrinking as it reduces dependencies
+%% between states (or at least that's why I remember doing it).
+%%
+%% Model state stores where each tree is through the snapshot/update cycle.
+%% The command frequencies are deliberately manipulated to make it more
+%% likely that compares will take place once both trees are updated.
+%%
 
 -module(hashtree_eqc).
 -compile([export_all]).
@@ -33,19 +55,37 @@
 -include_lib("eunit/include/eunit.hrl").
 
 hashtree_test_() ->
-    {timeout, 60,
-        fun() ->
-                ?assert(eqc:quickcheck(?QC_OUT(eqc:testing_time(29,
-                            hashtree_eqc:prop_correct()))))
-        end
-    }.
+    {setup,
+     fun() ->
+             application:set_env(lager, handlers, [{lager_console_backend, info}]),
+             application:ensure_started(syntax_tools),
+             application:ensure_started(compiler),
+             application:ensure_started(goldrush),
+             application:ensure_started(lager)
+     end,
+     fun(_) ->
+             application:stop(lager),
+             application:stop(goldrush),
+             application:stop(compiler),
+             application:stop(syntax_tools),
+             application:unload(lager)
+     end,
+     [{timeout, 60,
+       fun() ->
+              lager:info("Any warnings should be investigated.  No lager output expected.\n"),
+              ?assert(eqc:quickcheck(?QC_OUT(eqc:testing_time(29,
+                                                              hashtree_eqc:prop_correct()))))
+      end
+      }]}.
 
 -record(state,
     {
-      started = false,
-      params = undefined,
-      only1 = [],
-      only2 = []
+      started = false,    % Boolean to prevent commands running before initialization step.
+      tree_id,            % Tree Id
+      params = undefined, % {Segments, Width, MemLevels}
+      snap1 = undefined,  % undefined, created, updated
+      snap2 = undefined,  % undefined, created, updated
+      num_updates = 0     % number of insert/delete operations
     }).
 
 integer_to_binary(Int) ->
@@ -68,60 +108,199 @@ object() ->
 objects() ->
     non_empty(list(object())).
 
+levels() ->
+    frequency([{20, 1},
+               { 5, 2}, % production
+               { 1, 3}]).
+
+mem_levels() -> %% Number of memory levels - strongly favor defefault setting
+    frequency([{20, 0},
+               { 1, 1},
+               { 1, 2},
+               { 1, 3},
+               { 1, 4}]).
+
+width() ->
+    frequency([{  1,    8},
+               {100,   16}, % pick for high density segments
+               {  1,   32},
+               {  1,   64},
+               {  1,  128},
+               {  1,  256},
+               {  1,  512},
+               { 50, 1024}]). % pick for production
+
+params() -> % {Segments, Width, MemLevels}
+    %% Generate in terms of number of levels, from that work out the segments
+    ?LET({Levels, Width, MemLevels},{levels(), width(), mem_levels()},
+         {trunc(math:pow(Width, Levels)), Width, MemLevels}).
+
 mark() ->
     frequency([{1, mark_empty}, {5, mark_open}]).
 
-command(_S = #state{started = Started}) ->
+%% Generate tree ids - the first one is used for the test, the others are added
+%% as empty hashtrees.
+ids() ->
+    non_empty(list({?LET(X, nat(), 1+X), ?LET(X,nat(), min(X,255))})).
+
+%%
+%% Generate the commands, split into two cases to force the start to happen as
+%% the first command.
+%%
+command(_S = #state{started = false}) ->
+    {call, ?MODULE, start, [params(), ids(), mark(), mark()]};
+command(_S = #state{started = true, tree_id = TreeId,
+                    params = {_Segments, _Width, MemLevels},
+                    snap1 = Snap1, snap2 = Snap2}) ->
+    %% Weights to increase snap frequency once update snapshot has begun
+    SS = Snap1 /= undefined orelse Snap2 /= undefined,
+    SF = case SS of true -> 100; _ -> 1 end,
     frequency(
-        [{1, {call, ?MODULE, start,
-              [{oneof(?POWERS), oneof(?POWERS), choose(0, 4)}, mark(), mark()]}} || not Started] ++
-        [{1, {call, ?MODULE, update_tree, [t1]}} || Started] ++
-        [{1, {call, ?MODULE, update_tree, [t2]}} || Started] ++
-        [{50, {call, ?MODULE, write, [t1, objects()]}} || Started] ++
-        [{50, {call, ?MODULE, write, [t2, objects()]}} || Started] ++
-        [{100,{call, ?MODULE, write_both, [objects()]}} || Started] ++
-        [{50, {call, ?MODULE, delete, [t1, key()]}} || Started] ++
-        [{50, {call, ?MODULE, delete, [t2, key()]}} || Started] ++
-        [{100,{call, ?MODULE, delete_both, [key()]}} || Started] ++
-        [{1, {call, ?MODULE, reopen_tree, [t1]}} || Started] ++
-        [{1, {call, ?MODULE, reopen_tree, [t2]}} || Started] ++
-        [{1, {call, ?MODULE, unsafe_close, [t1]}} || Started] ++
-        [{1, {call, ?MODULE, unsafe_close, [t2]}} || Started] ++
-        [{1, {call, ?MODULE, rehash_tree, [t1]}} || Started] ++
-        [{1, {call, ?MODULE, rehash_tree, [t2]}} || Started] ++
-        [{1, {call, ?MODULE, reconcile, []}} || Started] ++
-        []
+      %% Update snapshots/trees. If memory is enabled must test with update_tree
+      %% If not, can use the method used by kv/yz_index_hashtree and separate
+      %% the two steps, dumping the result from update_perform.
+        [{10*SF, {call, ?MODULE, update_tree,  [t1, s1]}} || Snap1 == undefined] ++
+	[{10*SF, {call, ?MODULE, update_snapshot,  [t1, s1]}} || Snap1 == undefined, MemLevels == 0] ++
+	[{10*SF, {call, ?MODULE, update_perform,   [t1]}} || Snap1 == created, MemLevels == 0] ++
+	[{10*SF, {call, ?MODULE, set_next_rebuild, [t1]}} || Snap1 == updated] ++
+        [{10*SF, {call, ?MODULE, update_tree,  [t2, s2]}} || Snap1 == undefined] ++
+	[{10*SF, {call, ?MODULE, update_snapshot,  [t2, s2]}} || Snap2 == undefined, MemLevels == 0] ++
+	[{10*SF, {call, ?MODULE, update_perform,   [t2]}} || Snap2 == created, MemLevels == 0] ++
+	[{10*SF, {call, ?MODULE, set_next_rebuild, [t2]}} || Snap2 == updated] ++
+
+      %% Can only run compares when both snapshots are updated.  Boost the frequency
+      %% when both are snapshotted (note this is guarded by both snapshot being updatable)
+        [{100*SF, {call, ?MODULE, local_compare, []}} || Snap1 == updated, Snap2 == updated] ++
+
+      %% Modify the data in the two tables
+        [{101-SF, {call, ?MODULE, write, [t1, objects()]}},
+	 {101-SF, {call, ?MODULE, write, [t2, objects()]}},
+         {101-SF, {call, ?MODULE, write_both, [objects()]}},
+         {101-SF, {call, ?MODULE, delete, [t1, key()]}},
+         {101-SF, {call, ?MODULE, delete, [t2, key()]}},
+         {101-SF, {call, ?MODULE, delete_both, [key()]}},
+
+      %% Mess around with reopening, crashing and rehashing.
+         {  1, {call, ?MODULE, reopen_tree, [t1, TreeId]}},
+         {  1, {call, ?MODULE, reopen_tree, [t2, TreeId]}},
+         {  1, {call, ?MODULE, unsafe_close, [t1, TreeId]}},
+         {  1, {call, ?MODULE, unsafe_close, [t2, TreeId]}},
+         {  1, {call, ?MODULE, rehash_tree, [t1]}},
+         {  1, {call, ?MODULE, rehash_tree, [t2]}}
+	]
     ).
 
-start(Params, T1Mark, T2Mark) ->
+%%
+%% Start the model up - initialize two trees, either mark them as open and empty
+%% or request they are checked.  Add additional unused hashtrees with ExtraIds
+%% to make sure the iterator code is fully exercised.
+%%
+%% Store the hashtree records in the process dictionary under keys 't1' and 't2'.
+%% 
+start(Params, [TreeId | ExtraIds], T1Mark, T2Mark) ->
     {Segments, Width, MemLevels} = Params,
     %% Return now so we can store symbolic value in procdict in next_state call
-    HT1 = hashtree:new({0,0}, [{segments, Segments},
+    T1 = hashtree:new(TreeId, [{segments, Segments},
                                {width, Width},
                                {mem_levels, MemLevels}]),
 
-    T1 = case T1Mark of
-        mark_empty -> hashtree:mark_open_empty({0,0}, HT1);
-        _ -> hashtree:mark_open_and_check({0,0}, HT1)
+    T1A = case T1Mark of
+        mark_empty -> hashtree:mark_open_empty(TreeId, T1);
+        _ -> hashtree:mark_open_and_check(TreeId, T1)
     end,
 
-    put(t1, T1),
+    add_extra_hashtrees(ExtraIds, T1A),
 
-    HT2 = hashtree:new({0,0}, [{segments, Segments},
-                               {width, Width},
-                               {mem_levels, MemLevels}]),
+    put(t1, T1A),
 
-    T2 = case T2Mark of
-        mark_empty -> hashtree:mark_open_empty({0,0}, HT2);
-        _ -> hashtree:mark_open_and_check({0,0}, HT2)
+    T2 = hashtree:new(TreeId, [{segments, hashtree:segments(T1A)},
+                               {width, hashtree:width(T1A)},
+                               {mem_levels, hashtree:mem_levels(T1A)}]),
+
+    T2A = case T2Mark of
+        mark_empty -> hashtree:mark_open_empty(TreeId, T2);
+        _ -> hashtree:mark_open_and_check(TreeId, T2)
     end,
 
-    put(t2, T2),
+    add_extra_hashtrees(ExtraIds, T2A),
 
-    ets:new(t1, [named_table, public, set]),
-    ets:new(t2, [named_table, public, set]),
+    put(t2, T2A),
+
+    %% Make sure ETS is pristine
+    catch ets:delete(t1),
+    catch ets:delete(t2),
+    catch ets:delete(s1),
+    catch ets:delete(s2),
+    ets_new(t1),
+    ets_new(t2),
+    TreeId.
+			   
+
+%% Add some extra tree ids and update the metadata to give
+%% the iterator code a workout on non-matching ids.
+add_extra_hashtrees(ExtraIds, T) ->
+    lists:foldl(fun(ExtraId, Tacc) ->
+			Tacc2 = hashtree:new(ExtraId, Tacc),
+			Tacc3 = hashtree:mark_open_empty(ExtraId, Tacc2),
+			Tacc4 = hashtree:insert(<<"k">>, <<"v">>, Tacc3),
+			hashtree:flush_buffer(Tacc4)
+		end, T, ExtraIds).
+
+%% Wrap the hashtree:update_tree call.  This works with memory levels
+%% enabled.  Copy the model tree to a snapshot table.
+update_tree(T, S) ->
+    %% Snapshot the hashtree and store both states
+    HT = hashtree:update_tree(get(T)),
+    put(T, HT),
+    %% Copy the current ets table to the snapshot table.
+    copy_tree(T, S),
     ok.
 
+%% Wrap the hashtree:update_snapshot call and set the next rebuild type to full
+%% to match the behavior needed by the *_index_hashtree modules that consume
+%% hashtree.  Otherwise if the state is treated as incremental on a safe reopen
+%% then the tree does not rebuild correctly.
+%%
+%% Store the snapshot state in the process dictionary under {snapstate, t1} or
+%% {snapstate, t2} for use by update_perform.
+%%
+%% N.B. This does not work with memory levels enabled as update_perform uses the
+%% snapshot state which is dumped.
+%%
+update_snapshot(T, S) ->
+    %% Snapshot the hashtree and store both states
+    {SS, HT} = hashtree:update_snapshot(get(T)),
+
+    %% Mark as a full rebuild until the update perfom step happens.
+    HT2 = hashtree:set_next_rebuild(HT, full),
+
+    put(T, HT2),
+    put({snapstate, T}, SS),
+    %% Copy the current ets table to the snapshot table.
+    copy_tree(T, S),
+    ok.
+
+
+%% 
+%% Wrap the hashtree:update_perform call and erase the snapshot hashtree state.
+%% Should only happen if a snapshot state exists.
+%%
+update_perform(T) ->
+    _ = hashtree:update_perform(get({snapstate, T})),
+    erase({snapstate, T}),
+    ok.
+
+
+%% Set the next rebuild state. Should only happen once update perform has
+%% completed.
+%%
+set_next_rebuild(T) ->
+    _ = hashtree:set_next_rebuild(get(T), incremental).
+
+
+%% Wrap hashtree:insert to (over)write key with a new hash to a single
+%% table and insert into the model tree.
+%%
 write(T, Objects) ->
     lists:foreach(fun({Key, Hash}) ->
                           put(T, hashtree:insert(Key, Hash, get(T))),
@@ -129,48 +308,59 @@ write(T, Objects) ->
                   end, Objects),
     ok.
 
+%% Call the other wrapper to write to both trees.
+%%
 write_both(Objects) ->
     write(t1, Objects),
     write(t2, Objects),
     ok.
 
+
+%% Wrap hashtree:delete to remove a key from a tree (and remove
+%% from the model tree).
+%%
+%% Keys do not need to be present to remove them from the AAE tree.
 delete(T, Key) ->
     put(T, hashtree:delete(Key, get(T))),
     ets:delete(T, Key),
     ok.
 
+%% Call the other wrapper to remove the key from both trees.
 delete_both(Key) ->
     delete(t1, Key),
     delete(t2, Key),
     ok.
 
-update_tree(T) ->
-    put(T, hashtree:update_tree(get(T))),
-    ok.
-
+%% Trigger a rehash of the whole interior tree.  There is a potential
+%% race condition with update_snapshot that is avoided by this model,
+%% however if called during update_perform executing it will silently
+%% break multi_select_segment.
 rehash_tree(T) ->
     put(T, hashtree:rehash_tree(get(T))),
     ok.
 
-reopen_tree(T) ->
+%% Flush, update tree, mark clean close, close and reopen the AAE tree.
+reopen_tree(T, TreeId) ->
     HT = hashtree:flush_buffer(get(T)),
     {Segments, Width, MemLevels} = {hashtree:segments(HT), hashtree:width(HT),
                                     hashtree:mem_levels(HT)},
     Path = hashtree:path(HT),
 
     UpdatedHT = hashtree:update_tree(HT),
-    CleanClosedHT = hashtree:mark_clean_close({0,0}, UpdatedHT),
+    CleanClosedHT = hashtree:mark_clean_close(TreeId, UpdatedHT),
     hashtree:close(CleanClosedHT),
 
-    T1 = hashtree:new({0,0}, [{segments, Segments},
+    T1 = hashtree:new(TreeId, [{segments, Segments},
                               {width, Width},
                               {mem_levels, MemLevels},
                               {segment_path, Path}]),
 
-    put(T, hashtree:mark_open_and_check({0,0}, T1)),
+    put(T, hashtree:mark_open_and_check(TreeId, T1)),
     ok.
 
-unsafe_close(T) ->
+%% Simulate an unsafe close.  This flushes the write buffer so that the
+%% model has a chance of knowing what the correct repairs should be.
+unsafe_close(T, TreeId) ->
     HT = get(T),
     {Segments, Width, MemLevels} = {hashtree:segments(HT), hashtree:width(HT),
                                     hashtree:mem_levels(HT)},
@@ -181,48 +371,50 @@ unsafe_close(T) ->
     hashtree:flush_buffer(HT),
     hashtree:fake_close(HT),
 
-    T0 = hashtree:new({0,0}, [{segments, Segments},
+    T0 = hashtree:new(TreeId, [{segments, Segments},
                               {width, Width},
                               {mem_levels, MemLevels},
                               {segment_path, Path}]),
 
-    put(T, hashtree:mark_open_and_check({0,0}, T0)),
+    put(T, hashtree:mark_open_and_check(TreeId, T0)),
 
     ok.
 
-reconcile() ->
-    put(t1, hashtree:update_tree(get(t1))),
-    put(t2, hashtree:update_tree(get(t2))),
-    KeyDiff = hashtree:local_compare(get(t1), get(t2)),
-    Missing = [M || {missing, M} <- KeyDiff],
-    RemoteMissing = [M || {remote_missing, M} <- KeyDiff],
-    Different = [D || {different, D} <- KeyDiff],
+%% Use the internal eunit local comparison to check for differences between the
+%% two trees.
+local_compare() ->
+    hashtree:local_compare(get(t1), get(t2)).
 
-    Insert = fun(T, Vals) ->
-                 write(T, Vals)
-             end,
+%% Preconditions to guard against impossible situations during shrinking.
+precondition(#state{started = false}, {call, _, F, _A}) ->
+    F == start;
+%% Make sure update_tree can only be called with no memory levels
+precondition(#state{params = {_, _, MemLevels}, snap1 = Snap1}, {call, _, update_tree, [t1, _]}) ->
+    Snap1 == undefined andalso MemLevels == 0;
+precondition(#state{params = {_, _, MemLevels}, snap2 = Snap2}, {call, _, update_tree, [t2, _]}) ->
+    Snap2 == undefined andalso MemLevels == 0;
+%% Make sure only one snapshot, tree update or rebuild is happening in sequence
+precondition(#state{snap1 = Snap1}, {call, _, update_snapshot, [t1, _]}) ->
+    Snap1 == undefined;
+precondition(#state{snap1 = Snap1}, {call, _, update_perform, [t1]}) ->
+    Snap1 == created;
+precondition(#state{snap1 = Snap1}, {call, _, set_next_rebuild, [t1]}) ->
+    Snap1 == updated;
+precondition(#state{snap2 = Snap2}, {call, _, update_snapshot, [t2, _]}) ->
+    Snap2 == undefined;
+precondition(#state{snap2 = Snap2}, {call, _, update_perform, [t2]}) ->
+    Snap2 == created;
+precondition(#state{snap2 = Snap2}, {call, _, set_next_rebuild, [t2]}) ->
+    Snap2 == updated;
+%% Only compare once the tree has been updated for the snapshot
+precondition(#state{snap1 = Snap1, snap2 = Snap2}, {call, _, local_compare, []}) ->
+    Snap1 == updated andalso Snap2 == updated;
+precondition(_S, _C) ->
+    true.
 
-    %% Lazy reuse of existing code - could be changed to check ETS directly
-    Only1 = ets:tab2list(t1),
-    Only2 = ets:tab2list(t2),
-
-    Insert(t1, [lists:keyfind(K, 1, Only2) ||  K <- Missing, lists:keyfind(K, 1,
-                Only2) /= false]),
-    Insert(t2, [lists:keyfind(K, 1, Only1) ||  K <- RemoteMissing, lists:keyfind(K, 1,
-                Only1) /= false]),
-    Insert(t2, [lists:keyfind(K, 1, Only1) ||  K <- Different, lists:keyfind(K, 1,
-                Only1) /= false]),
-    ok.
-
-precondition(#state{started = Started}, {call, _, F, _A}) ->
-    case F of
-        start ->
-            Started == false;
-        _ ->
-            Started == true
-    end.
-
-postcondition(_S,{call,_,start, [_, T1Mark, T2Mark]},_R) ->
+%% Check the post conditions.  After the initial create,
+%% make sure the next rebuilds are set correctly
+postcondition(_S,{call,_,start, [_Params, _ExtraIds, T1Mark, T2Mark]},_R) ->
     NextRebuildT1 = hashtree:next_rebuild(get(t1)),
     NextRebuildT2 = hashtree:next_rebuild(get(t2)),
     case T1Mark of
@@ -233,40 +425,59 @@ postcondition(_S,{call,_,start, [_, T1Mark, T2Mark]},_R) ->
         mark_empty -> eq(NextRebuildT2, incremental);
         _ -> eq(NextRebuildT2, full)
     end;
+%% After a comparison, check against the results against
+%% the ETS table containing the *snapshot* copies.
+postcondition(_S,{call, _, local_compare, _},  Result) ->
+    Expect = expect_compare(),
+    eq(Expect, lists:sort(Result));	
 postcondition(_S,{call,_,_,_},_R) ->
     true.
 
-next_state(S,_R,{call, _, start, [Params,_,_]}) ->
-    S#state{started = true, params = Params};
-next_state(S,_V,{call, _, write, [t1, Objects]}) ->
-    S#state{only1=keymerge(Objects, S#state.only1)};
-next_state(S,_V,{call, _, write, [t2, Objects]}) ->
-    S#state{only2=keymerge(Objects, S#state.only2)};
-next_state(S,_R,{call, _, write_both, [Objects]}) ->
-    S#state{only1=keymerge(Objects, S#state.only1),
-            only2=keymerge(Objects, S#state.only2)};
-next_state(S,_V,{call, _, delete, [t1, Key]}) ->
-    S#state{only1=lists:keydelete(Key, 1, S#state.only1)};
-next_state(S,_V,{call, _, delete, [t2, Key]}) ->
-    S#state{only2=lists:keydelete(Key, 1, S#state.only2)};
-next_state(S,_R,{call, _, delete_both, [Key]}) ->
-    S#state{only1=lists:keydelete(Key, 1, S#state.only1),
-            only2=lists:keydelete(Key, 1, S#state.only2)};
-next_state(S,_R,{call, _, reopen_tree, _A}) ->
-    S;
-next_state(S,_R,{call, _, unsafe_close, _A}) ->
-    S;
-next_state(S,_R,{call, _, rehash_tree, _A}) ->
-    S;
-next_state(S,_R,{call, _, reconcile, []}) ->
-    Keys = keymerge(S),
-    S#state{only1 = Keys,
-            only2 = Keys};
-next_state(S,_R,{call, _, update_tree, _A}) ->
+next_state(S,R,{call, _, start, [Params,_ExtraIds,_,_]}) ->
+    %% Start returns the TreeId used, stick in the state
+    %% as no hashtree:tree_id call yet.
+    S#state{started = true, tree_id = R, params = Params};
+next_state(S,_V,{call, _, update_tree, [t1, _]}) ->
+    S#state{snap1 = updated};
+next_state(S,_V,{call, _, update_tree, [t2, _]}) ->
+    S#state{snap2 = updated};
+next_state(S,_V,{call, _, update_snapshot, [t1, _]}) ->
+    S#state{snap1 = created};
+next_state(S,_V,{call, _, update_snapshot, [t2, _]}) ->
+    S#state{snap2 = created};
+next_state(S,_V,{call, _, update_perform, [t1]}) ->
+    S#state{snap1 = updated};
+next_state(S,_V,{call, _, update_perform, [t2]}) ->
+    S#state{snap2 = updated};
+next_state(S,_V,{call, _, set_next_rebuild, [t1]}) ->
+    S#state{snap1 = undefined};
+next_state(S,_V,{call, _, set_next_rebuild, [t2]}) ->
+    S#state{snap2 = undefined};
+next_state(S,_V,{call, _, write, [_T, Objs]}) ->
+    S#state{num_updates = S#state.num_updates + length(Objs)};
+next_state(S,_R,{call, _, write_both, [Objs]}) ->
+    S#state{num_updates = S#state.num_updates + 2*length(Objs)};
+next_state(S,_V,{call, _, delete, _}) ->
+    S#state{num_updates = S#state.num_updates + 1};
+next_state(S,_R,{call, _, delete_both, _}) ->
+    S#state{num_updates = S#state.num_updates + 2};
+next_state(S,_R,{call, _, reopen_tree, [t1, _]}) ->
+    S#state{snap1 = undefined};
+next_state(S,_R,{call, _, reopen_tree, [t2, _]}) ->
+    S#state{snap2 = undefined};
+next_state(S,_R,{call, _, unsafe_close, [t1, _]}) ->
+    S#state{snap1 = undefined};
+next_state(S,_R,{call, _, unsafe_close, [t2, _]}) ->
+    S#state{snap2 = undefined};
+next_state(S,_R,{call, _, rehash_tree, [t1]}) ->
+    S#state{snap1 = undefined};
+next_state(S,_R,{call, _, rehash_tree, [t2]}) ->
+    S#state{snap2 = undefined};
+next_state(S,_R,{call, _, local_compare, []}) ->
     S.
 
 prop_correct() ->
-    ?FORALL(Cmds,non_empty(commands(?MODULE, #state{})),
+    ?FORALL(Cmds,commands(?MODULE, #state{}),
             aggregate(command_names(Cmds),
                 begin
                     %%io:format(user, "Starting in ~p\n", [self()]),
@@ -275,67 +486,40 @@ prop_correct() ->
                     catch ets:delete(t1),
                     catch ets:delete(t2),
                     {_H,S,Res} = HSR = run_commands(?MODULE,Cmds),
+		    {Segments, Width, MemLevels} = 
+                        case S#state.params of
+                            undefined ->
+                                %% Possible if Cmds just init
+                                %% set segments to 1 to avoid div by zero
+                                {1, undefined, undefined};
+                            Params ->
+                                Params
+                        end,
+                    NumUpdates = S#state.num_updates,
                     pretty_commands(?MODULE, Cmds, HSR,
                                     ?WHENFAIL(
                                        begin
+					   {Segments, Width, MemLevels} = S#state.params,
+					   eqc:format("Segments ~p\nWidth ~p\nMemLevels ~p\n",
+						      [Segments, Width, MemLevels]),
+					   eqc:format("=== t1 ===\n~p\n\n", [ets:tab2list(t1)]),
+					   eqc:format("=== s1 ===\n~p\n\n", [safe_tab2list(s1)]),
+					   eqc:format("=== t2 ===\n~p\n\n", [ets:tab2list(t2)]),
+					   eqc:format("=== s2 ===\n~p\n\n", [safe_tab2list(s2)]),
+					   eqc:format("=== ht1 ===\n~w\n~p\n\n", [get(t1), catch dump(get(t1))]),
+					   eqc:format("=== ht2 ===\n~w\n~p\n\n", [get(t2), catch dump(get(t2))]),
+					   
                                            catch hashtree:destroy(hashtree:close(get(t1))),
                                            catch hashtree:destroy(hashtree:close(get(t2)))
                                        end,
-                            begin
-                                    Unique1 = S#state.only1 -- S#state.only2,
-                                    Unique2 = S#state.only2 -- S#state.only1,
-                                    Expected =  [{missing, Key} || {Key, _} <-
-                                        Unique2, not
-                                        lists:keymember(Key, 1, S#state.only1)] ++
-                                    [{remote_missing, Key} || {Key, _} <-
-                                        Unique1, not
-                                        lists:keymember(Key, 1, S#state.only2)] ++
-                                    [{different, Key} || Key <-
-                                        sets:to_list(sets:intersection(sets:from_list([Key
-                                                        || {Key,_} <- Unique1]),
-                                                sets:from_list([Key || {Key,_}
-                                                    <- Unique2])))],
+                                       measure(num_updates, NumUpdates,
+                                       measure(segment_fill_ratio, NumUpdates / (2 * Segments), % Est of avg fill rate per segment
+				       collect(with_title(mem_levels), MemLevels,
+                                       collect(with_title(segments), Segments,
+                                       collect(with_title(width), Width,
+                                               equals(ok, Res))))))))
+		end)).
 
-                                case S#state.started of
-                                    false ->
-                                        true;
-                                    _ ->
-                                        %% io:format("\nFinal update tree1:\n"),
-                                        T10 = hashtree:update_tree(get(t1)),
-                                        %% io:format("\nFinal update tree2:\n"),
-                                        T20 = hashtree:update_tree(get(t2)),
-
-                                        %% io:format("\nFinal compare:\n"),
-                                        KeyDiff = hashtree:local_compare(T10, T20),
-
-                                        D1 = try dump(T10) catch _:Err1 -> Err1 end,
-                                        D2 = try dump(T20) catch _:Err2 -> Err2 end,
-
-                                        T11 = hashtree:mark_clean_close({0,0}, T10),
-                                        T21 = hashtree:mark_clean_close({0,0}, T20),
-                                        catch hashtree:destroy(hashtree:close(T11)),
-                                        catch hashtree:destroy(hashtree:close(T21)),
-                                        {Segments, Width, MemLevels} = S#state.params,
-
-                                        ?WHENFAIL(
-                                           begin
-                                               eqc:format("only1:\n~p\n", [S#state.only1]),
-                                               eqc:format("only2:\n~p\n", [S#state.only2]),
-                                               eqc:format("t1:\n~p\n", [D1]),
-                                               eqc:format("t2:\n~p\n", [D2])
-                                           end,
-                                           collect(with_title(mem_levels), MemLevels,
-                                           collect(with_title(segments), Segments,
-                                           collect(with_title(width), Width,
-                                           collect(with_title(length),
-                                           length(S#state.only1) + length(S#state.only2),
-                                                   conjunction([{cmds, equals(ok, Res)},
-                                                                {diff, equals(lists:usort(Expected),
-                                                                              lists:usort(KeyDiff))}]))))))
-                                end
-                            end
-                                ))
-                        end)).
 
 dump(Tree) ->
     Fun = fun(Entries) ->
@@ -344,12 +528,41 @@ dump(Tree) ->
     {SnapTree, _Tree2} = hashtree:update_snapshot(Tree),
     hashtree:multi_select_segment(SnapTree, ['*','*'], Fun).
 
-keymerge(S) ->
-    keymerge(S#state.only1, S#state.only2).
 
-keymerge(SuccList, L) ->
-    lists:ukeymerge(1, lists:ukeysort(1, SuccList),
-                    lists:ukeysort(1, L)).
+expect_compare() ->
+    Snap1 = orddict:from_list(ets:tab2list(s1)),
+    Snap2 = orddict:from_list(ets:tab2list(s2)),
+    SnapDeltas = riak_ensemble_util:orddict_delta(Snap1, Snap2),
+
+    lists:sort(
+      [{missing, K} || {K, {'$none', _}} <- SnapDeltas] ++
+	  [{remote_missing, K} || {K, {_, '$none'}} <- SnapDeltas] ++
+          [{different, K} || {K, {V1, V2}} <- SnapDeltas, V1 /= '$none', V2 /= '$none']). %% UNDO SnapDeltas this line
+%%
+%% Functions for handling the model data stored in ETS tables
+%%
+
+%% Create ETS table with public options
+ets_new(T) ->
+    ets:new(T, [named_table, public, set]).
+
+%% Convert a table to a list falling back to undefined for printing
+%% failure state.
+safe_tab2list(Id) ->
+    try
+        ets:tab2list(Id)
+    catch
+        _:_ ->
+            undefined
+    end.
+
+%% Copy the model data from the live to snapshot table for
+%% update_tree/update_snapshot.
+copy_tree(T, S) ->
+    catch ets:delete(S),
+    ets_new(S),
+    ets:insert(S, ets:tab2list(T)),
+    ok.
 
 -endif.
 -endif.

--- a/test/hashtree_eqc.erl
+++ b/test/hashtree_eqc.erl
@@ -295,7 +295,7 @@ update_perform(T) ->
 %% completed.
 %%
 set_next_rebuild(T) ->
-    _ = hashtree:set_next_rebuild(get(T), incremental).
+    put(T, hashtree:set_next_rebuild(get(T), incremental)).
 
 
 %% Wrap hashtree:insert to (over)write key with a new hash to a single

--- a/test/hashtree_eqc.erl
+++ b/test/hashtree_eqc.erl
@@ -429,14 +429,17 @@ precondition(_S, _C) ->
 postcondition(_S,{call,_,start, [_Params, _ExtraIds, T1Mark, T2Mark]},_R) ->
     NextRebuildT1 = hashtree:next_rebuild(get(t1)),
     NextRebuildT2 = hashtree:next_rebuild(get(t2)),
-    case T1Mark of
-        mark_empty -> eq(NextRebuildT1, incremental);
-        _ -> eq(NextRebuildT1, full)
-    end,
-    case T2Mark of
-        mark_empty -> eq(NextRebuildT2, incremental);
-        _ -> eq(NextRebuildT2, full)
-    end;
+    %% TODO: Convert this to a conjunction
+    T1Expect = case T1Mark of
+                   mark_empty -> incremental;
+                   _ -> full
+               end,
+    T2Expect = case T2Mark of
+                   mark_empty -> incremental;
+                   _ -> full
+               end,
+    eqc_statem:conj([eq({t1, T1Expect}, {t1, NextRebuildT1}),
+                     eq({t2, T2Expect}, {t2, NextRebuildT2})]);
 %% After a comparison, check against the results against
 %% the ETS table containing the *snapshot* copies.
 postcondition(_S,{call, _, local_compare, _},  Result0) ->


### PR DESCRIPTION
N.B. Successor to #828, requires basho/eleveldb#188 merged for dialyzer to pass.
## Context

This pull request resolves issues discovered while debugging yz_aae_test.
The test would fail when AAE did not repair the same set of keys.
## Hashtree Fixes
- If keys in the last segments of the tree were deleted (but when there was another treeid following it in the same leveldb database), then the accumulator function was not called with an empty list of hashes for the remaining final segments.
- Always calls prefetch_stop after using iterators to make sure their output is ordered.
- Adds a paranoia check to `update_tree` to do a full rebuild if the list of dirty hashes is not the right length, and log.
- Replaces the previous bucket clearing code which issued a delete for all buckets regardless whether they were populated.  Now scans the on disk bucket keys to do the removal.
- Removes empty segments/buckets from higher levels to keep the tree canonical.
- Avoids empty call to leveldb:write if the flush buffer is empty.
## Model Fixes:
- Open/close counters only work correctly if the rebuild mode is set to full between snapshot creation and and update perform.  The *_index_hashtree modules will need to implement that as separate PRs.
- Now checks top level hashes if the compare set is empty to make sure the trees are canonical.
## Reproduction

If you check code out to the first commit in the PR, the test has been modified, but the fix not applied yet.  It often takes longer than the eunit test time, so you can provoke from the console using

```
eqc:quickcheck(eqc:testing_time(30*60,hashtree_eqc:prop_correct())).
```

Make sure the .eunit is in your path to pick up hashtree with the right exports.
## Example Failure

```
hashtree_eqc:start({1048576, 1024, 0}, [{1, 0}, {1, 1}], mark_empty, mark_empty,
    []) ->
  ok
hashtree_eqc:write(t2,
    [{<<50, 51>>,
      <<150, 155, 129, 115, 36, 118, 147, 22, 134, 106, 101, 83, 105,
        135, 166, 182, 63, 51, 224, 94>>},
     {<<48>>,
      <<150, 155, 129, 115, 36, 118, 147, 22, 134, 106, 101, 83, 105,
        135, 166, 182, 63, 51, 224, 94>>}]) ->
  ok
hashtree_eqc:delete(t1, <<50, 51>>) -> ok
hashtree_eqc:delete(t2, <<49, 53>>) -> ok
hashtree_eqc:update_snapshot(t1, s1) -> ok
hashtree_eqc:update_snapshot(t2, s2) -> ok
hashtree_eqc:update_perform(t2) -> ok
hashtree_eqc:update_perform(t1) -> ok
hashtree_eqc:local_compare() -> [{missing, <<48>>}]

Reason:
  Post-condition failed:
  [{missing, <<48>>}, {missing, <<50, 51>>}] /= [{missing, <<48>>}]
```
