### PR TITLE
Fix for get_value

### DIFF
--- a/src/riak_core_bucket.erl
+++ b/src/riak_core_bucket.erl
@@ -251,7 +251,7 @@ n_val(BProps) ->
 % a slighly faster version of proplists:get_value
 get_value(Key, Proplist) ->
     case lists:keyfind(Key, 1, Proplist) of
-        {n_val, Value} -> Value;
+        {Key, Value} -> Value;
         _ -> undefined
     end.
 


### PR DESCRIPTION
There was a lingering pattern match against a specific atom in the get_value function which was accidentally merged.
