### PR TITLE
Use ETS table instead of application environment variables in riak_core_throttle

### DIFF
--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -105,6 +105,8 @@ start(_StartType, _StartArgs) ->
             riak_core_cli_registry:register_node_finder(),
             riak_core_cli_registry:register_cli(),
 
+            riak_core_throttle:init(),
+
             {ok, Pid};
         {error, Reason} ->
             {error, Reason}

--- a/src/riak_core_sup.erl
+++ b/src/riak_core_sup.erl
@@ -77,6 +77,7 @@ init([]) ->
                   ?CHILD(riak_core_capability, worker),
                   ?CHILD(riak_core_gossip, worker),
                   ?CHILD(riak_core_claimant, worker),
+                  ?CHILD(riak_core_table_owner, worker),
                   ?CHILD(riak_core_stat_sup, supervisor),
                   [EnsembleSup || ensembles_enabled()]
                  ]),

--- a/src/riak_core_table_owner.erl
+++ b/src/riak_core_table_owner.erl
@@ -1,0 +1,126 @@
+%% -------------------------------------------------------------------
+%% Copyright (c) 2016 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%%
+%% @doc <p>ETS tables, when created with the `ets:new/2' function, have a single
+%% owning process. If the owning process exits, then any ETS tables associated
+%% with that process are deleted. The purpose of the `riak_core_table_owner'
+%% module (which is a gen_server process) is to serve as the owning process for
+%% ETS tables that do not otherwise have an obvious owning process. For example,
+%% the `riak_core_throttle' module uses an ETS table for maintaining its state,
+%% but it is not itself a process and therefore the owning process for it ETS
+%% table is not clear. In this case, `riak_core_table_owner' can be used to
+%% create and own the ETS table on its behalf.</p>
+%%
+%% <p>It is important that this process never crashes, as that would lead to
+%% loss of data. Therefore, a defensive approach is taken and any calls to
+%% external modules are protected with the try/catch mechanism.</p>
+%%
+%% <p>Note that this first iteration does not provide any API functions for
+%% reading or writing data in ETS tables and therefore is appropriate only for
+%% named <em>public</em> ETS tables. In order to be more broadly useful, future
+%% enhancements to this module should include API functions for efficiently
+%% reading and writing ETS data, preferably without going through a gen_server
+%% call.</p>
+-module(riak_core_table_owner).
+
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0,
+         create_table/2,
+         maybe_create_table/2]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+%% Unfortunately the `ets' module does not define a type for options, but we
+%% can at least insist on a list.
+-type ets_options() :: [].
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec start_link() -> {ok, pid()} | ignore | {error, Reason::term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, dict:new(), []).
+
+%% Creates a new ETS table with the given `Name' and `Options'.
+%% Since the table will be owned by the `riak_core_table_owner' process, it
+%% should be created with the `public' option so that other processes can read
+%% and write data in the table.
+-spec create_table(Name::atom(), Options::ets_options()) -> ets:tid().
+create_table(Name, Options) ->
+    gen_server:call(?MODULE, {create_table, Name, Options}).
+
+%% Creates a new ETS table with the given `Name' and `Options', if and only if
+%% it was not already created previously.
+%% Since the table will be owned by the `riak_core_table_owner' process, it
+%% should be created with the `public' option so that other processes can read
+%% and write data in the table.
+-spec maybe_create_table(Name::atom(), Options::ets_options()) -> ets:tid().
+maybe_create_table(Name, Options) ->
+    gen_server:call(?MODULE, {maybe_create_table, Name, Options}).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init(State) ->
+    {ok, State}.
+
+handle_call({create_table, Name, Options}, _From, State) ->
+    do_create_table(Name, Options, State);
+handle_call({maybe_create_table, Name, Options}, _From, State) ->
+    case dict:find(Name, State) of
+        {ok, Table} ->
+            {reply, {ok, Table}, State};
+        error ->
+            do_create_table(Name, Options, State)
+    end.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+do_create_table(Name, Options, State) ->
+    try
+        Table = ets:new(Name, Options),
+        {reply, {ok, Table}, dict:store(Name, Table, State)}
+    catch
+        Error ->
+            {reply, {error, Error}, State}
+    end.

