### PR TITLE
Port of Add thumbs (#879) to TS [JIRA: RIAK-3246]

### DIFF
--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -1,0 +1,11 @@
+minimum_reviewers: 2
+merge: true
+build_steps:
+  - make clean
+  - make deps
+  - make compile
+  - make test
+  - make xref
+  - make dialyzer
+org_mode: true
+timeout: 1800

--- a/src/riak_core_capability.erl
+++ b/src/riak_core_capability.erl
@@ -109,6 +109,13 @@
 -define(ETS, riak_capability_ets).
 -define(CAPS, '$riak_capabilities').
 
+-ifdef(TEST).
+-compile(export_all).
+-type state() :: #state{}.
+-export_type([state/0]).
+
+-endif.
+
 %%%===================================================================
 %%% API
 %%%===================================================================
@@ -156,6 +163,12 @@ get(Capability, Default) ->
         _:_ ->
             Default
     end.
+
+-ifdef(TEST).
+%% @doc Exported for testing - takes opaque state record and returns negotiated
+get_negotiated(State) ->
+    State#state.negotiated.
+-endif.
 
 %% @doc Return a list of all negotiated capabilities
 all() ->
@@ -628,41 +641,3 @@ load_registered() ->
         undefined -> [];
         {ok, Caps} -> Caps
     end.
-
-%% ===================================================================
-%% EUnit tests
-%% ===================================================================
--ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
-
-basic_test() ->
-    S1 = init_state([]),
-
-    S2 = register_capability(n1, 
-                             {riak_core, test},
-                             capability_info([x,a,c,y], y, []),
-                             S1),
-    S3 = add_node_capabilities(n2,
-                               [{{riak_core, test}, [a,b,c,y]}],
-                               S2),
-    S4 = negotiate_capabilities(n1, [{riak_core, []}], S3),
-    ?assertEqual([{{riak_core, test}, a}], S4#state.negotiated),
-
-    S5 = negotiate_capabilities(n1,
-                                [{riak_core, [{test, [{prefer, c}]}]}],
-                                S4),
-    ?assertEqual([{{riak_core, test}, c}], S5#state.negotiated),
-
-    S6 = add_node_capabilities(n3,
-                               [{{riak_core, test}, [b]}],
-                               S5),
-    S7 = negotiate_capabilities(n1, [{riak_core, []}], S6),
-    ?assertEqual([{{riak_core, test}, y}], S7#state.negotiated),
-
-    S8 = negotiate_capabilities(n1,
-                                [{riak_core, [{test, [{use, x}]}]}],
-                                S7),
-    ?assertEqual([{{riak_core, test}, x}], S8#state.negotiated),
-    ok.
-
--endif.

--- a/src/riak_core_node_watcher.erl
+++ b/src/riak_core_node_watcher.erl
@@ -37,9 +37,15 @@
          node_up/0,
          node_down/0,
          services/0, services/1,
-         nodes/1,
-         avsn/0]).
+         nodes/1]).
 
+%% TEST API
+-ifdef(TEST).
+
+-export([avsn/0,
+         set_broadcast_module/2]).
+
+-endif.
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
@@ -157,9 +163,15 @@ nodes(Service) ->
 %% Test API
 %% ===================================================================
 
+-ifdef(TEST).
+
 avsn() ->
     gen_server:call(?MODULE, get_avsn, infinity).
 
+set_broadcast_module(Module, Fn) ->
+    gen_server:call(?MODULE, {set_bcast_mod, Module, Fn}, infinity).
+
+-endif.
 
 %% ====================================================================
 %% gen_server callbacks

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -1936,11 +1936,12 @@ resize_test() ->
 resize_xfer_test_() ->
     {setup,
      fun() ->
+             meck:unload(),
              meck:new(riak_core, [passthrough]),
              meck:expect(riak_core, vnode_modules,
                          fun() -> [{some_app, fake_vnode}, {other_app, other_vnode}] end)
      end,
-     fun(_) -> meck:unload(riak_core) end,
+     fun(_) -> meck:unload() end,
      fun test_resize_xfers/0}.
 
 test_resize_xfers() ->

--- a/src/riak_core_test_util.erl
+++ b/src/riak_core_test_util.erl
@@ -28,14 +28,25 @@
 -export([setup_mockring1/0,
          fake_ring/2,
          stop_pid/1,
-         wait_for_pid/1]).
+         wait_for_pid/1,
+         stop_pid/2,
+         unlink_named_process/1]).
 -include_lib("eunit/include/eunit.hrl").
 
