### PR TITLE
Bump eleveldb to 2.0.20

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
   {riak_sysmon, ".*", {git, "git://github.com/basho/riak_sysmon.git", {branch, "2.0"}}},
   {riak_ensemble, ".*", {git, "git://github.com/basho/riak_ensemble", {branch, "2.0"}}},
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
-  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.19"}}},
+  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.20"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho5"}}},
   {clique, ".*", {git, "git://github.com/basho/clique.git", {tag, "0.2.5"}}}
 ]}.


### PR DESCRIPTION
Bump eleveldb to 2.0.20. Pick up performance improvements around compaction and some debug-level information about iterator usage in case of errors.
