### PR TITLE
Update handoff config callbacks for new clique API

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,5 +18,5 @@
   {riak_ensemble, ".*", {git, "git://github.com/basho/riak_ensemble", {branch, "develop-2.2"}}},
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho7"}}},
-  {clique, "0.3.6", {git, "git://github.com/basho/clique.git", {tag, "0.3.6"}}}
+  {clique, ".*", {git, "git://github.com/basho/clique.git", {branch, "develop"}}}
 ]}.


### PR DESCRIPTION
The latest version of clique changes the API for config change callbacks, and fixes some issues with the callback behavior when using the --node or --all flags on the "set" command.

NOTE - do not merge this PR until the new clique version is tagged and rebar.config is updated appropriately.