+stop_pid(undefined) ->
+    ok;
+stop_pid(Name) when is_atom(Name) ->
+    stop_pid(whereis(Name));
 stop_pid(Other) when not is_pid(Other) ->
     ok;
 stop_pid(Pid) ->
+    stop_pid(Pid, kill).
+
+stop_pid(Other, _ExitType) when not is_pid(Other) ->
+    ok;
+stop_pid(Pid, ExitType) ->
     unlink(Pid),
-    exit(Pid, shutdown),
+    exit(Pid, ExitType),
     ok = wait_for_pid(Pid).
 
 wait_for_pid(Pid) ->
@@ -48,6 +59,9 @@ wait_for_pid(Pid) ->
             {error, didnotexit}
     end.
 
+
+unlink_named_process(Name) when is_atom(Name) ->
+    unlink(whereis(Name)).
 
 setup_mockring1() ->
     % requires a running riak_core_ring_manager, in test-mode is ok

--- a/src/riak_core_util.erl
+++ b/src/riak_core_util.erl
@@ -1027,10 +1027,11 @@ bounded_pmap_test_() ->
 make_fold_req_test_() ->
     {setup,
      fun() ->
+             meck:unload(),
              meck:new(riak_core_capability, [passthrough])
      end,
      fun(_) ->
-             meck:unload(riak_core_capability)
+             ok
      end,
      [
       fun() ->
@@ -1049,7 +1050,7 @@ make_fold_req_test_() ->
                        end,
 
               meck:expect(riak_core_capability, get,
-                          fun(_, _) -> v1 end),
+                          fun({riak_core, fold_req_version}, _) -> v1 end),
               F_1         = make_fold_req(F_1),
               F_1         = make_fold_req(F_2),
               F_1         = make_fold_req(FoldFun, Acc0),
@@ -1057,12 +1058,16 @@ make_fold_req_test_() ->
               ok = Newest(),
 
               meck:expect(riak_core_capability, get,
-                          fun(_, _) -> v2 end),
+                          fun({riak_core, fold_req_version}, _) -> v2 end),
               F_2_default = make_fold_req(F_1),
               F_2         = make_fold_req(F_2),
               F_2_default = make_fold_req(FoldFun, Acc0),
               F_2         = make_fold_req(FoldFun, Acc0, Forw, Opts),
