### PR TITLE
Add participate_in_2i_coverage riak option

### DIFF
--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -159,7 +159,13 @@ standard_join(Node, Ring, Rejoin, Auto) ->
                                                   node(),
                                                   gossip_vsn,
                                                   GossipVsn),
-            {_, Ring5} = riak_core_capability:update_ring(Ring4),
+            ParticipateInCoverage = app_helper:get_env(riak_core,participate_in_coverage),
+            Ring4a =
+                riak_core_ring:update_member_meta(node(),
+                                                  Ring4,
+                                                  node(),
+                                                  participate_in_coverage, ParticipateInCoverage),
+            {_, Ring5} = riak_core_capability:update_ring(Ring4a),
             Ring6 = maybe_auto_join(Auto, node(), Ring5),
             riak_core_ring_manager:set_my_ring(Ring6),
             riak_core_gossip:send_ring(Node, node())

--- a/src/riak_core_apl.erl
+++ b/src/riak_core_apl.erl
@@ -29,7 +29,7 @@
          get_apl_ann_with_pnum/1,
          get_primary_apl/3, get_primary_apl/4,
          get_primary_apl_chbin/4,
-         first_up/2, offline_owners/1, offline_owners/2
+         first_up/2, offline_owners/1, offline_owners/2, offline_owners/3
         ]).
 
 -export_type([preflist/0, preflist_ann/0, preflist_with_pnum_ann/0]).
@@ -175,9 +175,12 @@ offline_owners(Service) ->
     offline_owners(Service, CHBin).
 
 offline_owners(Service, CHBin) ->
+    offline_owners(Service, CHBin, []).
+
+offline_owners(Service, CHBin, OtherDownNodes) ->
     UpSet = ordsets:from_list(riak_core_node_watcher:nodes(Service)),
     DownVNodes = chashbin:to_list_filter(fun({_Index, Node}) ->
-                                                 not is_up(Node, UpSet)
+                                                 (not is_up(Node, UpSet) or lists:member(Node,OtherDownNodes))
                                          end, CHBin),
     DownVNodes.
 

--- a/src/riak_core_coverage_fsm.erl
+++ b/src/riak_core_coverage_fsm.erl
@@ -180,7 +180,6 @@ init([Mod,
 init({test, Args, StateProps}) ->
     %% Call normal init
     {ok, initialize, StateData, 0} = init(Args),
-
     %% Then tweak the state record with entries provided by StateProps
     Fields = record_info(fields, state),
     FieldPos = lists:zip(Fields, lists:seq(2, length(Fields)+1)),


### PR DESCRIPTION
Allows marking of nodes 'down' in calculations for 2i coverage
queries.  In create_plan, it queries each node for the value of the
participate_in_2i_coverage and treats those with the value set
explicitly to `false` as 'down' for the calculation of avaiable
vnodes.

See related riak_kv commit that adds a default value to the KV schema.
This is an operator feature. The operator must bring down the node,
change the config, and start the node, for it to have effect.