### PR TITLE
Develop 2.9

### DIFF
--- a/docs/node_worker_pool.md
+++ b/docs/node_worker_pool.md
@@ -1,0 +1,116 @@
+# Node Worker Pool
+
+
+## Background
+
+Riak Core has a pool of workers started by riak_core_vnode, based on configuration returned from the application vnode init code.
+
+https://github.com/basho/riak_core/blob/2.1.9/src/riak_core_vnode.erl#L223-#L243
+
+This provides a pool of workers per-vnode, for running async tasks.  Work is redirected to the runners by returning {async, Work, From, State} from a `Mod:handle_coverage/4` or `Mod:handle_command/3` request.
+
+https://github.com/basho/riak_core/blob/2.1.9/src/riak_core_vnode.erl#L358-L362
+
+https://github.com/basho/riak_core/blob/2.1.9/src/riak_core_vnode.erl#L394-L398
+
+By default in riak, the vnode `vnode_worker_pool_size` is set to 10.  On an average riak cluster there is typically 8 to 15 vnodes per physical node, meaning there is o(100) vnode_workers that can be launched concurrently from these pools.  This means that it is easy to pass enough async work to the vnode pool to overwhelm resources in the cluster.  This may still be true even if the `vnode_worker_pool_size` is reduced to 1, and at these lower numbers multiple queries could become queued behind one long-running request.
+
+
+## Feature Overview
+
+The purpose of node worker pool feature is to provide  pool of workers that are shared amongst all vnodes on the node, and allow for potentially complex or expensive queries to be re-directed to node-wide pools rather than the vnode pool.  The node-wide pools allow for tighter management of resource contention, in that the pool sizes can be smaller than the count of vnodes on the node.
+
+For some application it may be sufficient to have two pools available from each vnode - the `vnode_worker_pool` and the `node_worker_pool`.  However, some implementations may wish to have a more complete model of queues for [differentiated services](https://en.wikipedia.org/wiki/Differentiated_services) with:
+
+- Expedited forwarding - i.e. use the almost unbounded vnode_worker_pool;
+
+- Assured Forwarding 1 to 4 - 4 classes of pools of a fixed size which can be allocated to different task types;
+
+- Best Effort - a narrow pool for any activity which is particularly expensive and can support arbitrary delays during busy periods.
+
+The application can determine both the size of each pool, and which pool can be used.  If an attempt is made to use an undefined (or uninitiated) pool then that work should fallback to the `vnode_worker_pool`.
+
+
+## Implementation
+
+The `riak_core_vnode_worker_pool` as started and shutdown by the vnode process, as that vnode process started and shutdown.  The node_worker_pool cannot be tied to an individual vnode in the same way, so the node_worker_pool's supervisor is started directly through the main riak_core supervision tree:
+
+https://github.com/martinsumner/riak_core/blob/mas-2.2.5-dscpworkerpool/src/riak_core_sup.erl#L82
+
+This does not start any pools.  The responsibility for naming and starting pools lies with the application, which can start pools via:
+
+https://github.com/martinsumner/riak_core/blob/mas-2.2.5-dscpworkerpool/src/riak_core_node_worker_pool_sup.erl#L44-L47
+
+The arguments to use here are as with the `vnode_worker_pool`, except for the addition of `QueueType` which will be the name of the pool, under which the pool will be registered.  There are pre-defined types to use for the anticipated queueing strategies:
+
+https://github.com/martinsumner/riak_core/blob/mas-2.2.5-dscpworkerpool/src/riak_core_node_worker_pool.erl#L29-L33
+
+The following code snippet from `riak_kv_app.erl` shows how pools may be started:
+
+```
+
+    WorkerPools =
+        case app_helper:get_env(riak_kv, worker_pool_strategy, none) of
+            none ->
+                [];
+            single ->
+                NWPS = app_helper:get_env(riak_kv, node_worker_pool_size),
+                [{node_worker_pool, {riak_kv_worker, NWPS, [], [], node_worker_pool}}];
+            dscp ->
+                AF1 = app_helper:get_env(riak_kv, af1_worker_pool_size),
+                AF2 = app_helper:get_env(riak_kv, af2_worker_pool_size),
+                AF3 = app_helper:get_env(riak_kv, af3_worker_pool_size),
+                AF4 = app_helper:get_env(riak_kv, af4_worker_pool_size),
+                BE = app_helper:get_env(riak_kv, be_worker_pool_size),
+                [{dscp_worker_pool, {riak_kv_worker, AF1, [], [], af1_pool}},
+                    {dscp_worker_pool, {riak_kv_worker, AF2, [], [], af2_pool}},
+                    {dscp_worker_pool, {riak_kv_worker, AF3, [], [], af3_pool}},
+                    {dscp_worker_pool, {riak_kv_worker, AF4, [], [], af4_pool}},
+                    {dscp_worker_pool, {riak_kv_worker, BE, [], [], be_pool}}]
+        end,
+
+....
+
+    riak_core:register(riak_kv, [
+
+                    ....
+
+                ]
+
+                ++ WorkerPools),
+```
+
+The implementation of both the `riak_core_node_worker_pool` and the `riak_core_vnode_worker_pool` is now based on a common behaviour - `riak_core_worker_pool`:
+
+https://github.com/martinsumner/riak_core/blob/mas-2.2.5-dscpworkerpool/src/riak_core_worker_pool.erl
+
+The primary difference in implementation is that `riak_core_node_worker_pool` must trap_exit on initialisation, as there is no closing vnode process to call shutdown_pool and neatly terminate the pool (with a wait for work to finish).
+
+A new function is added to the `riak_core_vnode` to prompt work to be queued for a node_worker_pool:
+
+https://github.com/martinsumner/riak_core/blob/mas-2.2.5-dscpworkerpool/src/riak_core_vnode.erl#L1092-L1105
+
+This is triggered by a response to Mod:handle_coverage/4 or Mod:handle_command/3 of:
+
+``{PoolName, Work, From, NewModState}``
+
+https://github.com/martinsumner/riak_core/blob/mas-2.2.5-dscpworkerpool/src/riak_core_vnode.erl#L378-L386
+
+If there is need to call for work to be queued directly from the application (e.g. using `riak_core_vnode:queue_work/4`), then the application should be aware of the vnode pool pid() to be used by `queue_work/4` as a fallback.  To receive this information onto ModState, the application may provide a `Mod:add_vnode_pool/2` function, which if present will be called by riak_core_vnode after the pool has been initialised:
+
+https://github.com/martinsumner/riak_core/blob/mas-2.2.5-dscpworkerpool/src/riak_core_vnode.erl#L245-L254
+
+
+## Snapshots Pre-fold
+
+Within `riak_kv`, fold functions returned from backends for performing queries which were directed towards a worker_pool (such as 2i queries) were passed to the worker without a snapshot being taken.  When the worker in the pool ran the `Fold()`, at that point a snapshot would be taken.
+
+This model works if there is unlimited capacity in the vnode worker pools, as it is likely that the fold functions across a coverage plan will be called reasonably close together, so as to present a roughly cluster-wide point-in-time view of the query.  However, with a constrained pool, a subset of the folds in the coverage plan may be delayed behind other work.  Therefore, it is preferable for async work which intends to use node_worker_pools to have had the snapshot taken prior to the fold function being returned from the vnode backend.
+
+This is implemented within leveled as the SnapPreFold boolean which can be passed into query requests.  When SnapPrefold is `true`, the snapshot will be taken at the point the backend receives the request, and when the fold is eventually called by the worker in the pool, it will be based on that snapshot.  So variation in worker availability across node will not impact the "consistency" of the query results - the results will be based on a loosely correlated point in time (subject to race conditions to the head of the vnode message queue).
+
+Some work has been done to implement prefold snapping in eleveldb, mainly by splitting up the existing fold API into two stages:
+
+https://github.com/martinsumner/riak_kv/blob/mas-2.2.5-clusteraae/src/riak_kv_eleveldb_backend.erl#L388-L430.
+
+To implement snap_prefold in Bitcask would probably require generating file links at the point the fold is closed, but no work has been done on that backend at present.

--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
   {poolboy, ".*", {git, "git://github.com/basho/poolboy.git", {branch, "develop-2.2.5"}}},
   {basho_stats, ".*", {git, "git://github.com/basho/basho_stats.git", {branch, "master"}}},
   {riak_sysmon, ".*", {git, "https://github.com/basho/riak_sysmon.git", {tag, "2.1.5"}}},
-  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "2.0"}}},
+  {eleveldb, ".*", {git, "git://github.com/martinsumner/eleveldb.git", {branch, "mas-2.3.4-ee"}}},
   {riak_ensemble, ".*", {git, "https://github.com/basho/riak_ensemble", {branch, "develop-2.2"}}},
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {branch, "master"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {branch, "master"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
   {poolboy, ".*", {git, "git://github.com/basho/poolboy.git", {branch, "develop-2.2.5"}}},
   {basho_stats, ".*", {git, "git://github.com/basho/basho_stats.git", {branch, "master"}}},
   {riak_sysmon, ".*", {git, "https://github.com/basho/riak_sysmon.git", {tag, "2.1.5"}}},
-  {eleveldb, ".*", {git, "git://github.com/martinsumner/eleveldb.git", {branch, "mas-2.3.4-ee"}}},
+  {eleveldb, ".*", {git, "git://github.com/martinsumner/eleveldb.git", {branch, "mas-2.0.34-ee"}}},
   {riak_ensemble, ".*", {git, "https://github.com/basho/riak_ensemble", {branch, "develop-2.2"}}},
   {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {branch, "master"}}},
   {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {branch, "master"}}},

