### PR TITLE
Refactor `riak_core_app` for better readability

### DIFF
--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -36,15 +36,27 @@ start(_StartType, _StartArgs) ->
     %% riak_core_sysmon_minder start it, because that process can act
     %% on any handler crash notification, whereas we cannot.
 
+    maybe_delay_start(),
+    ok = validate_ring_state_directory_exists(),
+    ok = safe_register_cluster_info(),
+    ok = add_bucket_defaults(),
+
+    start_riak_core_sup().
+
+stop(_State) ->
+    lager:info("Stopped  application riak_core.\n", []),
+    ok.
+
+maybe_delay_start() ->
     case application:get_env(riak_core, delayed_start) of
         {ok, Delay} ->
             lager:info("Delaying riak_core startup as requested"),
             timer:sleep(Delay);
         _ ->
             ok
-    end,
+    end.
 
-    %% Validate that the ring state directory exists
+validate_ring_state_directory_exists() ->
     riak_core_util:start_app_deps(riak_core),
     RingStateDir = app_helper:get_env(riak_core, ring_state_dir),
     case filelib:ensure_dir(filename:join(RingStateDir, "dummy")) of
@@ -52,66 +64,84 @@ start(_StartType, _StartArgs) ->
             ok;
         {error, RingReason} ->
             lager:critical(
-              "Ring state directory ~p does not exist, "
-              "and could not be created: ~p",
+              "Ring state directory ~p does not exist, " "and could not be created: ~p",
               [RingStateDir, lager:posix_error(RingReason)]),
             throw({error, invalid_ring_state_dir})
-    end,
+    end.
 
+safe_register_cluster_info() ->
     %% Register our cluster_info app callback modules, with catch if
     %% the app is missing or packaging is broken.
     catch cluster_info:register_app(riak_core_cinfo_core),
+    ok.
 
+add_bucket_defaults() ->
     %% add these defaults now to supplement the set that may have been
     %% configured in app.config
     riak_core_bucket:append_bucket_defaults(riak_core_bucket_type:defaults(default_type)),
+    ok.
 
+start_riak_core_sup() ->
     %% Spin up the supervisor; prune ring files as necessary
     case riak_core_sup:start_link() of
         {ok, Pid} ->
-            riak_core:register(riak_core, [{stat_mod, riak_core_stat},
-                                           {permissions, [get_bucket,
-                                                          set_bucket,
-                                                          get_bucket_type,
-                                                          set_bucket_type]}]),
-            ok = riak_core_ring_events:add_guarded_handler(riak_core_ring_handler, []),
+            ok = register_applications(),
+            ok = add_ring_event_handler(),
 
-            riak_core_capability:register({riak_core, vnode_routing},
-                                          [proxy, legacy],
-                                          legacy,
-                                          {riak_core,
-                                           legacy_vnode_routing,
-                                           [{true, legacy}, {false, proxy}]}),
-            riak_core_capability:register({riak_core, staged_joins},
-                                          [true, false],
-                                          false),
-            riak_core_capability:register({riak_core, resizable_ring},
-                                          [true, false],
-                                          false),
-            riak_core_capability:register({riak_core, fold_req_version},
-                                          [v2, v1],
-                                          v1),
-            riak_core_capability:register({riak_core, security},
-                                          [true, false],
-                                          false),
-            riak_core_capability:register({riak_core, bucket_types},
-                                          [true, false],
-                                          false),
-            riak_core_capability:register({riak_core, net_ticktime},
-                                          [true, false],
-                                          false),
-
-            riak_core_cli_registry:load_schema(),
-            riak_core_cli_registry:register_node_finder(),
-            riak_core_cli_registry:register_cli(),
-
-            riak_core_throttle:init(),
+            ok = register_capabilities(),
+            ok = init_cli_registry(),
+            ok = riak_core_throttle:init(),
 
             {ok, Pid};
         {error, Reason} ->
             {error, Reason}
     end.
 
-stop(_State) ->
-    lager:info("Stopped  application riak_core.\n", []),
+register_applications() ->
+    riak_core:register(riak_core, [{stat_mod, riak_core_stat},
+                                   {permissions, [get_bucket,
+                                                  set_bucket,
+                                                  get_bucket_type,
+                                                  set_bucket_type]}]),
+    ok.
+
+add_ring_event_handler() ->
+    ok = riak_core_ring_events:add_guarded_handler(riak_core_ring_handler, []).
+
+init_cli_registry() ->
+    riak_core_cli_registry:load_schema(),
+    riak_core_cli_registry:register_node_finder(),
+    riak_core_cli_registry:register_cli(),
+    ok.
+
+register_capabilities() ->
+    Capabilities = [[{riak_core, vnode_routing},
+                     [proxy, legacy],
+                     legacy,
+                     {riak_core,
+                      legacy_vnode_routing,
+                      [{true, legacy}, {false, proxy}]}],
+                    [{riak_core, staged_joins},
+                     [true, false],
+                     false],
+                    [{riak_core, resizable_ring},
+                     [true, false],
+                     false],
+                    [{riak_core, fold_req_version},
+                     [v2, v1],
+                     v1],
+                    [{riak_core, security},
+                     [true, false],
+                     false],
+                    [{riak_core, bucket_types},
+                     [true, false],
+                     false],
+                    [{riak_core, net_ticktime},
+                     [true, false],
+                     false]],
+    lists:foreach(
+      fun(Capability) ->
+              apply(riak_core_capability, register, Capability)
+      end,
+      Capabilities),
     ok.


### PR DESCRIPTION
Clean up `riak_core_app` so that it no longer has YUGE functions and more clearly expresses its intent.
