### PR TITLE
Add a soft-limit check to vnode proxy

### DIFF
--- a/src/riak_core_vnode_proxy.erl
+++ b/src/riak_core_vnode_proxy.erl
@@ -165,8 +165,12 @@ handle_call(overloaded, _From, State=#state{check_mailbox=Mailbox,
                                             check_threshold=Threshold}) ->
     Result = (Mailbox > Threshold),
     {reply, Result, State};
-handle_call(mailbox_size, _From, State=#state{check_mailbox=Mailbox}) ->
-    {reply, {ok, Mailbox}, State};
+handle_call(mailbox_size, _From, State=#state{check_mailbox=Mailbox,
+					      check_request_interval=CRI}) ->
+    Result = if (Mailbox < (CRI * 2)) -> ok;
+		true -> soft_loaded
+	     end,
+    {reply, Result, State};
 handle_call(_Msg, _From, State) ->
     {reply, ok, State}.
 

--- a/src/riak_core_vnode_proxy.erl
+++ b/src/riak_core_vnode_proxy.erl
@@ -165,6 +165,8 @@ handle_call(overloaded, _From, State=#state{check_mailbox=Mailbox,
                                             check_threshold=Threshold}) ->
     Result = (Mailbox > Threshold),
     {reply, Result, State};
+handle_call(mailbox_size, _From, State=#state{check_mailbox=Mailbox}) ->
+    {reply, {ok, Mailbox}, State};
 handle_call(_Msg, _From, State) ->
     {reply, ok, State}.
 

--- a/src/riak_core_vnode_proxy.erl
+++ b/src/riak_core_vnode_proxy.erl
@@ -20,7 +20,7 @@
 -export([start_link/2, init/1, reg_name/2, reg_name/3, call/2, call/3, cast/2,
          unregister_vnode/3, command_return_vnode/2, overloaded/1]).
 -export([system_continue/3, system_terminate/4, system_code_change/4]).
-
+-export([soft_load_mailbox_check/2]).
 -include("riak_core_vnode.hrl").
 
 -ifdef(TEST).
@@ -167,9 +167,7 @@ handle_call(overloaded, _From, State=#state{check_mailbox=Mailbox,
     {reply, Result, State};
 handle_call(mailbox_size, _From, State=#state{check_mailbox=Mailbox,
 					      check_request_interval=CRI}) ->
-    Result = if (Mailbox < (CRI * 2)) -> {ok, Mailbox, CRI};
-		true -> {soft_loaded, Mailbox, CRI}
-	     end,
+    Result = soft_load_mailbox_check(Mailbox, CRI),
     {reply, Result, State};
 handle_call(_Msg, _From, State) ->
     {reply, ok, State}.
@@ -195,9 +193,7 @@ handle_cast({vnode_proxy_pong, Ref, Msgs}, State=#state{check_request=RequestSta
     {noreply, NewState};
 handle_cast({mailbox_size, From, Tag}, State=#state{check_mailbox=Mailbox,
 					      check_request_interval=CRI}) ->
-    Result = if (Mailbox < (CRI * 2)) -> {ok, Mailbox, CRI};
-		true -> {soft_loaded, Mailbox, CRI}
-	     end,
+    Result = soft_load_mailbox_check(Mailbox, CRI),
     From ! {mbox, {Tag, Result}},
     {noreply, State};
 
@@ -322,6 +318,13 @@ send_proxy_ping(Pid, MailboxSizeAfterPing) ->
     Ref = make_ref(),
     Pid ! {'$vnode_proxy_ping', self(), Ref, MailboxSizeAfterPing},
     Ref.
+
+%% @private moved into it's own function for call and cast (and for
+%% intercepting in riak-test)
+soft_load_mailbox_check(MBox, Interval) when MBox < Interval *2 ->
+    {ok, MBox, Interval};
+soft_load_mailbox_check(MBox, Interval) ->
+    {soft_loaded, MBox, Interval}.
 
 -ifdef(TEST).
 


### PR DESCRIPTION
See riak#1661 for initial issue/discussion. 

This PR supports https://github.com/basho/riak_kv/pull/1670

Adds a message (call and cast) for getting the estimated length of the mailbox queue from the vnode proxy. The returns of `soft-limit` indicates that the estimate of the vnode queue length is greater or equal to double the check interval. The return includes the mailbox queue estimated length and the check interval (i.e. soft-limit / 2) so that the caller can make their own decisions about the load state of the vnode.

NOTE: in our testing we lowered the check interval down to `50` as even a small increase in queue size can lead to high outlying latency increases for coordinated operations.