### PR TITLE
Find bucket grants

### DIFF
--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -43,6 +43,7 @@
          disable/0,
          enable/0,
          find_one_user_by_metadata/2,
+         find_bucket_grants/2,
          get_ciphers/0,
          get_username/1,
          is_enabled/0,
@@ -117,6 +118,13 @@ return_if_user_matches_metadata(Key, Value, {_Username, Options} = User) ->
         false ->
             {error, not_found}
     end.
+
+-spec find_bucket_grants(bucket(), user | group) -> [{RoleName :: string(), [permission()]}].
+find_bucket_grants(Bucket, Type) ->
+    Grants = match_grants({'_', Bucket}, Type),
+    lists:map(fun ({{Role, _Bucket}, Permissions}) ->
+                      {bin2name(Role), Permissions}
+              end, Grants).
 
 prettyprint_users([all], _) ->
     "all";
@@ -1339,6 +1347,8 @@ role_exists(Rolename, RoleType) ->
 illegal_name_chars(Name) ->
     [Name] =/= string:tokens(Name, ?ILLEGAL).
 
+bin2name(Bin) ->
+    unicode:characters_to_list(Bin, utf8).
 
 %% Rather than introduce yet another dependency to Riak this late in
 %% the 2.0 cycle, we'll live with string:to_lower/1. It will lowercase

--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -1089,7 +1089,6 @@ validate_password_option(Pass, Options) ->
                        Options),
     {ok, NewOptions}.
 
-
 validate_permissions(Perms) ->
     KnownPermissions = app_helper:get_env(riak_core, permissions, []),
     validate_permissions(Perms, KnownPermissions).
@@ -1347,8 +1346,11 @@ role_exists(Rolename, RoleType) ->
 illegal_name_chars(Name) ->
     [Name] =/= string:tokens(Name, ?ILLEGAL).
 
-bin2name(Bin) ->
-    unicode:characters_to_list(Bin, utf8).
+bin2name(Bin) when is_binary(Bin) ->
+    unicode:characters_to_list(Bin, utf8);
+%% 'all' can be stored in a grant instead of a binary name
+bin2name(Name) when is_atom(Name) ->
+    Name.
 
 %% Rather than introduce yet another dependency to Riak this late in
 %% the 2.0 cycle, we'll live with string:to_lower/1. It will lowercase


### PR DESCRIPTION
Adds find bucket grants functionality for returning all grants for the given bucket of the specified type. Role names are returned as strings using a new bin2name utility function.

A match_grants helper function was also added to simplify several metadata folds.