### PR TITLE
RTS-1469: Set replication defaults for time series tables

### DIFF
--- a/src/riak_core_bucket_type.erl
+++ b/src/riak_core_bucket_type.erl
@@ -161,8 +161,30 @@ common_defaults() ->
      {postcommit, []},
      {chash_keyfun, {riak_core_util, chash_std_keyfun}}].
 
+%% @doc When creating a Time Series table, set the replication property
+%% defaults to other values than for normal KV bucket types.  Naturally
+%% let the user override any default values (per RTS-1469)
+%% The `ddl` property contains the TS table DDL, so denotes a
+%% time series bucket type.
+-spec ts_defaults(bucket_type_props()) -> bucket_type_props().
+ts_defaults(Props) ->
+    case proplists:is_defined(ddl, Props) of
+        true ->
+            ts_specific_defaults();
+        _ -> []
+    end.
+
+ts_specific_defaults() ->
+    [{allow_mult, false},
+     {dvv_enabled, false},
+     {dw, one},
+     {last_write_wins, true},
+     {r, one},
+     {rw, one}].
+
+
 %% @doc Create the type. The type is not activated (available to nodes) at this time. This
-%% function may be called arbitratily many times if the claimant does not change between
+%% function may be called arbitrarily many times if the claimant does not change between
 %% calls and the type is not active. An error will also be returned if the properties
 %% are not valid. Properties not provided will be taken from those returned by
 %% @see defaults/0.
@@ -170,8 +192,9 @@ common_defaults() ->
 create(?DEFAULT_TYPE, _Props) ->
     {error, default_type};
 create(BucketType, Props) when is_binary(BucketType) ->
-    ?IF_CAPABLE(riak_core_claimant:create_bucket_type(BucketType,
-                                                      riak_core_bucket_props:merge(Props, defaults())),
+    Props1 = riak_core_bucket_props:merge(Props,
+        riak_core_bucket_props:merge(ts_defaults(Props), defaults())),
+    ?IF_CAPABLE(riak_core_claimant:create_bucket_type(BucketType, Props1),
                 {error, not_capable}).
 
 %% @doc Returns the state the type is in.


### PR DESCRIPTION
If a bucket type property contains a `ddl` property, we infer that it's a time series bucket type, aka table.  Add in a new set of defaults if the user does not specify them.

https://bashoeng.atlassian.net/browse/RTS-1469