--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -392,7 +392,7 @@ register(App,
     register_pool(App, WorkerMod, PoolSize, WArgs, WProps, node_worker_pool),
     register(App, T);
 register(App, 
-            [{dscp_pool, 
+            [{dscp_worker_pool, 
                 {WorkerMod, PoolSize, WArgs, WProps, PoolType}}|T]) ->
     register_pool(App, WorkerMod, PoolSize, WArgs, WProps, PoolType),
     register(App, T).

--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -24,7 +24,7 @@
          leave/0, remove_from_cluster/1]).
 -export([vnode_modules/0, health_check/1]).
 -export([register/1, register/2, bucket_fixups/0, bucket_validators/0]).
--export([stat_mods/0, pool_mods/0]).
+-export([stat_mods/0]).
 
 -export([add_guarded_event_handler/3, add_guarded_event_handler/4]).
 -export([delete_guarded_event_handler/3]).
@@ -317,12 +317,6 @@ stat_mods() ->
     case application:get_env(riak_core, stat_mods) of
         undefined -> [];
         {ok, Mods} -> Mods
-    end.
-
-pool_mods() ->
-    case application:get_env(riak_core, pool_mods) of
-        undefined -> [];
-        {ok, Mods} -> Mods % should be {Module, PoolSize}
     end.
 
 health_check(App) ->

--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -388,6 +388,11 @@ register(App, [{auth_mod, {AuthType, AuthMod}}|T]) ->
     register(App, T);
 register(App, 
             [{node_worker_pool, 
+                {WorkerMod, PoolSize, WArgs, WProps, node_worker_pool}}|T]) ->
+    register_pool(App, WorkerMod, PoolSize, WArgs, WProps, node_worker_pool),
+    register(App, T);
+register(App, 
+            [{dscp_pool, 
                 {WorkerMod, PoolSize, WArgs, WProps, PoolType}}|T]) ->
     register_pool(App, WorkerMod, PoolSize, WArgs, WProps, PoolType),
     register(App, T).

--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -386,8 +386,10 @@ register(App, [{permissions, Permissions}|T]) ->
 register(App, [{auth_mod, {AuthType, AuthMod}}|T]) ->
     register_proplist({AuthType, AuthMod}, auth_mods),
     register(App, T);
-register(App, [{node_worker_pool, {WorkerMod, PoolSize, WArgs, WProps}}|T]) ->
-    register_pool(App, WorkerMod, PoolSize, WArgs, WProps),
+register(App, 
+            [{node_worker_pool, 
+                {WorkerMod, PoolSize, WArgs, WProps, PoolType}}|T]) ->
+    register_pool(App, WorkerMod, PoolSize, WArgs, WProps, PoolType),
     register(App, T).
 
 register_mod(App, Module, Type) when is_atom(Type) ->
@@ -407,11 +409,12 @@ register_mod(App, Module, Type) when is_atom(Type) ->
                 lists:usort([{App,Module}|Mods]))
     end.
 
-register_pool(_App, WorkerMod, PoolSize, WorkerArgs, WorkerProps) ->
+register_pool(_App, WorkerMod, PoolSize, WorkerArgs, WorkerProps, PoolType) ->
     riak_core_node_worker_pool_sup:start_pool(WorkerMod,
                                                 PoolSize, 
                                                 WorkerArgs, 
-                                                WorkerProps).
+                                                WorkerProps,
+                                                PoolType).
 
 register_metadata(App, Value, Type) ->
     case application:get_env(riak_core, Type) of

--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -380,13 +380,13 @@ register(App, [{permissions, Permissions}|T]) ->
 register(App, [{auth_mod, {AuthType, AuthMod}}|T]) ->
     register_proplist({AuthType, AuthMod}, auth_mods),
     register(App, T);
