### PR TITLE
Always use the wrapped iterator_move [JIRA: RIAK-2566]

### DIFF
--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -958,7 +958,7 @@ multi_select_segment(#state{id=Id, itr=Itr}, Segments, F) ->
               %% Always call prefetch stop to ensure the iterator
               %% is safe to use in the compare.  Requires
               %% eleveldb > 2.0.16 or this may segv/hang.
-              _ = eleveldb:iterator_move(Itr, prefetch_stop)
+              _ = iterator_move(Itr, prefetch_stop)
           end,
     #itr_state{remaining_segments = LeftOver,
                current_segment=LastSegment,


### PR DESCRIPTION
Without this change, leveldb can segfault.
