### PR TITLE
Filter local capabilities when no longer in ring

### DIFF
--- a/src/riak_core_capability.erl
+++ b/src/riak_core_capability.erl
@@ -373,7 +373,7 @@ add_node2(Node, Capabilities, State) ->
 %% is not declared. We must remove it from our local copy of its supported modes
 %% so that the default value can be used.
 filter_removed_caps(Node, Capabilities, State1) ->
-    {NodeSupported, _Removed} = lists:partition(
+    NodeSupported = lists:filter(
         fun({CapName, _}) ->
             lists:keymember(CapName, 1, Capabilities)
         end, get_supported(Node, State1)),

--- a/src/riak_core_capability.erl
+++ b/src/riak_core_capability.erl
@@ -349,7 +349,11 @@ remove_members(Ring, State=#state{supported=Supported}) ->
 %% to determine capabilities through RPC to the node. If RPC fails, use
 %% default values. However, unresolved nodes will be marked as such and RPC
 %% re-attempted at the next server tick.
-add_node(Node, [], State=#state{unknown=Unknown}) ->
+add_node(Node, Capabilities, State1) ->
+    State2 = add_node2(Node, Capabilities, State1),
+    filter_removed_caps(Node, Capabilities, State2).
+
+add_node2(Node, [], State=#state{unknown=Unknown}) ->
     {Capabilities, Resolved} = query_capabilities(Node, State),
     Unknown2 = case Resolved of
                    true ->
@@ -359,8 +363,22 @@ add_node(Node, [], State=#state{unknown=Unknown}) ->
                end,
     State2 = State#state{unknown=Unknown2},
     add_node_capabilities(Node, Capabilities, State2);
-add_node(Node, Capabilities, State) ->
+add_node2(Node, Capabilities, State) ->
     add_node_capabilities(Node, Capabilities, State).
+
+%% Remove supported capabilities for a node where it no longer appears in the
+%% rings capabilities for the node.
+%%
+%% This can occur when another node downgrades to a version where the capability
+%% is not declared. We must remove it from our local copy of its supported modes
+%% so that the default value can be used.
+filter_removed_caps(Node, Capabilities, State1) ->
+    {NodeSupported, _Removed} = lists:partition(
+        fun({CapName, _}) ->
+            lists:keymember(CapName, 1, Capabilities)
+        end, get_supported(Node, State1)),
+    Supported = orddict:store(Node, NodeSupported, State1#state.supported),
+    State1#state{ supported = Supported }.
 
 add_node_capabilities(Node, Capabilities, State) ->
     lists:foldl(fun({Capability, Supported}, StateAcc) ->


### PR DESCRIPTION
`riak_core_capability` tracks the supported modes of capabilities for each clustered node in the `#state.supported` record field.  When the ring changes, new capabilities are added or updated. Previous to this change, capabilities that had been removed in the ring were not removed from the local copy, affecting the final negotiated capability value.  This can happen in the following scenario:
1. In a three node cluster, all nodes are version 2 and declare capability `my_cap` supported modes as `[b,a]` and a default of `a`.  Because `b` is preferred (first in the list) and all nodes specify the same modes then `b` is the negotiated capability.
2. One of the nodes is downgraded to version 1, where `my_cap` is not registered at all and doesn't appear in the nodes capabilities, or in the metadata it puts into the ring that is received by the other nodes.

With this change, when capabilities are added for a node, they must also appear in the ring capabilities for that node or be removed.