-register(App, 
-            [{node_worker_pool, 
+register(App,
+            [{node_worker_pool,
                 {WorkerMod, PoolSize, WArgs, WProps, node_worker_pool}}|T]) ->
     register_pool(App, WorkerMod, PoolSize, WArgs, WProps, node_worker_pool),
     register(App, T);
-register(App, 
-            [{dscp_worker_pool, 
+register(App,
+            [{dscp_worker_pool,
                 {WorkerMod, PoolSize, WArgs, WProps, PoolType}}|T]) ->
     register_pool(App, WorkerMod, PoolSize, WArgs, WProps, PoolType),
     register(App, T).
@@ -409,11 +409,11 @@ register_mod(App, Module, Type) when is_atom(Type) ->
     end.
 
 register_pool(_App, WorkerMod, PoolSize, WorkerArgs, WorkerProps, PoolType) ->
-    riak_core_node_worker_pool_sup:start_pool(WorkerMod,
-                                                PoolSize, 
-                                                WorkerArgs, 
-                                                WorkerProps,
-                                                PoolType).
+    ok = riak_core_node_worker_pool_sup:start_pool(WorkerMod,
+                                                   PoolSize,
+                                                   WorkerArgs,
+                                                   WorkerProps,
+                                                   PoolType).
 
 register_metadata(App, Value, Type) ->
     case application:get_env(riak_core, Type) of

--- a/src/riak_core_node_worker_pool.erl
+++ b/src/riak_core_node_worker_pool.erl
@@ -24,27 +24,37 @@
 -export([do_init/1, reply/2, do_work/3]).
 
 %% API
--export([start_link/4, stop/2, shutdown_pool/2, handle_work/3]).
+-export([start_link/5, stop/2, shutdown_pool/2, handle_work/3]).
 
+-type worker_pool()
+	% Allows you to set up a DSCP-style set of pools (assuming the
+	% vnode_wroker_pool counts as ef.  Otherwise can just have a single
+	% node_worker_pool
+	:: be_pool|af1_pool|af2_pool|af3_pool|af4_pool|node_worker_pool.
 
-start_link(WorkerMod,
-			PoolSize,
-			WorkerArgs,
-			WorkerProps) ->
-	{ok, Pid} = riak_core_worker_pool:start_link([WorkerMod,
-														PoolSize,
-														WorkerArgs,
-														WorkerProps],
-													?MODULE),
-	register(node_worker_pool, Pid),
+-export_type([worker_pool/0]).
+
+-spec start_link(atom(), pos_integer(), list(), list(), worker_pool())
+																-> {ok, pid()}.
+%% @doc
+%% Start a worker pool, and register under the name PoolType, which should be
+%% a recognised name from type worker_pool()
+start_link(WorkerMod, PoolSize, WorkerArgs, WorkerProps, PoolType) ->
+	{ok, Pid} =
+		riak_core_worker_pool:start_link([WorkerMod,
+												PoolSize,
+												WorkerArgs,
+												WorkerProps],
+											?MODULE),
+	register(PoolType, Pid),
 	{ok, Pid}.
 
 do_init([WorkerMod, PoolSize, WorkerArgs, WorkerProps]) ->
     poolboy:start_link([{worker_module, riak_core_vnode_worker},
-							{worker_args,
+						{worker_args,
 								[node, WorkerArgs, WorkerProps, self()]},
-							{worker_callback_mod, WorkerMod},
-							{size, PoolSize}, {max_overflow, 0}]).
+						{worker_callback_mod, WorkerMod},
+						{size, PoolSize}, {max_overflow, 0}]).
 
 handle_work(Pid, Work, From) ->
 	riak_core_worker_pool:handle_work(Pid, Work, From).

--- a/src/riak_core_node_worker_pool.erl
+++ b/src/riak_core_node_worker_pool.erl
@@ -47,6 +47,8 @@ start_link(WorkerMod, PoolSize, WorkerArgs, WorkerProps, PoolType) ->
 												WorkerProps],
 											?MODULE),
 	register(PoolType, Pid),
+	lager:info("Registered worker pool of type ~w and size ~w", 
+				[PoolType, PoolSize]),
 	{ok, Pid}.
 
 do_init([WorkerMod, PoolSize, WorkerArgs, WorkerProps]) ->

--- a/src/riak_core_node_worker_pool.erl
+++ b/src/riak_core_node_worker_pool.erl
@@ -1,0 +1,65 @@
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_core_node_worker_pool).
+
+-behaviour(riak_core_worker_pool).
+
+-export([do_init/1, reply/2, do_work/3]).
+
+%% API
+-export([start_link/4, stop/2, shutdown_pool/2, handle_work/3]).
+
+
+start_link(WorkerMod,
+			PoolSize,
+			WorkerArgs,
+			WorkerProps) ->
+	{ok, Pid} = riak_core_worker_pool:start_link([WorkerMod,
+														PoolSize,
+														WorkerArgs,
+														WorkerProps],
+													?MODULE),
+	register(node_worker_pool, Pid),
+	{ok, Pid}.
+
+do_init([WorkerMod, PoolSize, WorkerArgs, WorkerProps]) ->
+    poolboy:start_link([{worker_module, riak_core_vnode_worker},
+							{worker_args,
+								[node, WorkerArgs, WorkerProps, self()]},
+							{worker_callback_mod, WorkerMod},
+							{size, PoolSize}, {max_overflow, 0}]).
+
+handle_work(Pid, Work, From) ->
+	riak_core_worker_pool:handle_work(Pid, Work, From).
+
+stop(Pid, Reason) ->
+    riak_core_worker_pool:stop(Pid, Reason).
+
+%% wait for all the workers to finish any current work
+shutdown_pool(Pid, Wait) ->
+	riak_core_worker_pool:shutdown_pool(Pid, Wait).
+
+reply(From, Msg) ->
+	riak_core_vnode:reply(From, Msg).
+
+do_work(Pid, Work, From) ->
+	riak_core_vnode_worker:handle_work(Pid, Work, From).
+
+

--- a/src/riak_core_node_worker_pool.erl
+++ b/src/riak_core_node_worker_pool.erl
@@ -52,6 +52,7 @@ start_link(WorkerMod, PoolSize, WorkerArgs, WorkerProps, PoolType) ->
 	{ok, Pid}.
 
 do_init([WorkerMod, PoolSize, WorkerArgs, WorkerProps]) ->
+	process_flag(trap_exit, true),
     poolboy:start_link([{worker_module, riak_core_vnode_worker},
 						{worker_args,
 								[node, WorkerArgs, WorkerProps, self()]},

--- a/src/riak_core_node_worker_pool_sup.erl
+++ b/src/riak_core_node_worker_pool_sup.erl
@@ -1,0 +1,48 @@
+%% -------------------------------------------------------------------
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_node_worker_pool_sup).
+-behaviour(supervisor).
+-export([start_link/0, init/1]).
+-export([start_pool/4]).
+
+%% Helper macro for declaring children of supervisor
+-define(CHILD(I, Args, Type, Timeout),
+		{I, {I, start_link, Args}, permanent, Timeout, Type, [I]}).
+-define(CHILD(I, Args, Type),
+		?CHILD(I, Args, Type, 5000)).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    Children =
+		[pool(WorkerMod, PoolSize, WArgs, WProps)
+			|| {_App, {WorkerMod, PoolSize, WArgs, WProps}}
+				<- riak_core:pool_mods()],
+    {ok, {{one_for_one, 5, 10}, Children}}.
+
+start_pool(WorkerMod, PoolSize, WorkerArgs, WorkerProps) ->
+    Ref = pool(WorkerMod, PoolSize, WorkerArgs, WorkerProps),
+    _ =  supervisor:start_child(?MODULE, Ref),
+    ok.
+
+pool(WorkerMod, PoolSize, WorkerArgs, WorkerProps) ->
+	?CHILD(riak_core_node_worker_pool,
+			[WorkerMod, PoolSize, WorkerArgs, WorkerProps],
+			worker).
+	

--- a/src/riak_core_node_worker_pool_sup.erl
+++ b/src/riak_core_node_worker_pool_sup.erl
@@ -21,10 +21,10 @@
 -export([start_pool/5]).
 
 %% Helper macro for declaring children of supervisor
--define(CHILD(I, Args, Type, Timeout),
-		{I, {I, start_link, Args}, permanent, Timeout, Type, [I]}).
--define(CHILD(I, Args, Type),
-		?CHILD(I, Args, Type, 5000)).
+-define(CHILD(I, PoolType, Args, Type, Timeout),
+		{PoolType, {I, start_link, Args}, permanent, Timeout, Type, [I]}).
+-define(CHILD(I, PoolType, Args, Type),
+		?CHILD(I, PoolType, Args, Type, 5000)).
 
 -type worker_pool() :: riak_core_node_worker_pool:worker_pool().
 
@@ -50,6 +50,7 @@ start_pool(WorkerMod, PoolSize, WorkerArgs, WorkerProps, QueueType) ->
 
 pool(WorkerMod, PoolSize, WorkerArgs, WorkerProps, QueueType) ->
 	?CHILD(riak_core_node_worker_pool,
+			QueueType,
 			[WorkerMod, PoolSize, WorkerArgs, WorkerProps, QueueType],
 			worker).
 	

--- a/src/riak_core_node_worker_pool_sup.erl
+++ b/src/riak_core_node_worker_pool_sup.erl
@@ -22,7 +22,9 @@
 
 %% Helper macro for declaring children of supervisor
 -define(CHILD(I, PoolType, Args, Type, Timeout),
-		{PoolType, {I, start_link, Args}, permanent, Timeout, Type, [I]}).
+		{PoolType, 
+			{I, start_link, Args}, 
+			permanent, Timeout, Type, [I]}).
 -define(CHILD(I, PoolType, Args, Type),
 		?CHILD(I, PoolType, Args, Type, 5000)).
 
@@ -32,11 +34,7 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    Children =
-		[pool(WorkerMod, PoolSize, WArgs, WProps, QueueType)
-			|| {_App, {WorkerMod, PoolSize, WArgs, WProps, QueueType}}
-				<- riak_core:pool_mods()],
-    {ok, {{one_for_one, 5, 10}, Children}}.
+    {ok, {{one_for_one, 5, 10}, []}}.
 
 -spec start_pool(atom(), pos_integer(), list(), list(), worker_pool()) -> ok.
 %% @doc

--- a/src/riak_core_sup.erl
+++ b/src/riak_core_sup.erl
@@ -79,6 +79,7 @@ init([]) ->
                   ?CHILD(riak_core_claimant, worker),
                   ?CHILD(riak_core_table_owner, worker),
                   ?CHILD(riak_core_stat_sup, supervisor),
+                  ?CHILD(riak_core_node_worker_pool_sup, supervisor),
                   [EnsembleSup || ensembles_enabled()]
                  ]),
 

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -382,12 +382,11 @@ vnode_command(Sender, Request, State=#state{mod=Mod,
                 P when is_pid(P) ->
                     riak_core_node_worker_pool:handle_work(PoolName0,
                                                             Work, 
-                                                            From)
+                                                            From);
                 _ ->
                     lager:info("Using vnode pool as ~w pool is not registered",
                                 [PoolName0]),
-                    riak_core_vnode_worker_pool:handle_work(Pool, Work, From);
-                
+                    riak_core_vnode_worker_pool:handle_work(Pool, Work, From)
             end,
             continue(State, NewModState);
         {stop, Reason, NewModState} ->

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -1092,7 +1092,7 @@ mod_set_forwarding(Forward, State=#state{mod=Mod, modstate=ModState}) ->
 queue_work(PoolName, Work, From, VnodeWrkPool) ->
     PoolName0 =
         case PoolName of
-            queue -> node_worker_pool;
+            queue -> riak_core_node_worker_pool:nwp();
             PoolName -> PoolName
         end,
     case whereis(PoolName0) of

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -44,6 +44,7 @@
          trigger_delete/1,
          core_status/1,
          handoff_error/3]).
