### PR TITLE
Bugfix/listkeys filters

### DIFF
--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -123,7 +123,7 @@ behaviour_info(_) ->
                 vnode_master :: atom(),
                 plan_fun :: function(),
                 process_fun :: function(),
-                coverage_plan_mod :: module()
+                coverage_plan_fn :: function()
                }).
 
 %% ===================================================================
@@ -165,7 +165,7 @@ init([Mod,
       From={_, ReqId, _},
       RequestArgs]) ->
     {Request, VNodeSelector, NVal, PrimaryVNodeCoverage,
-     NodeCheckService, VNodeMaster, Timeout, PlannerMod, ModState} =
+     NodeCheckService, VNodeMaster, Timeout, CoveragePlanFn, ModState} =
         Mod:init(From, RequestArgs),
     maybe_start_timeout_timer(Timeout),
     PlanFun = plan_callback(Mod),
@@ -182,7 +182,7 @@ init([Mod,
                        vnode_master=VNodeMaster,
                        plan_fun = PlanFun,
                        process_fun = ProcessFun,
-                       coverage_plan_mod = PlannerMod},
+                       coverage_plan_fn = CoveragePlanFn},
     {ok, initialize, StateData, 0};
 init({test, Args, StateProps}) ->
     %% Call normal init
@@ -211,11 +211,11 @@ maybe_start_timeout_timer(Timeout) ->
     ok.
 
 %% @private
-find_plan(_Mod, #vnode_coverage{}=Plan, _NVal, _PVC, _ReqId, _Service,
+find_plan(_CoveragePlanFn, #vnode_coverage{}=Plan, _NVal, _PVC, _ReqId, _Service,
           _Request) ->
     interpret_plan(Plan);
-find_plan(Mod, Target, NVal, PVC, ReqId, Service, Request) ->
-    Mod:create_plan(Target, NVal, PVC, ReqId, Service, Request).
+find_plan(CoveragePlanFn, Target, NVal, PVC, ReqId, Service, Request) ->
+    CoveragePlanFn(Target, NVal, PVC, ReqId, Service, Request).
 
 %% @private
 %% Take a `vnode_coverage' record and interpret it as a mini coverage plan
@@ -247,8 +247,8 @@ initialize(timeout, StateData0=#state{mod=Mod,
                                       timeout=Timeout,
                                       vnode_master=VNodeMaster,
                                       plan_fun = PlanFun,
-                                      coverage_plan_mod = PlanMod}) ->
-    CoveragePlan = find_plan(PlanMod,
+                                      coverage_plan_fn = CoveragePlanFn}) ->
+    CoveragePlan = find_plan(CoveragePlanFn,
                              VNodeSelector,
                              NVal,
                              PVC,

--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -165,8 +165,29 @@ init([Mod,
       From={_, ReqId, _},
       RequestArgs]) ->
     {Request, VNodeSelector, NVal, PrimaryVNodeCoverage,
-     NodeCheckService, VNodeMaster, Timeout, CoveragePlanFn, ModState} =
+     NodeCheckService, VNodeMaster, Timeout, CoveragePlanRet, ModState} =
         Mod:init(From, RequestArgs),
+
+    %% As part of fixing listkeys, we have changed the API model so
+    %% that modules with riak_core_coverage_fsm behaviour now return a
+    %% coverage plan function rather than a module.  The four
+    %% core_coverage_fsm modules used regularly in RiakTS have all
+    %% been changed to return functions.  
+    %%
+    %% However, to ensure backwards compatibility with any modules
+    %% that may have been missed, we add a check here in case someone
+    %% is still sending us back a module atom.  In that case, convert
+    %% the coverage plan module to the appropriate function for use
+    %% further down the stack
+
+    CoveragePlanFn = 
+	case is_atom(CoveragePlanRet) of
+	    true ->
+		fun CoveragePlanRet:create_plan/6;
+	    _ ->
+		CoveragePlanRet
+	end,
+
     maybe_start_timeout_timer(Timeout),
     PlanFun = plan_callback(Mod),
     ProcessFun = process_results_callback(Mod),

--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -181,12 +181,12 @@ init([Mod,
     %% further down the stack
 
     CoveragePlanFn = 
-	case is_atom(CoveragePlanRet) of
-	    true ->
-		fun CoveragePlanRet:create_plan/6;
-	    _ ->
-		CoveragePlanRet
-	end,
+        case is_atom(CoveragePlanRet) of
+            true ->
+                fun CoveragePlanRet:create_plan/6;
+            _ ->
+                CoveragePlanRet
+        end,
 
     maybe_start_timeout_timer(Timeout),
     PlanFun = plan_callback(Mod),

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -420,7 +420,7 @@ vnode_handoff_command(Sender, Request, ForwardTo,
         {forward, NewModState} ->
             forward_request(HOType, Request, HOTarget, ForwardTo, Sender, State),
             continue(State, NewModState);
- 	{forward, NewReq, NewModState} ->
+        {forward, NewReq, NewModState} ->
             forward_request(HOType, NewReq, HOTarget, ForwardTo, Sender, State),
             continue(State, NewModState);
         {drop, NewModState} ->

--- a/src/riak_core_vnode_master.erl
+++ b/src/riak_core_vnode_master.erl
@@ -35,7 +35,7 @@
          sync_spawn_command/3, make_request/3,
          make_coverage_request/4, all_nodes/1, reg_name/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-	 terminate/2, code_change/3]).
+         terminate/2, code_change/3]).
 -record(state, {idxtab, sup_name, vnode_mod, legacy}).
 
 -define(LONG_TIMEOUT, 120*1000).


### PR DESCRIPTION
**Context**

stream_list_keys has always returned inconsistent results when used with TS data.  I've tracked this down to the coverage filter functions that are applied during the fold over keys on a vnode.  These filters check whether a key should be included, by checking if its hash falls within a specified hash range for a vnode.  These filters are applied to the storage keys in leveldb.  For TS, however, these filters need to be applied not to the storage key (which is the local key), but instead to the partition key, which can be derived from the local key by an appropriate transformation.

This PR addresses this inconsistency by changing the filter functions to use a key conversion function on the storage key prior to hashing. It is one of three PRs: riak_kv (https://github.com/basho/riak_kv/pull/1404), riak_core (https://github.com/basho/riak_core/pull/834) and riak_pipe (https://github.com/basho/riak_pipe/pull/105).  For reference, I include my diagram of the listkeys code path here:

 ![RiakTS Listkeys Path](https://gist.githubusercontent.com/erikleitch/8191db35b09bc8357df4/raw/69e7510c9233ecc3e35fd78a12807df6fab5514d/tslistkeys.png)

**Changes in this repo**
- **riak_core_coverage_fsm.erl**<br>
  - record 'state', field 'coverage_plan_mod' has been changed  to 'coverage_plan_fn'.  The previous version of this code used coverage_plan_mod to return the name of a module whose static function create_plan/6 function would be used to construct the coverage plan.  This PR uses coverage_plan_fn to return a dynamically constructed function that creates the coverage plan, using the key conversion function specific to a TS table.
  - riak_kv_keys_fsm:init(), called in riak_core_coverage_fsm:init(), now
    returns coverage_plan_fn instead of a coverage_plan_mod
  - find_plan changed to use CoveragePlanFn directly rather than
    Mod:create_plan