--- a/src/riak_core_table_owner.erl
+++ b/src/riak_core_table_owner.erl
@@ -56,7 +56,9 @@
 
 %% Unfortunately the `ets' module does not define a type for options, but we
 %% can at least insist on a list.
--type ets_options() :: [].
+-type ets_options() :: list().
+-type ets_table() :: ets:tab().
+-type create_table_result() :: {ok, ets_table()} | {error, Reason::term()}.
 
 %%%===================================================================
 %%% API
@@ -70,7 +72,7 @@ start_link() ->
 %% Since the table will be owned by the `riak_core_table_owner' process, it
 %% should be created with the `public' option so that other processes can read
 %% and write data in the table.
--spec create_table(Name::atom(), Options::ets_options()) -> ets:tid().
+-spec create_table(Name::atom(), Options::ets_options()) -> create_table_result().
 create_table(Name, Options) ->
     gen_server:call(?MODULE, {create_table, Name, Options}).
 
@@ -79,7 +81,7 @@ create_table(Name, Options) ->
 %% Since the table will be owned by the `riak_core_table_owner' process, it
 %% should be created with the `public' option so that other processes can read
 %% and write data in the table.
--spec maybe_create_table(Name::atom(), Options::ets_options()) -> ets:tid().
+-spec maybe_create_table(Name::atom(), Options::ets_options()) -> create_table_result().
 maybe_create_table(Name, Options) ->
     gen_server:call(?MODULE, {maybe_create_table, Name, Options}).
 

--- a/src/riak_core_throttle.erl
+++ b/src/riak_core_throttle.erl
@@ -79,9 +79,14 @@
 %% @doc Initialize the throttling subsystem. Should be called just once during
 %% startup, although calling multiple times will not have any negative
 %% consequences.
+-spec init() -> ok.
 init() ->
-    {ok, ?ETS_TABLE_NAME} = riak_core_table_owner:maybe_create_table(?ETS_TABLE_NAME,
-                                                                     ?ETS_TABLE_OPTIONS).
+    case riak_core_table_owner:maybe_create_table(?ETS_TABLE_NAME, ?ETS_TABLE_OPTIONS) of
+        {ok, ?ETS_TABLE_NAME} ->
+            ok;
+        {error, Reason} ->
+            throw({"Failed to create ETS table for riak_core_throttle", Reason})
+    end.
 
 %% @doc Sets the throttle for the activity identified by `AppName' and `Key' to
 %% the specified `Time'.

--- a/src/riak_core_throttle.erl
+++ b/src/riak_core_throttle.erl
@@ -43,6 +43,7 @@
          disable_throttle/2,
          enable_throttle/2,
          is_throttle_enabled/2,
+         init/0,
          init/4,
          set_limits/3,
          get_limits/2,
@@ -66,11 +67,21 @@
 
 -export_type([activity_key/0, throttle_time/0, load_factor/0, limits/0]).
 
+-define(ETS_TABLE_NAME, riak_core_throttles).
+-define(ETS_TABLE_OPTIONS, [set, named_table, public]).
+
 -define(THROTTLE_KEY(Key), list_to_atom("throttle_" ++ atom_to_list(Key))).
 -define(THROTTLE_LIMITS_KEY(Key),
         list_to_atom("throttle_limits_" ++ atom_to_list(Key))).
 -define(THROTTLE_ENABLED_KEY(Key),
         list_to_atom("throttle_enabled_" ++ atom_to_list(Key))).
+
+%% @doc Initialize the throttling subsystem. Should be called just once during
+%% startup, although calling multiple times will not have any negative
+%% consequences.
+init() ->
+    {ok, ?ETS_TABLE_NAME} = riak_core_table_owner:maybe_create_table(?ETS_TABLE_NAME,
+                                                                     ?ETS_TABLE_OPTIONS).
 
 %% @doc Sets the throttle for the activity identified by `AppName' and `Key' to
 %% the specified `Time'.
@@ -82,32 +93,32 @@ set_throttle(AppName, Key, Time) when Time >= 0 ->
 %% @private
 %% Actually set the throttle, but don't log anything.
 do_set_throttle(AppName, Key, Time) when Time >= 0 ->
-    application:set_env(AppName, ?THROTTLE_KEY(Key), Time).
+    set_value(AppName, ?THROTTLE_KEY(Key), Time).
 
 %% @doc Clears the throttle for the activity identified by `AppName' and `Key'.
 -spec clear_throttle(app_name(), activity_key()) -> ok.
 clear_throttle(AppName, Key) ->
