### PR TITLE
Update behavior specs to use -callback directives [JIRA: RIAK-3243]

### DIFF
--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -67,8 +67,6 @@
 -behaviour(gen_fsm).
 
 %% API
--export([behaviour_info/1]).
-
 -export([start_link/3]).
 
 -ifdef(TEST).
@@ -87,28 +85,30 @@
          terminate/3,
          code_change/4]).
 
--spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
-behaviour_info(callbacks) ->
-    [
-     {init, 2},
-     {process_results, 2},
-     {finish, 2}
-    ];
-behaviour_info(_) ->
-    undefined.
+-type mod_state() :: term().
+-callback init(from(), RequestArgs :: [term()]) ->
+    {Request :: term(), vnode_selector(), NVal :: pos_integer(), primary_vnode_coverage(),
+     NodeCheckService :: module(), VNodeMaster :: atom(), timeout(), mod_state()}.
+-callback process_results(Results :: term(), mod_state()) ->
+    {ok, mod_state()} |
+    {done, mod_state()} |
+    {error, term()}.
+-callback finish(clean | {error, term()}, mod_state()) -> {stop, normal, mod_state()}.
 
 -define(DEFAULT_TIMEOUT, 60000*8).
 
 -type req_id() :: non_neg_integer().
 -type from() :: {atom(), req_id(), pid()}.
+-type vnode_selector() :: all | allup.
+-type primary_vnode_coverage() :: all | pos_integer().
 
 -record(state, {coverage_vnodes :: [{non_neg_integer(), node()}],
                 mod :: atom(),
                 mod_state :: tuple(),
                 n_val :: pos_integer(),
                 node_check_service :: module(),
-                vnode_selector :: all | allup,
-                pvc :: all | pos_integer(), % primary vnode coverage
+                vnode_selector :: vnode_selector(),
+                pvc :: primary_vnode_coverage(),
                 request :: tuple(),
                 req_id :: req_id(),
                 required_responses :: pos_integer(),

--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -104,7 +104,7 @@
 
 -record(state, {coverage_vnodes :: [{non_neg_integer(), node()}],
                 mod :: atom(),
-                mod_state :: tuple(),
+                mod_state :: mod_state(),
                 n_val :: pos_integer(),
                 node_check_service :: module(),
                 vnode_selector :: vnode_selector(),

--- a/src/riak_core_vnode_worker.erl
+++ b/src/riak_core_vnode_worker.erl
@@ -33,16 +33,18 @@
                                  {gen_server, pulse_gen_server}]}).
 -endif.
 
+-type mod_state() :: term().
+
 -record(state, {
         module :: atom(),
-        modstate :: any()
+        modstate :: mod_state()
     }).
 
 -callback init_worker(partition(), Args :: term(), Props :: [{atom(), term()}]) ->
-    {ok, State :: term()}.
--callback handle_work(Work :: term(), sender(), State :: term()) ->
-    {reply, Reply :: term(), State :: term()} |
-    {noreply, State :: term()}.
+    {ok, mod_state()}.
+-callback handle_work(Work :: term(), sender(), mod_state()) ->
+    {reply, Reply :: term(), mod_state()} |
+    {noreply, mod_state()}.
 
 start_link(Args) ->
     WorkerMod = proplists:get_value(worker_callback_mod, Args),

--- a/src/riak_core_vnode_worker.erl
+++ b/src/riak_core_vnode_worker.erl
@@ -20,7 +20,8 @@
 
 -behaviour(gen_server).
 
--export([behaviour_info/1]).
+-include("riak_core_vnode.hrl").
+
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
         code_change/3]).
 -export([start_link/1, handle_work/3, handle_work/4]).
@@ -37,12 +38,11 @@
         modstate :: any()
     }).
 
--spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
-behaviour_info(callbacks) ->
-    [{init_worker,3},
-     {handle_work,3}];
-behaviour_info(_Other) ->
-    undefined.
+-callback init_worker(partition(), Args :: term(), Props :: [{atom(), term()}]) ->
+    {ok, State :: term()}.
+-callback handle_work(Work :: term(), sender(), State :: term()) ->
+    {reply, Reply :: term(), State :: term()} |
+    {noreply, State :: term()}.
 
 start_link(Args) ->
     WorkerMod = proplists:get_value(worker_callback_mod, Args),


### PR DESCRIPTION
This PR updates the `riak_core_vnode_worker` and `riak_core_coverage_fsm` behaviors to use `-callback` directives instead of the old-style `behaviour_info` system. I've done my best to figure out all the proper type specs for the behaviors, and Dialyzer passes so I think this is all correct, though if anyone knows of a way we could tighten up the specs any further that'd always be welcome.