-              ok = Newest()
+              ok = Newest(),
+              %% It seems you could unload `meck' in the test teardown,
+              %% but that sometimes causes the eunit process to crash.
+              %% Instead, unload at end of test.
+              meck:unload()
       end
      ]
     }.

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -1078,6 +1078,7 @@ current_state(Pid) ->
     gen_fsm:sync_send_all_state_event(Pid, current_state).
 
 pool_death_test() ->
+    meck:unload(),
     meck:new(test_vnode, [non_strict, no_link]),
     meck:expect(test_vnode, init, fun(_) -> {ok, [], [{pool, test_pool_mod, 1, []}]} end),
     meck:expect(test_vnode, terminate, fun(_, _) -> normal end),
@@ -1097,9 +1098,7 @@ pool_death_test() ->
     exit(Pid, normal),
     wait_for_process_death(Pid),
     meck:validate(test_pool_mod),
-    meck:validate(test_vnode),
-    meck:unload(test_pool_mod),
-    meck:unload(test_vnode).
+    meck:validate(test_vnode).
 
 wait_for_process_death(Pid) ->
     wait_for_process_death(Pid, is_process_alive(Pid)).

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -35,10 +35,6 @@
 %% Field debugging
 -export([get_tab/0]).
 
--ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
--endif.
-
 -record(idxrec, {key, idx, mod, pid, monref}).
 -record(monrec, {monref, key}).
 

--- a/src/riak_core_vnode_proxy.erl
+++ b/src/riak_core_vnode_proxy.erl
@@ -356,6 +356,7 @@ overload_test_() ->
     {timeout, 900, {foreach,
      fun() ->
              VnodePid = spawn(fun fake_loop/0),
+             meck:unload(),
              meck:new(riak_core_vnode_manager, [passthrough]),
              meck:expect(riak_core_vnode_manager, get_vnode_pid,
                          fun(_Index, fakemod) -> {ok, VnodePid};
@@ -371,8 +372,8 @@ overload_test_() ->
              {VnodePid, ProxyPid}
      end,
      fun({VnodePid, ProxyPid}) ->
-             meck:unload(riak_core_vnode_manager),
-             meck:unload(fakemod),
+             unlink(VnodePid),
+             unlink(ProxyPid),
              exit(VnodePid, kill),
              exit(ProxyPid, kill)
      end,

--- a/test/btypes_eqc.erl
+++ b/test/btypes_eqc.erl
@@ -33,7 +33,7 @@
 -type type_prop_val()  :: boolean().
 
 -define(QC_OUT(P),
-    eqc:on_output(fun(Str, Args) -> io:format(user, Str, Args) end, P)).
+        eqc:on_output(fun(Str, Args) -> io:format(user, Str, Args) end, P)).
 
 -record(state, {
           %% a list of properties we have created
@@ -41,10 +41,10 @@
          }).
 
 btypes_test_() -> {
-        timeout, 120,
-        ?_test(?assert(
-            eqc:quickcheck(?QC_OUT(eqc:numtests(100, prop_btype_invariant())))))
-    }.
+              timeout, 120,
+              ?_test(?assert(
+                        eqc:quickcheck(?QC_OUT(eqc:testing_time(100, prop_btype_invariant())))))
+             }.
 
 run_eqc() ->
     run_eqc(100).
@@ -342,51 +342,14 @@ prop_btype_invariant() ->
             aggregate(command_names(Cmds),
                       ?TRAPEXIT(
                          begin
-                             meck:new(riak_core_capability, []),
-                             meck:expect(riak_core_capability, get,
-                                         fun({riak_core, bucket_types}) -> true;
-                                            (X) -> meck:passthrough([X]) end),
-                             os:cmd("rm -r ./btypes_eqc_meta"),
-                             application:set_env(riak_core, claimant_tick, 4294967295),
-                             application:set_env(riak_core, broadcast_lazy_timer, 4294967295),
-                             application:set_env(riak_core, broadcast_exchange_timer, 4294967295),
-                             application:set_env(riak_core, metadata_hashtree_timer, 4294967295),
-                             stop_pid(whereis(riak_core_ring_events)),
-                             stop_pid(whereis(riak_core_ring_manager)),
-                             {ok, RingEvents} = riak_core_ring_events:start_link(),
-                             {ok, _RingMgr} = riak_core_ring_manager:start_link(test),
-                             {ok, Claimant} = riak_core_claimant:start_link(),
-                             {ok, MetaMgr} = riak_core_metadata_manager:start_link([{data_dir, "./btypes_eqc_meta"}]),
-                             {ok, Hashtree} = riak_core_metadata_hashtree:start_link("./btypes_eqc_meta/trees"),
-                             {ok, Broadcast} = riak_core_broadcast:start_link(),
-                             {H, S, Res} = run_commands(?MODULE,Cmds),
-                             stop_pid(Broadcast),
-                             stop_pid(Hashtree),
-                             stop_pid(MetaMgr),
-                             stop_pid(Claimant),
-                             riak_core_ring_manager:stop(),
-                             stop_pid(RingEvents),
-                             os:cmd("rm -r ./btypes_eqc_meta"),
-                             meck:unload(riak_core_capability),
+                             {H, S, Res} =
+                                 bucket_eqc_utils:per_test_setup([],
+                                     fun() ->
+                                             run_commands(?MODULE,Cmds)
+                                     end),
                              pretty_commands(?MODULE, Cmds, {H, S, Res},
                                              Res == ok)
-                         end))).
-
-stop_pid(Other) when not is_pid(Other) ->
-    ok;
-stop_pid(Pid) ->
-    unlink(Pid),
-    exit(Pid, shutdown),
-    ok = wait_for_pid(Pid).
-
-wait_for_pid(Pid) ->
-    Mref = erlang:monitor(process, Pid),
-    receive
-        {'DOWN', Mref, process, _, _} ->
-            ok
-    after
-        5000 ->
-            {error, didnotexit}
-    end.
+                         end
+                        ))).
 
 -endif.

--- a/test/bucket_eqc_utils.erl
+++ b/test/bucket_eqc_utils.erl
@@ -1,0 +1,62 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(bucket_eqc_utils).
+
+%% API
+-export([per_test_setup/2]).
+
+
+per_test_setup(DefaultBucketProps, TestFun) ->
+    try
+        meck:new(riak_core_capability, []),
+        meck:expect(riak_core_capability, get,
+                    fun({riak_core, bucket_types}) -> true;
+                       (X) -> meck:passthrough([X]) end),
+        os:cmd("rm -rf ./meta_temp"),
+        riak_core_test_util:stop_pid(whereis(riak_core_ring_events)),
+        riak_core_test_util:stop_pid(whereis(riak_core_ring_manager)),
+        application:set_env(riak_core, claimant_tick, 4294967295),
+        application:set_env(riak_core, broadcast_lazy_timer, 4294967295),
+        application:set_env(riak_core, broadcast_exchange_timer, 4294967295),
+        application:set_env(riak_core, metadata_hashtree_timer, 4294967295),
+        application:set_env(riak_core, cluster_name, "eqc_test"),
+        application:set_env(riak_core, default_bucket_props, DefaultBucketProps),
+        {ok, RingEvents} = riak_core_ring_events:start_link(),
+        {ok, RingMgr} = riak_core_ring_manager:start_link(test),
+        {ok, Claimant} = riak_core_claimant:start_link(),
+        {ok, MetaMgr} = riak_core_metadata_manager:start_link([{data_dir, "./meta_temp"}]),
+        {ok, Hashtree} = riak_core_metadata_hashtree:start_link("./meta_temp/trees"),
+        {ok, Broadcast} = riak_core_broadcast:start_link(),
+
+        Results = TestFun(),
+
+        riak_core_test_util:stop_pid(Broadcast),
+        riak_core_test_util:stop_pid(Hashtree),
+        riak_core_test_util:stop_pid(MetaMgr),
+        riak_core_test_util:stop_pid(Claimant),
+        unlink(RingMgr),
+        riak_core_ring_manager:stop(),
+        riak_core_test_util:stop_pid(RingEvents),
+        Results
+    after
+        os:cmd("rm -rf ./meta_temp"),
+        meck:unload()
+    end.

--- a/test/bucket_fixup_test.erl
+++ b/test/bucket_fixup_test.erl
@@ -82,8 +82,9 @@ load_test_() ->
      fun(_) ->
              process_flag(trap_exit, true),
              catch application:stop(riak_core),
+             riak_core_test_util:unlink_named_process(riak_core_ring_manager),
              catch(riak_core_ring_manager:stop()),
-             catch(exit(whereis(riak_core_ring_events), shutdown)),
+             riak_core_test_util:stop_pid(whereis(riak_core_ring_events), shutdown),
              application:unset_env(riak_core, bucket_fixups),
              application:unset_env(riak_core, default_bucket_props),
              application:unset_env(riak_core, ring_creation_size)

--- a/test/core_vnode_eqc.erl
+++ b/test/core_vnode_eqc.erl
@@ -52,17 +52,23 @@ simple_test_() ->
     {setup,
      fun setup_simple/0,
      fun(OldVars) ->
-             riak_core_ring_manager:stop(),
-	     application:stop(exometer),
-	     application:stop(lager),
-	     application:stop(goldrush),
-             [ok = application:set_env(riak_core, K, V) || {K,V} <- OldVars],
-             ok
+         riak_core_test_util:unlink_named_process(riak_core_ring_manager),
+         riak_core_ring_manager:stop(),
+         riak_core_test_util:stop_pid(riak_core_ring_events),
+         application:stop(exometer),
+         application:stop(lager),
+         application:stop(goldrush),
+         [ok = application:set_env(riak_core, K, V) || {K,V} <- OldVars],
+         ok
      end,
      {timeout, 600,
       ?_assertEqual(true, quickcheck(?QC_OUT(numtests(100, prop_simple()))))}}.
 
 setup_simple() ->
+    %% call `meck:unload' here because there are other tests that have
+    %% meck'ed things we use, and they an break us if eunit doesn't tear
+    %% them down fast enough.
+    meck:unload(),
     error_logger:tty(false),
     application:set_env(sasl, sasl_error_logger, {file, "core_vnode_eqc_sasl.log"}),
     error_logger:logfile({open, "core_vnode_eqc.log"}),
