### PR TITLE
Merge develop-2.2 into develop

### DIFF
--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -91,6 +91,7 @@
          future_ring/1,
          disowning_indices/2,
          cancel_transfers/1,
+         legacy_reconcile/2,
          pending_changes/1,
          next_owner/1,
          next_owner/2,
@@ -1423,7 +1424,7 @@ legacy_reconcile(MyNodeName, StateA, StateB) ->
              vclock=VClock,
              chring=CHRing,
              meta=Meta}.
-             
+
 %% ====================================================================
 %% Internal functions
 %% ====================================================================


### PR DESCRIPTION
Pick up fixes:

Deterministic resolution when colliding on 1-second granularity
Extra debug logging for ring transitions
Add back legacy reconcile code because it’s an API change