### PR TITLE
Add support for setting/querying a cluster-wide time zone

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,5 +18,6 @@
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "ts-1.0.4"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho6"}}},
+  {jam, ".*", {git, "git://github.com/macintux/jam.git", {branch, "master"}}},
   {clique, "0.3.5", {git, "git://github.com/basho/clique.git", {tag, "0.3.5"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -18,6 +18,6 @@
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "ts-1.0.4"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho6"}}},
-  {jam, ".*", {git, "git://github.com/macintux/jam.git", {branch, "master"}}},
+  {jam, ".*", {git, "git://github.com/basho/jam.git", {branch, "develop"}}},
   {clique, "0.3.5", {git, "git://github.com/basho/clique.git", {tag, "0.3.5"}}}
 ]}.

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -31,7 +31,8 @@
          print_users/1, print_user/1, print_sources/1,
          print_groups/1, print_group/1, print_grants/1,
          security_enable/1, security_disable/1, security_status/1, ciphers/1,
-	 stat_show/1, stat_info/1, stat_enable/1, stat_disable/1, stat_reset/1]).
+         timezone/1,
+         stat_show/1, stat_info/1, stat_enable/1, stat_disable/1, stat_reset/1]).
 
 %% New CLI API
 -export([command/1]).
@@ -751,6 +752,27 @@ commit_staged([]) ->
                       "may have changed, please verify the~n"
                       "plan and try to commit again~n")
     end.
+
+timezone([]) ->
+    TZ = riak_core_metadata:get({riak_core, timezone}, string,
+                                [{default, "not configured"}]),
+    io:format("~s~n", [TZ]);
+timezone([TZString]) ->
+    TZ = jam:process(jam_iso8601:parse_tz(TZString)),
+    attempt_set_timezone(jam:is_valid(TZ), TZ, TZString).
+
+attempt_set_timezone(false, _TZ, String) ->
+    io:format("Failed, unrecognized timezone string '~s'~n",
+              [String]);
+attempt_set_timezone(true, TZ, _String) ->
+    NewString = jam_iso8601:to_string(TZ, [{z, false}]),
+    riak_core_metadata:put({riak_core, timezone}, string,
+                           NewString),
+    riak_core_metadata:put({riak_core, timezone}, seconds,
+                           jam:tz_offset(TZ)),
+    io:format("Success, timezone is now configured to '~s'~n",
+              [NewString]).
+
 
 transfer_limit([]) ->
     {Limits, Down} =

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -758,7 +758,7 @@ timezone([]) ->
                                 [{default, "not configured"}]),
     io:format("~s~n", [TZ]);
 timezone([TZString]) ->
-    TZ = jam:process(jam_iso8601:parse_tz(TZString)),
+    TZ = jam:compile(jam_iso8601:parse_tz(TZString)),
     attempt_set_timezone(jam:is_valid(TZ), TZ, TZString).
 
 attempt_set_timezone(false, _TZ, String) ->
@@ -769,7 +769,7 @@ attempt_set_timezone(true, TZ, _String) ->
     riak_core_metadata:put({riak_core, timezone}, string,
                            NewString),
     riak_core_metadata:put({riak_core, timezone}, seconds,
-                           jam:tz_offset(TZ)),
+                           jam:tz_to_seconds(TZ)),
     io:format("Success, timezone is now configured to '~s'~n",
               [NewString]).
 


### PR DESCRIPTION
riak/riak_ee PRs to come. Expect to change `rebar.config` once my repo is migrated to Basho's ownership and once the API has stabilized enough to lay down a tag. I think it's reasonable to review/approve these PRs now in the expectation of more to arrive before the next TS release, but that'll be a topic for discussion, I'm sure.