@@ -353,9 +359,9 @@ start_servers() ->
 stop_servers() ->
     %% Make sure VMaster is killed before sup as start_vnode is a cast
     %% and there may be a pending request to start the vnode.
-    stop_pid(whereis(mock_vnode_master)),
-    stop_pid(whereis(riak_core_vnode_manager)),
-    stop_pid(whereis(riak_core_vnode_sup)).
+    riak_core_test_util:stop_pid(mock_vnode_master),
+    riak_core_test_util:stop_pid(riak_core_vnode_manager),
+    riak_core_test_util:stop_pid(riak_core_vnode_sup).
 
 restart_master() ->
     %% Call get status to make sure the riak_core_vnode_master
@@ -363,25 +369,8 @@ restart_master() ->
     %% commands like neverreply are not cast on to the vnode and the
     %% counters are not updated correctly.
     sys:get_status(mock_vnode_master),
-    stop_pid(whereis(mock_vnode_master)),
+    riak_core_test_util:stop_pid(mock_vnode_master),
     {ok, _VMaster} = riak_core_vnode_master:start_link(mock_vnode).
-
-stop_pid(undefined) ->
-    ok;
-stop_pid(Pid) ->
-    unlink(Pid),
-    exit(Pid, kill), %% Don't wait for graceful shutdown
-    ok = wait_for_pid(Pid).
-
-wait_for_pid(Pid) ->
-    Mref = erlang:monitor(process, Pid),
-    receive
-        {'DOWN',Mref,process,_,_} ->
-            ok
-    after
-        5000 ->
-            {error, didnotexit}
-    end.
 
 %% Async work collector process - collect all messages until work requested
 async_work_proc(AsyncWork, Crashes) ->

