### PR TITLE
More robustness additions for the info service

### DIFF
--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -1,5 +1,5 @@
 minimum_reviewers: 2
-merge: true
+merge: false
 build_steps:
   - make clean
   - make deps

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -155,5 +155,10 @@ start_eleveldb_info_service() ->
     Shutdown = {eleveldb, remove_metadata_pid, []},
     InfoSource = {riak_core_bucket, get_bucket, []},
     ResultsHandler = {eleveldb_metadata, handle_metadata_response, []},
-    {ok, _Pid} = riak_core_info_service:start_service(Registration, Shutdown, InfoSource, ResultsHandler),
-    ok.
+    case riak_core_info_service:start_service(Registration, Shutdown, InfoSource, ResultsHandler) of
+        {ok, _Pid} ->
+            ok;
+        {error, Error} ->
+            lager:warning("Info service failed to register for eleveldb: ~p", [Error]),
+            ok
+    end.

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -152,7 +152,7 @@ register_capabilities() ->
 %% TODO: This belongs in riak_kv - an issue will be created to move it, but time constraints.
 start_eleveldb_info_service() ->
     Registration = {eleveldb, set_metadata_pid, [bucket_props]},
-    Shutdown = {eleveldb, remove_metadata_pid, []},
+    Shutdown = {eleveldb, remove_metadata_pid, [bucket_props]},
     InfoSource = {riak_core_bucket, get_bucket, []},
     ResultsHandler = {eleveldb_metadata, handle_metadata_response, []},
     case riak_core_info_service:start_service(Registration, Shutdown, InfoSource, ResultsHandler) of

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -151,7 +151,7 @@ register_capabilities() ->
 
 %% TODO: This belongs in riak_kv - an issue will be created to move it, but time constraints.
 start_eleveldb_info_service() ->
-    Registration = {eleveldb, set_metadata_pid, []},
+    Registration = {eleveldb, set_metadata_pid, [bucket_props]},
     Shutdown = {eleveldb, remove_metadata_pid, []},
     InfoSource = {riak_core_bucket, get_bucket, []},
     ResultsHandler = {eleveldb_metadata, handle_metadata_response, []},

--- a/src/riak_core_app.erl
+++ b/src/riak_core_app.erl
@@ -27,6 +27,8 @@
 %% Application callbacks
 -export([start/2, stop/1]).
 
+-export([start_eleveldb_info_service/0]).
+
 %% ===================================================================
 %% Application callbacks
 %% ===================================================================
@@ -91,6 +93,7 @@ start_riak_core_sup() ->
             ok = register_capabilities(),
             ok = init_cli_registry(),
             ok = riak_core_throttle:init(),
+            ok = start_eleveldb_info_service(),
 
             {ok, Pid};
         {error, Reason} ->
@@ -144,4 +147,13 @@ register_capabilities() ->
               apply(riak_core_capability, register, Capability)
       end,
       Capabilities),
+    ok.
+
+%% TODO: This belongs in riak_kv - an issue will be created to move it, but time constraints.
+start_eleveldb_info_service() ->
+    Registration = {eleveldb, set_metadata_pid, []},
+    Shutdown = {eleveldb, remove_metadata_pid, []},
+    InfoSource = {riak_core_bucket, get_bucket, []},
+    ResultsHandler = {eleveldb_metadata, handle_metadata_response, []},
+    {ok, _Pid} = riak_core_info_service:start_service(Registration, Shutdown, InfoSource, ResultsHandler),
     ok.

