### PR TITLE
revive dtrace

### DIFF
--- a/src/riak_core_dtrace.erl
+++ b/src/riak_core_dtrace.erl
@@ -52,14 +52,15 @@ dtrace(ArgList) ->
         undefined ->
             case application:get_env(riak_core, dtrace_support) of
                 {ok, true} ->
-                    case string:to_float(erlang:system_info(version)) of
-                        {5.8, _} ->
+                    case [ list_to_integer(X)
+                           || X <- string:tokens(erlang:system_info(version), ".") ] of
+                        {5, 8, _} ->
                             %% R14B04
                             put(?MAGIC, dtrace),
                             if ArgList == enabled_check -> true;
                                true                     -> dtrace(ArgList)
                             end;
-                        {Num, _} when Num > 5.8 ->
+                        Ver when Ver > {5,8,0} ->
                             %% R15B or higher, though dyntrace option
                             %% was first available in R15B01.
                             put(?MAGIC, dyntrace),

--- a/src/riak_core_dtrace.erl
+++ b/src/riak_core_dtrace.erl
@@ -107,9 +107,11 @@ dtrace(Int0, Int1, Ints, String0, String1, Strings)
             dtrace([Int0, Int1] ++ Ints ++ [S0, String1] ++ Strings)
     end.
 
+-spec enabled() -> boolean().
 enabled() ->
     dtrace(enabled_check).
 
+-spec put_tag(iodata() | undefined) -> boolean() | undefined.
 put_tag(Tag) ->
     case enabled() of
         true ->
@@ -117,7 +119,7 @@ put_tag(Tag) ->
             put(?DTRACE_TAG_KEY, FTag),
             dyntrace:put_tag(FTag);
         false ->
-            ok
+            undefined
     end.
 
 timeit0(ArgList) ->


### PR DESCRIPTION
```
dtrace -q -n 'erlang*:::user_trace-i4s4
{ printf("%s|%10s %10s  %s\n", cwd, riak_op.bk, riak_op.op, riak_op.stage)  }
' 
devstage1|     A,k-0        get  init
devstage1|     A,k-0        put  init
devstage1|     A,k-0        put  prepare
devstage1|     A,k-0        put  validate
devstage1|     A,k-0        put  precommit
devstage1|     A,k-0        put  execute_local
devstage1|     A,k-0        put  waiting_local_vnode
devstage1|     A,k-0        put  waiting_local_vnode
devstage1|     A,k-0        put  execute_remote
devstage1|     A,k-0        put  waiting_remote_vnode
devstage1|     A,k-0        put  waiting_remote_vnode
devstage1|     A,k-0        put  waiting_remote_vnode
devstage1|     A,k-0        put  process_reply
devstage1|     A,k-0        put  postcommit
devstage1|     A,k-0        put  finish
```

riak_kv changes coming soon