--- a/test/riak_core_capability_tests.erl
+++ b/test/riak_core_capability_tests.erl
@@ -1,0 +1,60 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_core: Core Riak Application
+%%
+%% Copyright (c) 2007-2017 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_capability_tests).
+
+%% ===================================================================
+%% EUnit tests
+%% ===================================================================
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+basic_test() ->
+    S1 = riak_core_capability:init_state([]),
+
+    S2 = riak_core_capability:register_capability(n1,
+                             {riak_core, test},
+                             riak_core_capability:capability_info([x,a,c,y], y, []),
+                             S1),
+    S3 = riak_core_capability:add_node_capabilities(n2,
+                               [{{riak_core, test}, [a,b,c,y]}],
+                               S2),
+    S4 = riak_core_capability:negotiate_capabilities(n1, [{riak_core, []}], S3),
+    ?assertEqual([{{riak_core, test}, a}], riak_core_capability:get_negotiated(S4)),
+
+    S5 = riak_core_capability:negotiate_capabilities(n1,
+                                [{riak_core, [{test, [{prefer, c}]}]}],
+                                S4),
+    ?assertEqual([{{riak_core, test}, c}], riak_core_capability:get_negotiated(S5)),
+
+    S6 = riak_core_capability:add_node_capabilities(n3,
+                               [{{riak_core, test}, [b]}],
+                               S5),
+    S7 = riak_core_capability:negotiate_capabilities(n1, [{riak_core, []}], S6),
+    ?assertEqual([{{riak_core, test}, y}], riak_core_capability:get_negotiated(S7)),
+
+    S8 = riak_core_capability:negotiate_capabilities(n1,
+                                [{riak_core, [{test, [{use, x}]}]}],
+                                S7),
+    ?assertEqual([{{riak_core, test}, x}], riak_core_capability:get_negotiated(S8)),
+    ok.
+
+-endif.

--- a/test/sync_command_test.erl
+++ b/test/sync_command_test.erl
@@ -90,27 +90,11 @@ setup_simple() ->
 stop_servers(_Pid) ->
     %% Make sure VMaster is killed before sup as start_vnode is a cast
     %% and there may be a pending request to start the vnode.
-    stop_pid(whereis(mock_vnode_master)),
-    stop_pid(whereis(riak_core_vnode_manager)),
-    stop_pid(whereis(riak_core_vnode_events)),
-    stop_pid(whereis(riak_core_vnode_sup)),
+    riak_core_test_util:stop_pid(mock_vnode_master),
+    riak_core_test_util:stop_pid(riak_core_vnode_manager),
+    riak_core_test_util:stop_pid(riak_core_ring_events),
+    riak_core_test_util:stop_pid(riak_core_vnode_sup),
+    riak_core_test_util:stop_pid(riak_core_ring_manager),
     application:stop(exometer),
     application:stop(lager),
     application:stop(goldrush).