-    application:unset_env(AppName, ?THROTTLE_KEY(Key)).
+    unset_value(AppName, ?THROTTLE_KEY(Key)).
 
 %% @doc Disables the throttle for the activity identified by `AppName' and
 %% `Key'.
 -spec disable_throttle(app_name(), activity_key()) -> ok.
 disable_throttle(AppName, Key) ->
     lager:info("Disabling throttle for ~p/~p.", [AppName, Key]),
-    application:set_env(AppName, ?THROTTLE_ENABLED_KEY(Key), false).
+    set_value(AppName, ?THROTTLE_ENABLED_KEY(Key), false).
 
 %% @doc Enables the throttle for the activity identified by `AppName' and
 %% `Key'.
 -spec enable_throttle(app_name(), activity_key()) -> ok.
 enable_throttle(AppName, Key) ->
     lager:info("Enabling throttle for ~p/~p.", [AppName, Key]),
-    application:set_env(AppName, ?THROTTLE_ENABLED_KEY(Key), true).
+    set_value(AppName, ?THROTTLE_ENABLED_KEY(Key), true).
 
 %% @doc Returns `true' if the throttle for the activity identified by `AppName'
 %% and `Key' is enabled, `false' otherwise.
 -spec is_throttle_enabled(app_name(), activity_key()) -> boolean().
 is_throttle_enabled(AppName, Key) ->
-    application:get_env(AppName, ?THROTTLE_ENABLED_KEY(Key), true).
+    get_value(AppName, ?THROTTLE_ENABLED_KEY(Key), true).
 
 %% @doc Initializes the throttle for the activity identified by `AppName' and
 %% `Key' using configuration values found in the application environment for