+-export([queue_work/4]).
 
 -ifdef(TEST).
 
@@ -229,23 +230,36 @@ do_init(State = #state{index=Index, mod=Mod, forward=Forward}) ->
         {error, Reason} ->
             {error, Reason};
         _ ->
-            case lists:keyfind(pool, 1, Props) of
-                {pool, WorkerModule, PoolSize, WorkerArgs}=PoolConfig ->
-                    lager:debug("starting worker pool ~p with size of ~p~n",
-                                [WorkerModule, PoolSize]),
-                    {ok, PoolPid} =
-                        riak_core_vnode_worker_pool:start_link(WorkerModule,
+            ModState0 = 
+                case lists:keyfind(pool, 1, Props) of
+                    {pool, WorkerMod, PoolSize, WorkerArgs}=PoolConfig ->
+                        lager:info("Starting vnode worker pool " ++ 
+                                        "~p with size of ~p~n",
+                                    [WorkerMod, PoolSize]),
+                        {ok, PoolPid} =
+                            riak_core_vnode_worker_pool:start_link(WorkerMod,
                                                                 PoolSize,
                                                                 Index,
                                                                 WorkerArgs,
-                                                                worker_props);
-                _ ->
-                    PoolPid = PoolConfig = undefined
-            end,
+                                                                worker_props),
+                        % If the vnode Module requires access to the vnode worker 
+                        % pool, it should export a function add_vnode_pool/2
+                        case erlang:function_exported(Mod, add_vnode_pool, 2) of
+                            true ->
+                                lager:info("Adding vnode_pool ~w to ~w state",
+                                            [PoolPid, Mod]),
+                                Mod:add_vnode_pool(PoolPid, ModState);
+                            false ->
+                                ModState
+                        end;
+                    _ ->
+                        PoolPid = PoolConfig = undefined,
+                        ModState
+                end,
             riak_core_handoff_manager:remove_exclusion(Mod, Index),
             Timeout = app_helper:get_env(riak_core, vnode_inactivity_timeout, ?DEFAULT_TIMEOUT),
             Timeout2 = Timeout + random:uniform(Timeout),
-            State2 = State#state{modstate=ModState, inactivity_timeout=Timeout2,
+            State2 = State#state{modstate=ModState0, inactivity_timeout=Timeout2,
                                  pool_pid=PoolPid, pool_config=PoolConfig},
             lager:debug("vnode :: ~p/~p :: ~p~n", [Mod, Index, Forward]),
             State3 = mod_set_forwarding(Forward, State2),
