### PR TITLE
Handle case where there are no existing users the same as if no users matched

### DIFF
--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -106,7 +106,7 @@
 find_one_user_by_metadata(Key, Value) ->
     riak_core_metadata:fold(
       fun(User, _Acc) -> return_if_user_matches_metadata(Key, Value, User) end,
-      [],
+      {error, not_found},
       {<<"security">>, <<"users">>},
       [{resolver, lww}, {default, []}]).
 


### PR DESCRIPTION
Previously, the `find_one_user_by_metadata` function would return `{error, not_found}` for the case when no users matched the metadata query, but would return an empty list when there were no existing users registered with `riak_core_security`. This change is to make both of those cases return the same value: `{error, not_found}`.