### PR TITLE
Add riak_core_security:find_user

### DIFF
--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -42,6 +42,7 @@
          del_user/1,
          disable/0,
          enable/0,
+         find_user/1,
          find_one_user_by_metadata/2,
          find_bucket_grants/2,
          get_ciphers/0,
@@ -102,6 +103,15 @@
 -type metadata_key() :: string().
 -type metadata_value() :: term().
 -type options() :: [{metadata_key(), metadata_value()}].
+
+-spec find_user(Username :: string()) -> options() | {error, not_found}.
+find_user(Username) ->
+    case user_details(name2bin(Username)) of
+        undefined ->
+            {error, not_found};
+        Options ->
+            Options
+    end.
 
 -spec find_one_user_by_metadata(metadata_key(), metadata_value()) -> {Username :: string(), options()} | {error, not_found}.
 find_one_user_by_metadata(Key, Value) ->

--- a/test/riak_core_security_tests.erl
+++ b/test/riak_core_security_tests.erl
@@ -38,7 +38,8 @@ security_test_() ->
      fun(S) ->
              stop_manager(S)
      end,
-     [{timeout, 60, { "test_find_bucket_grants", fun test_find_bucket_grants/0 }},
+     [{timeout, 60, { "find_user", fun test_find_user/0 }},
+      {timeout, 60, { "test_find_bucket_grants", fun test_find_bucket_grants/0 }},
       {timeout, 60, { "find_one_user_by_metadata", fun test_find_one_user_by_metadata/0 }},
       {timeout, 60, { "trust auth works",
                       fun() ->
@@ -260,6 +261,12 @@ test_find_bucket_grants() ->
     ?assertEqual(lists:sort(["riak_kv.get", "riak_kv.put"]), lists:sort(Perms)),
     ?assertMatch({_, ["riak_kv.get"]}, lists:keyfind(all, 1, GroupGrants)),
     ?assertMatch({_, ["riak_kv.put"]}, lists:keyfind("testgroup", 1, GroupGrants)).
+
+test_find_user() ->
+    Options = [{key, value}],
+    Username = "testuser",
+    ok = riak_core_security:add_user(Username, Options),
+    ?assertMatch(Options, riak_core_security:find_user(Username)).
 
 test_find_one_user_by_metadata() ->
     ok = riak_core_security:add_user("paul", [{"key_and_value", "match"}]),


### PR DESCRIPTION
Allows lookup of a user by username rather than metadata.