@@ -368,26 +382,7 @@ vnode_command(Sender, Request, State=#state{mod=Mod,
             %% the fold concurrently
             %% If a node_worker_pool has not been setup under the given name
             %% then it will fallback to the vnode worker pool
-            PoolName0 =
-                case PoolName of
-                    queue -> 
-                        % Legacy of previous versions - there was only a
-                        % single worker_pool (node_worker_pool) and it was
-                        % utilised by passing `queue` as the handle response
-                        node_worker_pool;
-                    PoolName -> 
-                        PoolName
-                end,
-            case whereis(PoolName0) of
-                P when is_pid(P) ->
-                    riak_core_node_worker_pool:handle_work(PoolName0,
-                                                            Work, 
-                                                            From);
-                _ ->
-                    lager:info("Using vnode pool as ~w pool is not registered",
-                                [PoolName0]),
-                    riak_core_vnode_worker_pool:handle_work(Pool, Work, From)
-            end,
+            queue_work(PoolName, Work, From, Pool),
             continue(State, NewModState);
         {stop, Reason, NewModState} ->
             {stop, Reason, State#state{modstate=NewModState}}
@@ -432,21 +427,7 @@ vnode_coverage(Sender, Request, KeySpaces, State=#state{index=Index,
             %% the fold concurrently
             %% If a node_worker_pool has not been setup under the given name
             %% then it will fallback to the vnode worker pool
-            PoolName0 =
-                case PoolName of
-                    queue -> node_worker_pool;
-                    PoolName -> PoolName
-                end,
-            case whereis(PoolName0) of
-                undefined ->
-                    lager:info("Using vnode pool as ~w pool is not registered",
-                                [PoolName0]),
-                    riak_core_vnode_worker_pool:handle_work(Pool, Work, From);
-                _P ->
-                    riak_core_node_worker_pool:handle_work(PoolName0,
-                                                            Work, 
-                                                            From)
-            end,
+            queue_work(PoolName, Work, From, Pool),
             continue(State, NewModState);
         {stop, Reason, NewModState} ->
             {stop, Reason, State#state{modstate=NewModState}}
@@ -1106,6 +1087,21 @@ mod_set_forwarding(Forward, State=#state{mod=Mod, modstate=ModState}) ->
             State#state{modstate=NewModState};
         false ->
             State
+    end.
+
+queue_work(PoolName, Work, From, VnodeWrkPool) ->
+    PoolName0 =
+        case PoolName of
+            queue -> node_worker_pool;
+            PoolName -> PoolName
+        end,
+    case whereis(PoolName0) of
+        undefined ->
+            lager:info("Using vnode pool as ~w pool is not registered",
+                        [PoolName0]),
+            riak_core_vnode_worker_pool:handle_work(VnodeWrkPool, Work, From);
+        _P ->
+            riak_core_node_worker_pool:handle_work(PoolName0, Work, From)
     end.
 
 %% ===================================================================

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -417,6 +417,15 @@ vnode_handoff_command(Sender, Request, ForwardTo,
             %% the result is sent back to 'From'
             riak_core_vnode_worker_pool:handle_work(Pool, Work, From),
             continue(State, NewModState);
+        {queue, Work, From, NewModState} ->
+            %% dispatch some work to the node worker pool
+            %% the result is sent back to 'From'
+            %% The node worker pool stops too many vnodes from running
+            %% the fold concurrently
+            riak_core_node_worker_pool:handle_work(node_worker_pool, 
+                                                    Work, 
+                                                    From),
+            continue(State, NewModState);
         {forward, NewModState} ->
             forward_request(HOType, Request, HOTarget, ForwardTo, Sender, State),
             continue(State, NewModState);

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -1099,6 +1099,7 @@ queue_work(PoolName, Work, From, VnodeWrkPool) ->
         undefined ->
             lager:info("Using vnode pool as ~w pool is not registered",
                         [PoolName0]),
+            riak_core_stat:update({worker_pool, unregistered}),
             riak_core_vnode_worker_pool:handle_work(VnodeWrkPool, Work, From);
         _P ->
             riak_core_node_worker_pool:handle_work(PoolName0, Work, From)

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -396,6 +396,15 @@ vnode_coverage(Sender, Request, KeySpaces, State=#state{index=Index,
             %% the result is sent back to 'From'
             riak_core_vnode_worker_pool:handle_work(Pool, Work, From),
             continue(State, NewModState);
+        {queue, Work, From, NewModState} ->
+            %% dispatch some work to the node worker pool
+            %% the result is sent back to 'From'
+            %% The node worker pool stops too many vnodes from running
+            %% the fold concurrently
+            riak_core_node_worker_pool:handle_work(node_worker_pool, 
+                                                    Work, 
+                                                    From),
+            continue(State, NewModState);
         {stop, Reason, NewModState} ->
             {stop, Reason, State#state{modstate=NewModState}}
     end.
@@ -416,15 +425,6 @@ vnode_handoff_command(Sender, Request, ForwardTo,
             %% dispatch some work to the vnode worker pool
             %% the result is sent back to 'From'
             riak_core_vnode_worker_pool:handle_work(Pool, Work, From),
-            continue(State, NewModState);
-        {queue, Work, From, NewModState} ->
-            %% dispatch some work to the node worker pool
-            %% the result is sent back to 'From'
-            %% The node worker pool stops too many vnodes from running
-            %% the fold concurrently
-            riak_core_node_worker_pool:handle_work(node_worker_pool, 
-                                                    Work, 
-                                                    From),
             continue(State, NewModState);
         {forward, NewModState} ->
             forward_request(HOType, Request, HOTarget, ForwardTo, Sender, State),

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -379,14 +379,15 @@ vnode_command(Sender, Request, State=#state{mod=Mod,
                         PoolName
                 end,
             case whereis(PoolName0) of
-                undefined ->
-                    lager:info("Using vnode pool as ~w pool is not registered",
-                                [PoolName0]),
-                    riak_core_vnode_worker_pool:handle_work(Pool, Work, From);
-                _P ->
+                P when is_pid(P) ->
                     riak_core_node_worker_pool:handle_work(PoolName0,
                                                             Work, 
                                                             From)
+                _ ->
+                    lager:info("Using vnode pool as ~w pool is not registered",
+                                [PoolName0]),
+                    riak_core_vnode_worker_pool:handle_work(Pool, Work, From);
+                
             end,
             continue(State, NewModState);
         {stop, Reason, NewModState} ->

--- a/src/riak_core_vnode_proxy.erl
+++ b/src/riak_core_vnode_proxy.erl
@@ -39,6 +39,8 @@
                 check_request          :: undefined | sent | ignore
                }).
 
+%% NOTE: changed down to 50 for gh1661 soft-limits on vnode mailbox
+-define(DEFAULT_CHECK_REQUEST_INTERVAL, 50).
 -define(DEFAULT_CHECK_INTERVAL, 5000).
 -define(DEFAULT_OVERLOAD_THRESHOLD, 10000).
 
@@ -64,7 +66,7 @@ init([Parent, RegName, Mod, Index]) ->
                                   ?DEFAULT_CHECK_INTERVAL),
     RequestInterval = app_helper:get_env(riak_core,
                                          vnode_check_request_interval,
-                                         Interval div 2),
+                                         ?DEFAULT_CHECK_REQUEST_INTERVAL),
     Threshold = app_helper:get_env(riak_core,
                                    vnode_overload_threshold,
                                    ?DEFAULT_OVERLOAD_THRESHOLD),

--- a/src/riak_core_vnode_worker_pool.erl
+++ b/src/riak_core_vnode_worker_pool.erl
@@ -39,204 +39,45 @@
 %% confuse (or cause a race) with this module's checkout management.
 -module(riak_core_vnode_worker_pool).
 
--behaviour(gen_fsm).
+-behaviour(riak_core_worker_pool).
 
-%% gen_fsm callbacks
--export([init/1, handle_event/3, handle_sync_event/4, handle_info/3,
-        terminate/3, code_change/4]).
-
-%% gen_fsm states
--export([ready/2, queueing/2, ready/3, queueing/3, shutdown/2, shutdown/3]).
+-export([do_init/1, reply/2, do_work/3]).
 
 %% API
 -export([start_link/5, stop/2, shutdown_pool/2, handle_work/3]).
 
--ifdef(PULSE).
--compile(export_all).
--compile({parse_transform, pulse_instrument}).
--compile({pulse_replace_module, [{gen_fsm, pulse_gen_fsm}]}).
--endif.
 
--record(state, {
-        queue = queue:new(),
-        pool :: pid(),
-        monitors = [] :: list(),
-        shutdown :: undefined | {pid(), reference()}
-    }).
-
-start_link(WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps) ->
-    gen_fsm:start_link(?MODULE, [WorkerMod, PoolSize,  VNodeIndex, WorkerArgs, WorkerProps], []).
-
+start_link(WorkerMod,
+			PoolSize, VNodeIndex,
+			WorkerArgs, WorkerProps) ->
+	riak_core_worker_pool:start_link([WorkerMod,
+										PoolSize,
+										VNodeIndex,
+										WorkerArgs,
+										WorkerProps],
+										?MODULE).
+	
 handle_work(Pid, Work, From) ->
-    gen_fsm:send_event(Pid, {work, Work, From}).
+	riak_core_worker_pool:handle_work(Pid, Work, From).
 
 stop(Pid, Reason) ->
-    gen_fsm:sync_send_all_state_event(Pid, {stop, Reason}).
+    riak_core_worker_pool:stop(Pid, Reason).
 
 %% wait for all the workers to finish any current work
 shutdown_pool(Pid, Wait) ->
-    gen_fsm:sync_send_all_state_event(Pid, {shutdown, Wait}, infinity).
+	riak_core_worker_pool:shutdown_pool(Pid, Wait).
 
-init([WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps]) ->
-    {ok, Pid} = poolboy:start_link([{worker_module, riak_core_vnode_worker},
-            {worker_args, [VNodeIndex, WorkerArgs, WorkerProps, self()]},
-            {worker_callback_mod, WorkerMod},
-            {size, PoolSize}, {max_overflow, 0}]),
-    {ok, ready, #state{pool=Pid}}.
+reply(From, Msg) ->
+	riak_core_vnode:reply(From, Msg).
 
-ready(_Event, _From, State) ->
-    {reply, ok, ready, State}.
+do_init([WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps]) ->
+    poolboy:start_link([{worker_module, riak_core_vnode_worker},
+							{worker_args,
+								[VNodeIndex, WorkerArgs, WorkerProps, self()]},
+							{worker_callback_mod, WorkerMod},
+							{size, PoolSize}, {max_overflow, 0}]).
 
-ready({work, Work, From} = Msg, #state{pool=Pool, queue=Q, monitors=Monitors} = State) ->
-    case poolboy:checkout(Pool, false) of
-        full ->
-            {next_state, queueing, State#state{queue=queue:in(Msg, Q)}};
-        Pid when is_pid(Pid) ->
-            NewMonitors = monitor_worker(Pid, From, Work, Monitors),
-            riak_core_vnode_worker:handle_work(Pid, Work, From),
-            {next_state, ready, State#state{monitors=NewMonitors}}
-    end;
-ready(_Event, State) ->
-    {next_state, ready, State}.
+do_work(Pid, Work, From) ->
+	riak_core_vnode_worker:handle_work(Pid, Work, From).
 
-queueing(_Event, _From, State) ->
-    {reply, ok, queueing, State}.
-
-queueing({work, _Work, _From} = Msg, #state{queue=Q} = State) ->
-    {next_state, queueing, State#state{queue=queue:in(Msg, Q)}};
-queueing(_Event, State) ->
-    {next_state, queueing, State}.
-
-shutdown(_Event, _From, State) ->
-    {reply, ok, shutdown, State}.
-
-shutdown({work, _Work, From}, State) ->
-    %% tell the process requesting work that we're shutting down
-    riak_core_vnode:reply(From, {error, vnode_shutdown}),
-    {next_state, shutdown, State};
-shutdown(_Event, State) ->
-    {next_state, shutdown, State}.
-
-handle_event({checkin, Pid}, shutdown, #state{pool=Pool, monitors=Monitors0} = State) ->
-    Monitors = demonitor_worker(Pid, Monitors0),
-    poolboy:checkin(Pool, Pid),
-    case Monitors of
-        [] -> %% work all done, time to exit!
-            {stop, shutdown, State};
-        _ ->
-            {next_state, shutdown, State#state{monitors=Monitors}}
-    end;
-handle_event({checkin, Worker}, _, #state{pool = Pool, queue=Q, monitors=Monitors} = State) ->
-    case queue:out(Q) of
-        {{value, {work, Work, From}}, Rem} ->
-            %% there is outstanding work to do - instead of checking
-            %% the worker back in, just hand it more work to do
-            NewMonitors = monitor_worker(Worker, From, Work, Monitors),
-            riak_core_vnode_worker:handle_work(Worker, Work, From),
-            {next_state, queueing, State#state{queue=Rem,
-                                               monitors=NewMonitors}};
-        {empty, Empty} ->
-            NewMonitors = demonitor_worker(Worker, Monitors),
-            poolboy:checkin(Pool, Worker),
-            {next_state, ready, State#state{queue=Empty, monitors=NewMonitors}}
-    end;
-handle_event(worker_start, StateName, #state{pool=Pool, queue=Q, monitors=Monitors}=State) ->
-    %% a new worker just started - if we have work pending, try to do it
-    case queue:out(Q) of
-        {{value, {work, Work, From}}, Rem} ->
-            case poolboy:checkout(Pool, false) of
-                full ->
-                    {next_state, queueing, State};
-                Pid when is_pid(Pid) ->
-                    NewMonitors = monitor_worker(Pid, From, Work, Monitors),
-                    riak_core_vnode_worker:handle_work(Pid, Work, From),
-                    {next_state, queueing, State#state{queue=Rem, monitors=NewMonitors}}
-            end;
-        {empty, _} ->
-            %% StateName might be either 'ready' or 'shutdown'
-            {next_state, StateName, State}
-    end;
-handle_event(_Event, StateName, State) ->
-    {next_state, StateName, State}.
-
-handle_sync_event({stop, Reason}, _From, _StateName, State) ->
-    {stop, Reason, ok, State}; 
-handle_sync_event({shutdown, Time}, From, _StateName, #state{queue=Q,
-        monitors=Monitors} = State) ->
-    discard_queued_work(Q),
-    case Monitors of
-        [] ->
-            {stop, shutdown, ok, State};
-        _ ->
-            case Time of
-                infinity ->
-                    ok;
-                _ when is_integer(Time) ->
-                    erlang:send_after(Time, self(), shutdown),
-                    ok
-            end,
-            {next_state, shutdown, State#state{shutdown=From, queue=queue:new()}}
-    end;
-handle_sync_event(_Event, _From, StateName, State) ->
-    {reply, {error, unknown_message}, StateName, State}.
-
-handle_info({'DOWN', _Ref, _, Pid, Info}, StateName, #state{monitors=Monitors} = State) ->
-    %% remove the listing for the dead worker
-    case lists:keyfind(Pid, 1, Monitors) of
-        {Pid, _, From, Work} ->
-            riak_core_vnode:reply(From, {error, {worker_crash, Info, Work}}),
-            NewMonitors = lists:keydelete(Pid, 1, Monitors),
-            %% trigger to do more work will be 'worker_start' message
-            %% when poolboy replaces this worker (if not a 'checkin'
-            %% or 'handle_work')
-            {next_state, StateName, State#state{monitors=NewMonitors}};
-        false ->
-            {next_state, StateName, State}
-    end;
-handle_info(shutdown, shutdown, #state{monitors=Monitors} = State) ->
-    %% we've waited too long to shutdown, time to force the issue.
-    _ = [riak_core_vnode:reply(From, {error, vnode_shutdown}) || 
-            {_, _, From, _} <- Monitors],
-    {stop, shutdown, State};
-handle_info(_Info, StateName, State) ->
-    {next_state, StateName, State}.
-
-terminate(_Reason, _StateName, #state{pool=Pool}) ->
-    %% stop poolboy
-    gen_fsm:sync_send_all_state_event(Pool, stop),
-    ok.
-
-code_change(_OldVsn, StateName, State, _Extra) ->
-    {ok, StateName, State}.
-
-%% Keep track of which worker we pair with what work/from and monitor the
-%% worker. Only active workers are tracked
-monitor_worker(Worker, From, Work, Monitors) ->
-    case lists:keyfind(Worker, 1, Monitors) of
-        {Worker, Ref, _OldFrom, _OldWork} ->
-            %% reuse old monitor and just update the from & work
-            lists:keyreplace(Worker, 1, Monitors, {Worker, Ref, From, Work});
-        false ->
-            Ref = erlang:monitor(process, Worker),
-            [{Worker, Ref, From, Work} | Monitors]
-    end.
-
-demonitor_worker(Worker, Monitors) ->
-    case lists:keyfind(Worker, 1, Monitors) of
-        {Worker, Ref, _From, _Work} ->
-            erlang:demonitor(Ref),
-            lists:keydelete(Worker, 1, Monitors);
-        false ->
-            %% not monitored?
-            Monitors
-    end.
-
-discard_queued_work(Q) ->
-    case queue:out(Q) of
-        {{value, {work, _Work, From}}, Rem} ->
-            riak_core_vnode:reply(From, {error, vnode_shutdown}),
-            discard_queued_work(Rem);
-        {empty, _Empty} ->
-            ok
-    end.
 

--- a/src/riak_core_vnode_worker_pool.erl
+++ b/src/riak_core_vnode_worker_pool.erl
@@ -58,6 +58,7 @@ start_link(WorkerMod,
 										?MODULE).
 	
 handle_work(Pid, Work, From) ->
+    riak_core_stat:update({worker_pool, vnode_pool}),
 	riak_core_worker_pool:handle_work(Pid, Work, From).
 
 stop(Pid, Reason) ->

--- a/src/riak_core_worker_pool.erl
+++ b/src/riak_core_worker_pool.erl
@@ -1,0 +1,263 @@
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc This is a wrapper around a poolboy pool, that implements a
+%% queue. That is, this process maintains a queue of work, and checks
+%% workers out of a poolboy pool to consume it.
+%%
+%% The workers it uses send two messages to this process.
+%%
+%% The first message is at startup, the bare atom
+%% `worker_started'. This is a clue to this process that a worker was
+%% just added to the poolboy pool, so a checkout request has a chance
+%% of succeeding. This is most useful after an old worker has exited -
+%% `worker_started' is a trigger guaranteed to arrive at a time that
+%% will mean an immediate poolboy:checkout will not beat the worker
+%% into the pool.
+%%
+%% The second message is when the worker finishes work it has been
+%% handed, the two-tuple, `{checkin, WorkerPid}'. This message gives
+%% this process the choice of whether to give the worker more work or
+%% check it back into poolboy's pool at this point. Note: the worker
+%% should *never* call poolboy:checkin itself, because that will
+%% confuse (or cause a race) with this module's checkout management.
+-module(riak_core_worker_pool).
+
+-behaviour(gen_fsm).
+
+%% gen_fsm callbacks
+-export([init/1, handle_event/3, handle_sync_event/4, handle_info/3,
+        terminate/3, code_change/4]).
+
+-export([start_link/2, handle_work/3, stop/2, shutdown_pool/2]).
+
+%% gen_fsm states
+-export([queueing/2, ready/2, ready/3, queueing/3, shutdown/2, shutdown/3]).
+
+-export([monitor_worker/4]).
+
+-ifdef(PULSE).
+-compile(export_all).
+-compile({parse_transform, pulse_instrument}).
+-compile({pulse_replace_module, [{gen_fsm, pulse_gen_fsm}]}).
+-endif.
+
+
+-record(state, {
+				queue = queue:new(),
+				pool :: pid(),
+				monitors = [] :: list(),
+				shutdown :: undefined | {pid(), reference()},
+				callback_mod :: atom()
+    }).
+
+
+-callback handle_work(Pid::pid(), Work::term(), From::term()) -> any().
+
+-callback stop(Pid::pid(), Reason::term()) -> any().
+
+-callback shutdown_pool(Pid::pid(), Wait::integer()) -> any().
+
+-callback do_init(PoolBoyArgs::list()) -> {ok, pid()}.
+
+-callback reply(Term::term(), Term::term()) -> any().
+
+-callback do_work(Pid::pid(), Work::term(), From::term()) -> any().
+
+
+start_link(PoolBoyArgs, CallbackMod) ->
+	gen_fsm:start_link(?MODULE, [PoolBoyArgs, CallbackMod], []).
+
+handle_work(Pid, Work, From) ->
+    gen_fsm:send_event(Pid, {work, Work, From}).
+
+stop(Pid, Reason) ->
+    gen_fsm:sync_send_all_state_event(Pid, {stop, Reason}).
+
+%% wait for all the workers to finish any current work
+shutdown_pool(Pid, Wait) ->
+    gen_fsm:sync_send_all_state_event(Pid, {shutdown, Wait}, infinity).
+
+init([PoolBoyArgs, CallbackMod]) ->
+	{ok, Pid} = CallbackMod:do_init(PoolBoyArgs),
+	{ok, ready, #state{pool=Pid, callback_mod=CallbackMod}}.
+	
+ready(_Event, _From, State) ->
+    {reply, ok, ready, State}.
+
+queueing(_Event, _From, State) ->
+    {reply, ok, queueing, State}.
+
+shutdown(_Event, _From, State) ->
+    {reply, ok, shutdown, State}.
+
+ready({work, Work, From} = Msg, #state{pool=Pool, queue=Q, monitors=Monitors} = State) ->
+    case poolboy:checkout(Pool, false) of
+        full ->
+            {next_state, queueing, State#state{queue=queue:in(Msg, Q)}};
+        Pid when is_pid(Pid) ->
+            NewMonitors =
+				riak_core_worker_pool:monitor_worker(Pid, From, Work, Monitors),
+            Mod = State#state.callback_mod,
+			Mod:do_work(Pid, Work, From),
+            {next_state, ready, State#state{monitors=NewMonitors}}
+    end;
+ready(_Event, State) ->
+    {next_state, ready, State}.
+
+queueing({work, _Work, _From} = Msg, #state{queue=Q} = State) ->
+    {next_state, queueing, State#state{queue=queue:in(Msg, Q)}};
+queueing(_Event, State) ->
+    {next_state, queueing, State}.
+
+shutdown({work, _Work, From}, State) ->
+    %% tell the process requesting work that we're shutting down
+    Mod = State#state.callback_mod,
+	Mod:reply(From, {error, vnode_shutdown}),
+    {next_state, shutdown, State};
+shutdown(_Event, State) ->
+    {next_state, shutdown, State}.
+
+handle_event({checkin, Pid}, shutdown, #state{pool=Pool, monitors=Monitors0} = State) ->
+    Monitors = demonitor_worker(Pid, Monitors0),
+    poolboy:checkin(Pool, Pid),
+    case Monitors of
+        [] -> %% work all done, time to exit!
+            {stop, shutdown, State};
+        _ ->
+            {next_state, shutdown, State#state{monitors=Monitors}}
+    end;
+handle_event({checkin, Worker}, _, #state{pool = Pool, queue=Q, monitors=Monitors} = State) ->
+    case queue:out(Q) of
+        {{value, {work, Work, From}}, Rem} ->
+            %% there is outstanding work to do - instead of checking
+            %% the worker back in, just hand it more work to do
+            NewMonitors = monitor_worker(Worker, From, Work, Monitors),
+            Mod = State#state.callback_mod,
+			Mod:do_work(Worker, Work, From),
+            {next_state, queueing, State#state{queue=Rem,
+                                               monitors=NewMonitors}};
+        {empty, Empty} ->
+            NewMonitors = demonitor_worker(Worker, Monitors),
+            poolboy:checkin(Pool, Worker),
+            {next_state, ready, State#state{queue=Empty, monitors=NewMonitors}}
+    end;
+handle_event(worker_start, StateName, #state{pool=Pool, queue=Q, monitors=Monitors}=State) ->
+    %% a new worker just started - if we have work pending, try to do it
+    case queue:out(Q) of
+        {{value, {work, Work, From}}, Rem} ->
+            case poolboy:checkout(Pool, false) of
+                full ->
+                    {next_state, queueing, State};
+                Pid when is_pid(Pid) ->
+                    NewMonitors = monitor_worker(Pid, From, Work, Monitors),
+                    Mod = State#state.callback_mod,
+					Mod:do_work(Pid, Work, From),
+                    {next_state, queueing, State#state{queue=Rem, monitors=NewMonitors}}
+            end;
+        {empty, _} ->
+            %% StateName might be either 'ready' or 'shutdown'
+            {next_state, StateName, State}
+    end;
+handle_event(_Event, StateName, State) ->
+    {next_state, StateName, State}.
+
+handle_sync_event({stop, Reason}, _From, _StateName, State) ->
+    {stop, Reason, ok, State}; 
+handle_sync_event({shutdown, Time}, From, _StateName, #state{queue=Q,
+        monitors=Monitors} = State) ->
+    discard_queued_work(Q, State#state.callback_mod),
+    case Monitors of
+        [] ->
+            {stop, shutdown, ok, State};
+        _ ->
+            case Time of
+                infinity ->
+                    ok;
+                _ when is_integer(Time) ->
+                    erlang:send_after(Time, self(), shutdown),
+                    ok
+            end,
+            {next_state, shutdown, State#state{shutdown=From, queue=queue:new()}}
+    end;
+handle_sync_event(_Event, _From, StateName, State) ->
+    {reply, {error, unknown_message}, StateName, State}.
+
+handle_info({'DOWN', _Ref, _, Pid, Info}, StateName, #state{monitors=Monitors} = State) ->
+    %% remove the listing for the dead worker
+    case lists:keyfind(Pid, 1, Monitors) of
+        {Pid, _, From, Work} ->
+			Mod = State#state.callback_mod,
+			Mod:reply(From, {error, {worker_crash, Info, Work}}),
+            NewMonitors = lists:keydelete(Pid, 1, Monitors),
+            %% trigger to do more work will be 'worker_start' message
+            %% when poolboy replaces this worker (if not a 'checkin'
+            %% or 'handle_work')
+            {next_state, StateName, State#state{monitors=NewMonitors}};
+        false ->
+            {next_state, StateName, State}
+    end;
+handle_info(shutdown, shutdown, #state{monitors=Monitors} = State) ->
+    %% we've waited too long to shutdown, time to force the issue
+	Mod = State#state.callback_mod,
+    _ = [Mod:reply(From, {error, vnode_shutdown}) || 
+            {_, _, From, _} <- Monitors],
+    {stop, shutdown, State};
+handle_info(_Info, StateName, State) ->
+    {next_state, StateName, State}.
+
+terminate(_Reason, _StateName, #state{pool=Pool}) ->
+    %% stop poolboy
+    gen_fsm:sync_send_all_state_event(Pool, stop),
+    ok.
+
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.
+
+%% Keep track of which worker we pair with what work/from and monitor the
+%% worker. Only active workers are tracked
+monitor_worker(Worker, From, Work, Monitors) ->
+    case lists:keyfind(Worker, 1, Monitors) of
+        {Worker, Ref, _OldFrom, _OldWork} ->
+            %% reuse old monitor and just update the from & work
+            lists:keyreplace(Worker, 1, Monitors, {Worker, Ref, From, Work});
+        false ->
+            Ref = erlang:monitor(process, Worker),
+            [{Worker, Ref, From, Work} | Monitors]
+    end.
+
+demonitor_worker(Worker, Monitors) ->
+    case lists:keyfind(Worker, 1, Monitors) of
+        {Worker, Ref, _From, _Work} ->
+            erlang:demonitor(Ref),
+            lists:keydelete(Worker, 1, Monitors);
+        false ->
+            %% not monitored?
+            Monitors
+    end.
+
+discard_queued_work(Q, Mod) ->
+    case queue:out(Q) of
+        {{value, {work, _Work, From}}, Rem} ->
+            Mod:reply(From, {error, vnode_shutdown}),
+            discard_queued_work(Rem, Mod);
+        {empty, _Empty} ->
+            ok
+    end.
+


### PR DESCRIPTION
Merge into basho repo develop 2.9.  2.9 hash two riak_core changes:

- There are changes to support the vnode soft limit monitoring, to allow for vnodes to report their approximate queue size in response to poll messages, so that Riak may route around slow vnodes (for example when choosing a put co-ordinator)

- The introduction of support for node worker-pool strategies (workers shared across vnodes on a given node) to be used to rate-limit the resources consumes by work which can be queued