### PR TITLE
Fix sync_spawn_command hang triggered by bug in vnode proxy overload handling

### DIFF
--- a/src/riak_core_vnode_proxy.erl
+++ b/src/riak_core_vnode_proxy.erl
@@ -279,6 +279,8 @@ handle_overload(Msg, #state{mod=Mod, index=Index}) ->
     case Msg of
         {'$gen_event', ?VNODE_REQ{sender=Sender, request=Request}} ->
             catch(Mod:handle_overload_command(Request, Sender, Index));
+        {'$gen_all_state_event', ?VNODE_REQ{sender=Sender, request=Request}} ->
+            catch(Mod:handle_overload_command(Request, Sender, Index));
         {'$gen_event', ?COVERAGE_REQ{sender=Sender, request=Request}} ->
             catch(Mod:handle_overload_command(Request, Sender, Index));
         _ ->


### PR DESCRIPTION
If we call `riak_core_vnode_master:sync_spawn_command`, it ends up sending
a gen_event all-state event to the proxy for forwarding. However, in
`handle_overload`, the old code only had case clauses for `'$gen_event'` and
not `'$gen_all_state_event'`. This means the event would be passed to
`handle_overload_info` instead of `handle_overload_request`, which would
likely skip the vnode callback code that sends a response.

In Riak this meant that certain operations would hang during overload,
since the caller of `sync_spawn_command` would never get a response.
(This situation was made worse by the fact that the call is being done
with an `infinity` timeout, but that's an issue we'll have to address some
other time.)