--- a/src/riak_core_info_service.erl
+++ b/src/riak_core_info_service.erl
@@ -1,0 +1,278 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2017 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%%% @doc
+%%%      The `riak_core_info_service' is a way for dependencies of
+%%%      `riak_core' to be registered to receive messages from
+%%%      `riak_core' without a cyclic dependency graph.
+%%%
+%%%      == Callbacks ==
+%%%      The dependency needs to know to which pid it should send
+%%%      requests for `riak_core' data. The pid will be sent to the
+%%%      `Registration' callback.
+%%%
+%%%      The `Provider' callback is a function inside `riak_core' that returns
+%%%      information that the dependency needs.
+%%%
+%%%      The `Handler' callback is a function in the dependency that
+%%%      expects the reply from the `Provider'.
+%%%
+%%%      === Handler Parameters ===
+%%%      The arguments to `Handler' will be, in order:
+%%%      <ol><li>Each item, if any, provided in the list in the 3rd element of the registration tuple</li>
+%%%      <li>The result from `Provider' wrapped in a 3-tuple:
+%%%        <ol><li>The result</li>
+%%%            <li>The list of parameters passed to `Provider' via the invoke message</li>
+%%%            <li>The opaque `HandlerContext' (see {@section Request Message})</li>
+%%%        </ol></li></ol>
+%%%
+%%%
+%%%      See {@link callback()}.
+%%%
+%%%      == Request Message ==
+%%%
+%%%      To ask the `info_service' process to call the `Provider'
+%%%      function, the dependency <b>must</b> send Erlang messages
+%%%      (rather than invoke API functions) to the info service
+%%%      process (registered previously via the `Registration'
+%%%      callback) of the following form:
+%%%
+%%%        `{invoke, ProviderParameters::[term()], HandlerContext::term()}'
+%%%
+%%%      The `HandlerContext' is a request identifier ignored by
+%%%      `riak_core', to be returned to the caller.
+%%%
+%%%      == History ==
+%%%      The information service originates from a need in `eleveldb' to retrieve
+%%%      bucket properties.
+%%%
+%%%      For that particular problem the callbacks would look like this:
+%%%  ```
+%%%  Registration = {eleveldb, set_metadata_pid, []}
+%%%  Provider = {riak_core_bucket, get_bucket, []}
+%%%  Handler = {eleveldb, handle_metadata_response, []}
+%%%  '''
+%%%
+%%%      And `handle_metadata_response/1' would look like this,
+%%%      assuming `Key' was sent with the original invocation message
+%%%      as the 3rd element of the tuple:
+%%%  ```
+%%%  handle_metadata_response({Props, _ProviderParams, Key}) ->
+%%%      property_cache(Key, Props).
+%%%
+%%%  set_metadata_pid(_Pid) ->
+%%%      erlang:nif_error({error, not_loaded}).
+%%%  '''
+%%%
+%%%      == Error Handling ==
+%%%
+%%%      If any callback generates an exception, the response from
+%%%      `catch' will be logged and (where relevant) communicated to
+%%%      the caller.
+%%%
+%%%      If the registration or response handler callback defined by
+%%%      the consumer returns anything other than `ok', the service
+%%%      process will terminate.
+
+-module(riak_core_info_service).
+
+-export([start_service/4]).
+
+
+-type callback() :: {module(), FunName::atom(),InitialArgs::[term()]} | undefined.
+
+%% @type callback(). Any arguments provided during registration of
+%% `Handler' will be sent as the first parameters when the callback is
+%% invoked; the result of the `Provider' callback will be wrapped in a
+%% tuple as the last parameter. See {@section Handler Parameters}
+
+-export_type([callback/0]).
+
+-spec start_service(Registration::callback(), Shutdown::callback(), Provider::callback(), Handler::callback()) ->
+                           ok |
+                           {error, term()}.
+
+start_service(Registration, Shutdown, Provider, Handler) ->
+    riak_core_info_service_sup:start_service(Registration, Shutdown, Provider, Handler).
+
+-ifdef(TEST).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(NODE_NAME, a_node).
+-define(REG(Key), {?MODULE, register, [self(), Key]}).
+-define(SHUT(Key), {?MODULE, shutdown, [self(), Key]}).
+-define(HANDLER(Key), {?MODULE, response, [self(), Key]}).
+
+-define(GET_RING, {riak_core_ring, fresh, [64, ?NODE_NAME]}).
+-define(CRASH, {?MODULE, crashme, []}).
+
+%% `supervisor` module does not supply a `start` interface, only
+%% `start_link`, so we use a process 'twixt us and the
+%% supervisor to start it, kill it, and take a dive
+sup_wrapper() ->
+    {ok, Sup} = riak_core_info_service_sup:start_link(),
+    receive
+        sup_kill ->
+            exit(Sup, kill)
+    end.
+
+%% Launching and terminating the supervisor is an async operation with
+%% all the non-determinism that that implies. So, we wait.
+sup_wait(Name, Fun) ->
+    sup_wait(Name, Fun, Fun(whereis(Name)), 5).
+
+sup_wait(_Name, _Fun, ok, _Count) ->
+    ok;
+sup_wait(_Name, Fun, wait, 0) ->
+    throw(Fun(throw));
+sup_wait(Name, Fun, wait, Count) ->
+    timer:sleep(50),
+    sup_wait(Name, Fun, Fun(whereis(Name)), Count-1).
+
+%% We're very selective about which messages to consider for these
+%% tests, but still, let's throw out extraneous messages from earlier
+%% tests
+flush_messages() ->
+    receive
+        _ -> flush_messages()
+    after 0 ->
+            ok
+    end.
+
+setup() ->
+    WaitTerminated = fun(undefined) -> ok;
+                        (throw) -> sup_did_not_die;
+                        (_) -> wait
+                     end,
+    WaitStarted    = fun(undefined) -> wait;
+                        (throw) -> sup_did_not_start;
+                        (_) -> ok
+                     end,
+    flush_messages(),
+
+    sup_wait(riak_core_info_service_sup, WaitTerminated),
+    Pid = spawn(fun sup_wrapper/0),
+    sup_wait(riak_core_info_service_sup, WaitStarted),
+
+    Pid.
+
+teardown(Pid) ->
+    Pid ! sup_kill.
+
+%% In the middle of a long run of unit tests, there may be any number
+%% of unrelated messages arriving in our mailbox. Ignore anything that
+%% doesn't match the patterns we generate, send the rest to the
+%% function argument to decide whether it's what we expected.
+my_receive(Fun) ->
+    receive
+        {response, _}=Msg ->
+            Fun(Msg);
+        {register, _}=Msg ->
+            Fun(Msg);
+        {shutdown, _}=Msg ->
+            Fun(Msg);
+        _ ->
+            my_receive(Fun)
+    after 1000 ->
+            throw(timeout)
+    end.
+
+%% Define a response handler function which crashes, verify that we
+%% see the shutdown message we expect
+exception_test() ->
+    Sup = setup(),
+    Key = 'exception_test',
+    Context = '_waydownwego',
+
+    {ok, Pid0} = riak_core_info_service:start_service(?REG(Key), ?SHUT(Key), ?GET_RING, ?CRASH),
+
+    Pid = my_receive(
+            fun({register, {AKey, SvcPid}}) when Key == AKey->
+                    SvcPid;
+                (Msg) ->
+                     throw({unexpected_message, Msg})
+            end),
+
+    ?assert(is_process_alive(Pid)),
+    ?assertEqual(Pid0, Pid),
+    Pid ! {invoke, [], Context},
+
+    Result = my_receive(
+               fun({shutdown, {AKey, _Pid}}) when Key == AKey ->
+                       shutdown;
+                  (Msg) ->
+                       throw({unexpected_message, Msg})
+            end),
+
+    %% Yes, if the ring structure changes again, this first assertion will fail
+    ?assertEqual(shutdown, Result),
+    teardown(Sup),
+    ok.
+
+%% Ask for a fresh ring
+receive_ring_test() ->
+    Sup = setup(),
+    Key = 'test_receive_ring',
+    Context = '_mesojedi',
+
+    {ok, Pid0} = riak_core_info_service:start_service(?REG(Key), ?SHUT(Key), ?GET_RING, ?HANDLER(Key)),
+
+    Pid = my_receive(
+            fun({register, {AKey, SvcPid}}) when Key == AKey ->
+                    SvcPid;
+                (Msg) ->
+                     throw({unexpected_message, Msg})
+            end),
+
+    ?assert(is_process_alive(Pid)),
+    ?assertEqual(Pid0, Pid),
+    Pid ! {invoke, [], Context},
+
+    Ring = my_receive(
+             fun({response, {AKey, {AContext, MyRing}}})
+                   when Key == AKey, Context == AContext ->
+                     MyRing;
+                (Msg) ->
+                     throw({unexpected_message, Msg})
+             end),
+
+    %% Yes, if the ring structure changes again, this first assertion will fail
+    ?assertEqual(chstate_v2, element(1, Ring)),
+    ?assertEqual(?NODE_NAME, element(2, Ring)),
+    teardown(Sup),
+    ok.
+
+crashme(_) ->
+    exit(for_testing).
+
+response(Pid, Key1, {Result, [], Context}) ->
+    Pid ! {response, {Key1, {Context, Result}}},
+    ok.
+
+register(Pid, Key, SvcPid) ->
+    Pid ! {register, {Key, SvcPid}},
+    ok.
+
+shutdown(Pid, Key, SvcPid) ->
+    Pid ! {shutdown, {Key, SvcPid}},
+    ok.
+
+-endif.

--- a/src/riak_core_info_service.erl
+++ b/src/riak_core_info_service.erl
@@ -125,6 +125,11 @@ verify_callable([{Module, Function, Parameters}|T]) ->
     %% case of registration and shutdown, it's the pid; in the case of
     %% the response handler, it's the response wrapped in a tuple.
     Arity = 1 + length(Parameters),
+
+    %% If `ensure_loaded' fails, `function_exported' will give us
+    %% `false', so no need to check for errors here
+    _ = code:ensure_loaded(Module),
+
     case erlang:function_exported(Module, Function, Arity) of
         true ->
             verify_callable(T);

--- a/src/riak_core_info_service.erl
+++ b/src/riak_core_info_service.erl
@@ -250,7 +250,6 @@ exception_test() ->
 
 no_callback_test() ->
     Key = 'no_callback_test',
-    io:format(user, "~p~n", [riak_core_info_service:start_service(?BOGUS_REG, ?SHUT(Key), ?GET_RING, ?HANDLER(Key))]),
     ?assertMatch({error, _}, riak_core_info_service:start_service(?BOGUS_REG, ?SHUT(Key), ?GET_RING, ?HANDLER(Key))).
 
 %% Ask for a fresh ring

--- a/src/riak_core_info_service_process.erl
+++ b/src/riak_core_info_service_process.erl
@@ -1,0 +1,168 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2017 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @see riak_core_info_service
+-module(riak_core_info_service_process).
+-behaviour(gen_server).
+
+-type callback() :: riak_core_info_service:callback().
+
+-record(state, {
+    registration :: callback(),
+    service_provider :: callback(),
+    response_handler :: callback(),
+    shutdown :: callback()
+}).
+
+-export([start_link/4,
+         init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-ifdef(TEST).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+%% `gen_server' implementation
+
+%% All arguments must be fully-defined callbacks.
+start_link(Registration, Shutdown, Provider, ResponseHandler)
+  when is_tuple(Registration),
+       is_tuple(Shutdown),
+       is_tuple(Provider),
+       is_tuple(ResponseHandler) ->
+    State = #state{registration = Registration,
+                   shutdown = Shutdown,
+                   service_provider = Provider,
+                   response_handler = ResponseHandler},
+    gen_server:start_link(?MODULE, State, []).
+
+init(#state{registration=Registration}=State) ->
+    %% Registration callback *must* return `ok' or this process will
+    %% shut down
+    handle_consumer_response(apply_callback(Registration, [self()]), registration, State).
+
+handle_info({invoke, ProviderParams, HandlerContext}, State) ->
+    handle_invoke_message(ProviderParams, HandlerContext, State);
+
+handle_info(callback_shutdown, State) ->
+    {stop, normal, State}.
+
+terminate(_Reason, State) ->
+    handle_shutdown_message(State).
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+handle_call(Request, _From, State) ->
+    terminate_not_implemented(Request, State).
+
+handle_cast(Request, State) ->
+    terminate_not_implemented(Request, State).
+
+%% Private
+
+terminate_not_implemented(Request, State) ->
+    lager:warning("Terminating - unknown message received: ~p", [Request]),
+    {stop, not_implemented, State}.
+
+handle_invoke_message(ProviderParams, HandlerContext,
+                      #state{service_provider = Provider,
+                             response_handler = ResponseHandler } = State) ->
+    %% At this layer we don't care much whether a callback succeeded
+    {_, Result} = apply_callback(Provider, ProviderParams),
+
+    Reply = {Result, ProviderParams, HandlerContext},
+    handle_consumer_response(apply_callback(ResponseHandler, [Reply]), response, State).
+
+handle_shutdown_message(#state{shutdown = Shutdown}=State) ->
+    _ = apply_callback(Shutdown, [self()]),
+    {stop, normal, State}.
+
+%% The original response to the callback will be wrapped in an `ok' or
+%% `exit' tuple, primarily so that the service process can terminate
+%% if something goes wrong during registration.
+-spec apply_callback(callback(), list(term())) -> {ok, term()} |
+                                                  {error, term()}.
+apply_callback({Mod, Fun, StaticArgs}, CallSpecificArgs) ->
+    %% Invoke the callback, passing static + call-specific args for this call
+    Args = StaticArgs ++ CallSpecificArgs,
+    _ = case (catch erlang:apply(Mod, Fun, Args)) of
+            {'EXIT', {Reason, _Stack}}=Exit->
+                %% provider called erlang:error(Reason)
+                lager:warning("~p:~p/~B exited (~p)",
+                              [Mod, Fun, length(Args), Reason]),
+                {error, Exit};
+            {'EXIT', Why}=Exit ->
+                %% provider called erlang:exit(Why)!
+                lager:warning("~p:~p/~B exited (~p)",
+                              [Mod, Fun, length(Args), Why]),
+                {error, Exit};
+            Result ->
+                {ok, Result}
+        end.
+
+handle_consumer_response({ok, ok}, response, State) ->
+    {noreply, State};
+handle_consumer_response({ok, ok}, registration, State) ->
+    {ok, State};
+handle_consumer_response({ok, Other}, response, State) ->
+    lager:error("Response handler gave ~p result, shutting down", [Other]),
+    {stop, invalid_return, State};
+handle_consumer_response({ok, Other}, registration, _State) ->
+    lager:error("Registration gave ~p result, shutting down", [Other]),
+    {stop, invalid_return};
+handle_consumer_response(_Error, response, State) ->
+    lager:error("Response handler failed, shutting down"),
+    {stop, response_handler_failure, State};
+handle_consumer_response(_Error, registration, _State) ->
+    lager:error("Registration failed, shutting down"),
+    {stop, registration_error}.
+
+-ifdef(TEST).
+callback_target() ->
+    ok.
+
+callback_target(static, dynamic) ->
+    ok.
+
+shutdown_target(Key, _Pid) ->
+    put(Key, true).
+
+callback1_test() ->
+    ?assertEqual({ok, ok}, apply_callback({?MODULE, callback_target, []}, [])).
+
+callback2_test() ->
+    ?assertEqual({ok, ok}, apply_callback({?MODULE, callback_target, [static]}, [dynamic])).
+
+shutdown_test() ->
+    Pkey = '_rcisp_test_shutdown',
+    put(Pkey, false),
+    ?assertEqual(false, get(Pkey)),
+    ?assertMatch({stop, normal, _}, handle_shutdown_message(#state{shutdown={?MODULE, shutdown_target, [Pkey]}})),
+    ?assertEqual(true, get(Pkey)),
+    put(Pkey, undefined).
+
+
+-endif.

--- a/src/riak_core_info_service_process.erl
+++ b/src/riak_core_info_service_process.erl
@@ -128,14 +128,14 @@ handle_consumer_response({ok, ok}, response, State) ->
 handle_consumer_response({ok, ok}, registration, State) ->
     {ok, State};
 handle_consumer_response({ok, Other}, response, State) ->
-    lager:error("Response handler gave ~p result, shutting down", [Other]),
-    {stop, invalid_return, State};
+    lager:warning("Response handler gave non-ok result: ~p", [Other]),
+    {noreply, State};
 handle_consumer_response({ok, Other}, registration, _State) ->
     lager:error("Registration gave ~p result, shutting down", [Other]),
     {stop, invalid_return};
-handle_consumer_response(_Error, response, State) ->
-    lager:error("Response handler failed, shutting down"),
-    {stop, response_handler_failure, State};
+handle_consumer_response({error, Error}, response, State) ->
+    lager:warning("Response handler failed: ~p", [Error]),
+    {noreply, State};
 handle_consumer_response(_Error, registration, _State) ->
     lager:error("Registration failed, shutting down"),
     {stop, registration_error}.

--- a/src/riak_core_info_service_sup.erl
+++ b/src/riak_core_info_service_sup.erl
@@ -1,0 +1,50 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2017 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @see riak_core_info_service
+-module(riak_core_info_service_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0,
+         start_service/4]).
+
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+start_service(Registration, Shutdown, Provider, Handler) ->
+    supervisor:start_child(?SERVER, [Registration, Shutdown, Provider, Handler]).
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+init([]) ->
+    ChildSpec = child_spec(),
+    SupFlags = {simple_one_for_one, 5, 1000},
+    {ok, {SupFlags, [ChildSpec]}}.
+
+child_spec() ->
+    {na,
+     {riak_core_info_service_process, start_link, []},
+     permanent, 2000, worker, [riak_core_info_service_process]}.

--- a/src/riak_core_sup.erl
+++ b/src/riak_core_sup.erl
@@ -79,6 +79,7 @@ init([]) ->
                   ?CHILD(riak_core_claimant, worker),
                   ?CHILD(riak_core_table_owner, worker),
                   ?CHILD(riak_core_stat_sup, supervisor),
+                  ?CHILD(riak_core_info_service_sup, supervisor),
                   [EnsembleSup || ensembles_enabled()]
                  ]),
 

--- a/src/riak_core_throttle.erl
+++ b/src/riak_core_throttle.erl
@@ -247,7 +247,7 @@ get_throttles(Conf, ConfigPrefix, TierNames, LoadFactorMeasure) ->
 %% @doc <p>Sets the throttle for the activity identified by `AppName' and `Key'
 %% to a value determined by consulting the limits for the activity. The
 %% throttle value is the value associated with the largest
-%% load factor <= `LoadFactor'.
+%% load factor `<= LoadFactor'.
 %% Normally the `LoadFactor' will be a number representing the current level
 %% of load for the activity, but it is also allowed to pass an atom or a tuple
 %% as the `LoadFactor'. This can be used when a numeric value cannot be


### PR DESCRIPTION
* Do not let riak_core crash on startup if the eleveldb callbacks are not present
* Verify the callbacks (3 of them, anyway) are available at registration time
* Add context to the registration and shutdown callbacks for future eleveldb work
