### PR TITLE
Develop 3.0 lastgaspring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dialyzer_unhandled_warnings
 _build
 rebar.lock
 .DS_Store
+nonode@nohost

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -61,8 +61,10 @@
          downgrade/2,
          set_tainted/1,
          check_tainted/2,
+         unset_tainted/1,
          set_lastgasp/1,
          check_lastgasp/1,
+         unset_lastgasp/1,
          nearly_equal/2,
          claimant/1,
          member_status/2,
@@ -268,6 +270,10 @@ check_tainted(Ring=?CHSTATE{}, Msg) ->
             ok
     end.
 
+-spec unset_tainted(chstate()) -> chstate().
+unset_tainted(Ring) ->
+    update_meta(riak_core_ring_tainted, false, Ring).
+
 -spec set_lastgasp(chstate()) -> chstate().
 set_lastgasp(Ring) ->
     update_meta(riak_core_ring_lastgasp, true, Ring).
@@ -280,6 +286,10 @@ check_lastgasp(Ring) ->
         _ ->
             false
     end.
+
+-spec unset_lastgasp(chstate()) -> chstate().
+unset_lastgasp(Ring) ->
+    update_meta(riak_core_ring_lastgasp, false, Ring).
 
 %% @doc Verify that the two rings are identical expect that metadata can
 %%      differ and RingB's vclock is allowed to be equal or a direct
@@ -2060,7 +2070,10 @@ lasgasp_test() ->
     RingA1 = set_lastgasp(RingA),
     ?assertMatch(false, check_lastgasp(RingA)),
     ?assertMatch(true, check_lastgasp(RingA1)),
-    ?assertMatch({no_change, RingB}, reconcile(RingA1, RingB)).
+    ?assertMatch({no_change, RingB}, reconcile(RingA1, RingB)),
+    
+    ?assertMatch(true, nearly_equal(RingA, unset_lastgasp(RingA1))),
+    ?assertMatch(false, check_lastgasp(unset_lastgasp(RingA1))).
 
 resize_xfer_test_() ->
     {setup,

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -527,14 +527,19 @@ maybe_ensure_vnodes_started(Ring) ->
     end.
 
 ensure_vnodes_started(Ring) ->
-    spawn(fun() ->
+    case riak_core_ring:check_lastgasp(Ring) of
+        true ->
+            lager:info("Don't start vnodes - last gasp ring");
+        false ->    
+            spawn(fun() ->
                   try
                       riak_core_ring_handler:ensure_vnodes_started(Ring)
                   catch
                       T:R ->
                           lager:error("~p", [{T, R, erlang:get_stacktrace()}])
                   end
-          end).
+            end)
+    end.
 
 schedule_management_timer() ->
     ManagementTick = app_helper:get_env(riak_core,
@@ -882,9 +887,14 @@ update_never_started(Mod, Indices, State) ->
     State#state{known_modules=KnownModules, never_started=NeverStarted3}.
 
 maybe_start_vnodes(Ring, State) ->
-    State2 = update_never_started(Ring, State),
-    State3 = maybe_start_vnodes(State2),
-    State3.
+    case riak_core_ring:check_lastgasp(Ring) of
+        true ->
+            State;
+        false ->
+            State2 = update_never_started(Ring, State),
+            State3 = maybe_start_vnodes(State2),
+            State3
+    end.
 
 maybe_start_vnodes(State=#state{vnode_start_tokens=Tokens,
                                 never_started=NeverStarted}) ->


### PR DESCRIPTION
When a node leaves a cluster before it closes it will change the ring to a fresh ring (which knows only of the local node).  This is necessary to ensure that restarting the node does not lead to any attempt to rejoin.

There is an issue though, that the close of riak is not immediate.  It is, as one would expect, an orderly shutdown of the dependencies, before riak_core is the final application to close.

During this closing process, there are multiple processes which are monitoring the ring and may react to the change in the ring.  At this stage, as the shutdown is not complete these processes may take unnecessary action, and as the node is still connected to he cluster at an erlang level - this could leak into the rest of the cluster.

This was causing significant problems for `riak_ensemble`, where ensembles would be changed through the cluster incorrectly.  In some cases there would then be a version mismatch that meant that this was never corrected back.

This PR introduces 'lastgasp' metadata to the ring.  If the ring is being changed to reflect shutdown on departure this metadata is set _after_ the ring has been persisted (so it is not seen on restart).

There are related PRs then due in `riak_kv` and `riak_repl` with ring_handlers amended to check this `lastgasp` status before reacting to a ring change.

These changes have stabilised ensemble riak_test tests (without actually changing `riak_ensemble`), and also reduce unexpected crashes during the shutdown processes caused by the false starting of elections/vnodes.