### PR TITLE
Fix circular dependency.

### DIFF
--- a/src/riak_core.app.src
+++ b/src/riak_core.app.src
@@ -6,7 +6,7 @@
   {vsn, git},
   {modules, []},
   {registered, []},
-  {included_applications, [folsom, riak_ensemble]},
+  {included_applications, [riak_ensemble]},
   {applications, [
                   kernel,
                   stdlib,


### PR DESCRIPTION
Remove folsom from included_applications - is started by exometer_core now, conflicts when building release.