@@ -145,15 +156,13 @@ init(AppName, Key,
 -spec set_limits(app_name(), activity_key(), limits()) -> ok | no_return().
 set_limits(AppName, Key, Limits) ->
     ok = validate_limits(AppName, Key, Limits),
-    application:set_env(AppName,
-                        ?THROTTLE_LIMITS_KEY(Key),
-                        lists:sort(Limits)).
+    set_value(AppName, ?THROTTLE_LIMITS_KEY(Key), lists:sort(Limits)).
 
 %% @doc Returns the limits for the activity identified by `AppName' and `Key'
 %% if defined, otherwise returns `undefined'.
 -spec get_limits(app_name(), activity_key()) -> limits() | undefined.
 get_limits(AppName, Key) ->
-    case application:get_env(AppName, ?THROTTLE_LIMITS_KEY(Key)) of
+    case get_value(AppName, ?THROTTLE_LIMITS_KEY(Key)) of
         {ok, Limits} ->
             Limits;
         _ ->
@@ -163,7 +172,7 @@ get_limits(AppName, Key) ->
 %% @doc Clears the limits for the activity identified by `AppName' and `Key'.
 -spec clear_limits(app_name(), activity_key()) -> ok.
 clear_limits(AppName, Key) ->
-    application:unset_env(AppName, ?THROTTLE_LIMITS_KEY(Key)).
+    unset_value(AppName, ?THROTTLE_LIMITS_KEY(Key)).
 
 %% @doc Returns a fun that used in Cuttlefish translations to translate from
 %% configuration items of the form:
@@ -279,7 +288,7 @@ maybe_throttle(_Key, Time, true) ->
 
 -spec get_throttle(app_name(), activity_key()) -> throttle_time() | undefined.
 get_throttle(AppName, Key) ->
-    application:get_env(AppName, ?THROTTLE_KEY(Key), undefined).
+    get_value(AppName, ?THROTTLE_KEY(Key), undefined).
 
 -spec get_throttle_for_load(app_name(), activity_key(), load_factor()) ->
     throttle_time() | undefined.
@@ -357,4 +366,28 @@ maybe_log_throttle_change(AppName, Key, NewValue, Reason) ->
         false ->
             lager:info("Changing throttle for ~p/~p from ~p to ~p based on ~ts",
                        [AppName, Key, OldValue, NewValue, Reason])
+    end.
+
+set_value(AppName, Key, Value) ->
+    true = ets:insert(?ETS_TABLE_NAME, {{AppName, Key}, Value}),
+    ok.
+
+unset_value(AppName, Key) ->
+    true = ets:delete(?ETS_TABLE_NAME, {AppName, Key}),
+    ok.
+
+get_value(AppName, Key) ->
+    case ets:lookup(?ETS_TABLE_NAME, {AppName, Key}) of
+        [] ->
+            {error, undefined};
+        [{{AppName, Key}, Value}] ->
+            {ok, Value}
+    end.
+
+get_value(AppName, Key, Default) ->
+    case get_value(AppName, Key) of
+        {ok, Value} ->
+            Value;
+        _ ->
+            Default
     end.

--- a/test/riak_core_throttle_tests.erl
+++ b/test/riak_core_throttle_tests.erl
@@ -33,6 +33,8 @@ clear_throttles(ActivityKeys) ->
                   ActivityKeys).
 
 throttle_test_() ->
+    riak_core_table_owner:start_link(),
+    riak_core_throttle:init(),
     {foreach,
      fun activity_keys/0,
      fun clear_throttles/1,
@@ -50,11 +52,13 @@ test_throttle_badkey([Key|_]) ->
     [?_assertError({badkey, Key}, riak_core_throttle:throttle(?APP_NAME, Key)),
      ?_assertEqual(undefined, riak_core_throttle:get_throttle(?APP_NAME, Key))].
 
-test_set_throttle([Key1, Key2|_]) ->
+test_set_throttle([Key1, Key2, Key3|_]) ->
     ok = riak_core_throttle:set_throttle(?APP_NAME, Key1, 42),
+    ok = riak_core_throttle:set_throttle(?APP_NAME, Key2, 0),
     [?_assertEqual(42, riak_core_throttle:throttle(?APP_NAME, Key1)),
      ?_assertEqual(42, riak_core_throttle:get_throttle(?APP_NAME, Key1)),
-     ?_assertError({badkey, Key2}, riak_core_throttle:throttle(?APP_NAME, Key2))].
+     ?_assertEqual(0, riak_core_throttle:throttle(?APP_NAME, Key2)),
+     ?_assertError({badkey, Key3}, riak_core_throttle:throttle(?APP_NAME, Key3))].
 
 test_throttle_disable([Key1, Key2, Key3|_]) ->
     ok = riak_core_throttle:set_throttle(?APP_NAME, Key1, 42),


### PR DESCRIPTION
Previously, `riak_core_throttle` had used application environment variables for maintaining its state. However, due to race conditions that manifested during application shutdown, errors would occur that prevented applications from shutting down cleanly. By replacing the use of application environment variables with ETS tables instead, we avoid these errors and shutdown cleanly.

Because `riak_core_throttle` is not itself a process, it cannot own its underlying ETS table. Thus, the `riak_core_table_owner` gen_server process was introduced for this purpose.
