### PR TITLE
Remove legacy search, continued

### DIFF
--- a/src/riak_core_claimant.erl
+++ b/src/riak_core_claimant.erl
@@ -569,17 +569,15 @@ valid_resize_request(NewRingSize, [], Ring) ->
     %%            for dynamic ring, if all registered applications support it
     %%            the cluster is capable. core knowing about search/kv is :(
     ControlRunning = app_helper:get_env(riak_control, enabled, false),
-    SearchRunning = app_helper:get_env(riak_search, enabled, false),
     NodeCount = length(riak_core_ring:all_members(Ring)),
     Changes = length(riak_core_ring:pending_changes(Ring)) > 0,
-    case {ControlRunning, SearchRunning, Capable, IsResizing, NodeCount, Changes} of
-        {false, false, true, true, N, false} when N > 1 -> true;
-        {true, _, _, _, _, _} -> {error, control_running};
-        {_,  true, _, _, _, _} -> {error, search_running};
-        {_, _, false, _, _, _} -> {error, not_capable};
-        {_, _, _, false, _, _} -> {error, same_size};
-        {_, _, _, _, 1, _} -> {error, single_node};
-        {_, _, _, _, _, true} -> {error, pending_changes}
+    case {ControlRunning, Capable, IsResizing, NodeCount, Changes} of
+        {false, true, true, N, false} when N > 1 -> true;
+        {true,  _, _, _, _} -> {error, control_running};
+        {_, false, _, _, _} -> {error, not_capable};
+        {_, _, false, _, _} -> {error, same_size};
+        {_, _, _, 1, _} -> {error, single_node};
+        {_, _, _, _, true} -> {error, pending_changes}
     end.
 
 

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -550,9 +550,6 @@ stage_resize_ring(NewRingSize) ->
             {error, control_running} ->
                 io:format("Failed: cannot resize ring with Riak Control running~n"),
                 error;
-            {error, search_running} ->
-                io:format("Failed: cannot resize ring with Riak Search~n"),
-                error;
             {error, single_node} ->
                 io:format("Failed: cannot resize single node~n"),
                 error;


### PR DESCRIPTION
This removes one more bit of code that we missed in #906. I posted about it in the review comments there before I realized the previous PR had already been merged.