-
-stop_pid(undefined) ->
-    ok;
-stop_pid(Pid) ->
-    unlink(Pid),
-    exit(Pid, shutdown),
-    ok = wait_for_pid(Pid).
-
-wait_for_pid(Pid) ->
-    Mref = erlang:monitor(process, Pid),
-    receive
-        {'DOWN',Mref,process,_,_} ->
-            ok
-    after
-        5000 ->
-            {error, didnotexit}
-    end.

--- a/test/worker_pool_test.erl
+++ b/test/worker_pool_test.erl
@@ -61,7 +61,9 @@ simple_worker_pool() ->
 
     %% make sure we got all the expected responses
 
-    [ ?assertEqual(true, receive_result(N)) || N <- lists:seq(1, 10)].
+    [ ?assertEqual(true, receive_result(N)) || N <- lists:seq(1, 10)],
+    unlink(Pool),
+    riak_core_vnode_worker_pool:stop(Pool, normal).
 
 simple_noreply_worker_pool() ->
     {ok, Pool} = riak_core_vnode_worker_pool:start_link(?MODULE, 3, 10, true, []),
@@ -76,7 +78,9 @@ simple_noreply_worker_pool() ->
 
     %% make sure we got all the expected responses
 
-    [ ?assertEqual(true, receive_result(N)) || N <- lists:seq(1, 10)].
+    [ ?assertEqual(true, receive_result(N)) || N <- lists:seq(1, 10)],
+    unlink(Pool),
+    riak_core_vnode_worker_pool:stop(Pool, normal).
 
 
 pool_test_() ->


### PR DESCRIPTION
`cherry-pick` of https://github.com/basho/riak_core/pull/879

* add thumbs
* Hopefully resolve test process stop issues.

- Add a call to `meck:unload/0` in setup for all tests that use meck
  in order to make sure meck processes are unloaded _before_ starting
  up new ones. It appears eunit doesn't always call a teardown function
  before moving on to another test, so they can't be depended upon.
- unlink before stopping `riak_core_ring_manager` and `riak_core_ring_events`
  in `core_vnode_eqc` - this seems to be what was actually causing the
  "unexpected exit" of a test process.
- add `stop_pid/2` in riak_core_test_util so you can pass an exit type
  which was being used by a test and failing
- unlink processes that are `start_link`ed to tests
- Fix sync command typo to stop riak_core_ring_events
* Add some additional fixes to stopping processes started with `start_link`.
- Stop proesses start_linked
- Add a `spawn` wrapper around a test to see if it helps with isolating tests (it did).
* `meck:unload()` before starting `core_vnode_eqc` test.

Ends up, the `meck` calls in `riak_core_util` were breaking
`core_vnode_eqc`, which doesn't even _use_ `meck`. Call `meck:unload()`
at end of test in `riak_core_util` (not in test teardown, which can also
cause problems), and again at the beginning of `core_vnode_eqc` just in
case some new test later on tries to break it again.
* Move `riak_core_capability` tests to their own file.

Because of `meck` issues we need to keep unit tests and modules
separate for modules that are mecked in other tests.
* Address review comments on test fixes.

- add `set_broadcast_module/2` to riak_core_node_watcher, wrapped in
  an `-ifdef(TEST)` so we can potentially change the implementation
  later without having to change the test, which used to do a direct
  `gen_server:call` to the `set_bcast_mod` `handle_call` function.
- Change `riak_core_ring_manager:stop/0` from a cast to a call. As a
  cast, it leaves us vulnerable to potential race conditions in test
  startup/shutdown. Because it was only a test function anyway, making
  the caller wait for the stop seems reasonable. Also wrapped it in
  `-ifdef(TEST)` to make sure it's not called from production code.
- Add `unlink_named_process` to `riak_core_test_util` and use it
  where we had `unlink(whereis(name_of_process))`
- remove last copy/paste of `stop_pid` function from `bg_manager_eqc`
  and `core_vnode_eqc` and use `riak_core_test_util` functions instead.
- Fix copyright notice in bucket_eqc_utils.
- Found that we needed to call `meck:unload` after each test in
  `bprops_eqc` and `btypes_eqc` to avoid a meck/coverdata issue.
  Moved setup and unload of `meck`s in `bucket_eqc_utils` to the
  `per_test_setup` function and dropped `setup_cleanup/0` as it was no
  longer doing anything.
* Update `bprops_eqc` and `btypes_eqc` to use `eqc:testing_time` instead
of `eqc:numtests` as it's possible for it to time out via `eunit` if
you allow them to do 100 iterations.