### PR TITLE
Fix size formatter crash on float value

### DIFF
--- a/src/riak_core_handoff_status.erl
+++ b/src/riak_core_handoff_status.erl
@@ -133,7 +133,7 @@ format_transfer_type(repair) ->
 format_transfer_size({Num, objects}) ->
     io_lib:format("~B Objs", [Num]);
 format_transfer_size({Num, bytes}) ->
-    riak_core_format:human_size_fmt("~B", Num);
+    riak_core_format:human_size_fmt("~.2f", Num);
 format_transfer_size(_) ->
     "--".
 


### PR DESCRIPTION
Just adding into here, to make sure it doesn't get missed in 3.0.2