### PR TITLE
Set `merge` to `false` in `.thumbs.yml`

### DIFF
--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -1,5 +1,5 @@
 minimum_reviewers: 2
-merge: true
+merge: false
 build_steps:
   - make clean
   - make deps


### PR DESCRIPTION
We want to make merges explicit, so set `merge: false` in `.thumbs.yml`. Will require us to explicitly ask Thumbot to merge which is good.