### PR TITLE
Fix size formatter crash on float value

### DIFF
--- a/src/riak_core_handoff_status.erl
+++ b/src/riak_core_handoff_status.erl
@@ -133,7 +133,7 @@ format_transfer_type(repair) ->
 format_transfer_size({Num, objects}) ->
     io_lib:format("~B Objs", [Num]);
 format_transfer_size({Num, bytes}) ->
-    riak_core_format:human_size_fmt("~B", Num);
+    riak_core_format:human_size_fmt("~.2f", Num);
 format_transfer_size(_) ->
     "--".
 


### PR DESCRIPTION
This prevents crash like
```
{'EXIT',
                                                  {badarg,
                                                   [{io_lib,format,
                                                     ["~B ~s",
                                                      [54.86940354760736,
                                                       "GB"]],
                                                     [{file,"io_lib.erl"},
                                                      {line,155}]},
                                                    {riak_core_format,fmt,2,
                                                     [{file,
                                                       "src/riak_core_format.erl"},
                                                      {line,37}]},
                                                    {riak_core_handoff_status,
                                                     row_details,2,
                                                     [{file,
                                                       "src/riak_core_handoff_status.erl"},
                                                      {line,104}]},
                                                    {riak_core_handoff_status,
                                                     '-build_handoff_details/1-lc$^0/1-0-',
                                                     2,
                                                     [{file,
                                                       "src/riak_core_handoff_status.erl"},
                                                      {line,87}]},
```

NOTE: This bug also exist in develop-3.0 branch