### PR TITLE
Add `node_confirms` default bucket props

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,12 +11,12 @@
 
 {deps, [
   {lager, ".*", {git, "git://github.com/basho/lager.git", {tag, "3.2.4"}}},
-  {poolboy, ".*", {git, "git://github.com/basho/poolboy.git", {tag, "0.8.1p3"}}},
-  {basho_stats, ".*", {git, "git://github.com/basho/basho_stats.git", {tag, "1.0.3"}}},
+  {poolboy, ".*", {git, "git://github.com/basho/poolboy.git", {branch, "develop-2.2.5"}}},
+  {basho_stats, ".*", {git, "git://github.com/basho/basho_stats.git", {branch, "master"}}},
   {riak_sysmon, ".*", {git, "https://github.com/basho/riak_sysmon.git", {tag, "2.1.5"}}},
-  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.34"}}},
-  {riak_ensemble, ".*", {git, "https://github.com/basho/riak_ensemble", {tag, "2.1.8"}}},
-  {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
-  {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho9"}}},
-  {clique, ".*", {git, "https://github.com/basho/clique.git", {tag, "0.3.9"}}}
+  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "2.0"}}},
+  {riak_ensemble, ".*", {git, "https://github.com/basho/riak_ensemble", {branch, "develop-2.2"}}},
+  {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {branch, "master"}}},
+  {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {branch, "master"}}},
+  {clique, ".*", {git, "https://github.com/basho/clique.git", {branch, "develop-2.2"}}}
 ]}.

--- a/src/riak_core_bucket_props.erl
+++ b/src/riak_core_bucket_props.erl
@@ -168,6 +168,8 @@ resolve_prop({precommit, PC1}, {precommit, PC2}) ->
     resolve_hooks(PC1, PC2);
 resolve_prop({pw, PW1}, {pw, PW2}) ->
     max(PW1, PW2);
+resolve_prop({pd, PD1}, {pd, PD2}) ->
+    max(PD1, PD2);
 resolve_prop({r, R1}, {r, R2}) ->
     max(R1, R2);
 resolve_prop({rw, RW1}, {rw, RW2}) ->
@@ -206,6 +208,7 @@ simple_resolve_test() ->
               {pr,0},
               {precommit,[{a, b}]},
               {pw,0},
+              {pd,0},
               {r,quorum},
               {rw,quorum},
               {small_vclock,50},
@@ -226,6 +229,7 @@ simple_resolve_test() ->
               {pr,1},
               {precommit,[{c, d}]},
               {pw,3},
+              {pd,3},
               {r,3},
               {rw,3},
               {w,1},
@@ -245,6 +249,7 @@ simple_resolve_test() ->
                 {pr,1},
                 {precommit,[{a, b}, {c, d}]},
                 {pw,3},
+                {pd,3},
                 {r,quorum},
                 {rw,quorum},
                 {small_vclock,50},

--- a/src/riak_core_bucket_props.erl
+++ b/src/riak_core_bucket_props.erl
@@ -168,8 +168,8 @@ resolve_prop({precommit, PC1}, {precommit, PC2}) ->
     resolve_hooks(PC1, PC2);
 resolve_prop({pw, PW1}, {pw, PW2}) ->
     max(PW1, PW2);
-resolve_prop({pd, PD1}, {pd, PD2}) ->
-    max(PD1, PD2);
+resolve_prop({node_confirms, NodeConfirms1}, {node_confirms, NodeConfirms2}) ->
+    max(NodeConfirms1, NodeConfirms2);
 resolve_prop({r, R1}, {r, R2}) ->
     max(R1, R2);
 resolve_prop({rw, RW1}, {rw, RW2}) ->
@@ -208,7 +208,7 @@ simple_resolve_test() ->
               {pr,0},
               {precommit,[{a, b}]},
               {pw,0},
-              {pd,0},
+              {node_confirms,0},
               {r,quorum},
               {rw,quorum},
               {small_vclock,50},
@@ -229,7 +229,7 @@ simple_resolve_test() ->
               {pr,1},
               {precommit,[{c, d}]},
               {pw,3},
-              {pd,3},
+              {node_confirms,3},
               {r,3},
               {rw,3},
               {w,1},
@@ -249,7 +249,7 @@ simple_resolve_test() ->
                 {pr,1},
                 {precommit,[{a, b}, {c, d}]},
                 {pw,3},
-                {pd,3},
+                {node_confirms,3},
                 {r,quorum},
                 {rw,quorum},
                 {small_vclock,50},

--- a/src/riak_core_bucket_type.erl
+++ b/src/riak_core_bucket_type.erl
@@ -120,26 +120,31 @@
 %% @doc The hardcoded defaults for all bucket types.
 -spec defaults() -> bucket_type_props().
 defaults() ->
-    custom_type_defaults().
+    v225_defaults() ++ custom_type_defaults().
+
+%% @private default propeties added for v2.2.5
+-spec v225_defaults() -> bucket_type_props().
+v225_defaults() ->
+    [{node_confirms, 0}].
 
 %% @doc The hardcoded defaults for the legacy, default bucket
 %% type. These find their way into the `default_bucket_props'
 %% environment variable
 -spec defaults(default_type) -> bucket_type_props().
 defaults(default_type) ->
-    default_type_defaults().
+    v225_defaults() ++ default_type_defaults().
 
 default_type_defaults() ->
-    common_defaults() ++
-        [{dvv_enabled, false},
-         {allow_mult, false}].
+    [{dvv_enabled, false},
+     {allow_mult, false}] ++
+        common_defaults().
 
 custom_type_defaults() ->
-    common_defaults() ++
-        %% @HACK dvv is a riak_kv only thing, yet there is nowhere else
-        %% to put it (except maybe fixups?)
-        [{dvv_enabled, true},
-         {allow_mult, true}].
+    %% @HACK dvv is a riak_kv only thing, yet there is nowhere else
+    %% to put it (except maybe fixups?)
+    [{dvv_enabled, true},
+     {allow_mult, true}] ++
+        common_defaults().
 
 common_defaults() ->
     [{linkfun, {modfun, riak_kv_wm_link_walker, mapreduce_linkfun}},
@@ -151,7 +156,6 @@ common_defaults() ->
      {r, quorum},
      {w, quorum},
      {pw, 0},
-     {node_confirms, 0},
      {dw, quorum},
      {rw, quorum},
      {basic_quorum, false},

--- a/src/riak_core_bucket_type.erl
+++ b/src/riak_core_bucket_type.erl
@@ -151,6 +151,7 @@ common_defaults() ->
      {r, quorum},
      {w, quorum},
      {pw, 0},
+     {pd, 0},
      {dw, quorum},
      {rw, quorum},
      {basic_quorum, false},

--- a/src/riak_core_bucket_type.erl
+++ b/src/riak_core_bucket_type.erl
@@ -151,7 +151,7 @@ common_defaults() ->
      {r, quorum},
      {w, quorum},
      {pw, 0},
-     {pd, 0},
+     {node_confirms, 0},
      {dw, quorum},
      {rw, quorum},
      {basic_quorum, false},


### PR DESCRIPTION
This is an upstream PR of two PRs already merged/tested on the nhs-fork.
The original PRs are:
- https://github.com/nhs-riak/riak_core/pull/1
- https://github.com/nhs-riak/riak_core/pull/8

See https://github.com/basho/riak_kv/pull/1663 for full details. This PR supports that KV feature.