### PR TITLE
Mas i1801 monitorworkerq

### DIFF
--- a/src/riak_core_node_worker_pool.erl
+++ b/src/riak_core_node_worker_pool.erl
@@ -32,7 +32,7 @@
 	% Allows you to set up a DSCP-style set of pools (assuming the
 	% vnode_worker_pool counts as ef.  Otherwise can just have a
 	% single node_worker_pool
-	:: be_pool|af1_pool|af2_pool|af3_pool|af4_pool|node_worker_pool.
+    :: be_pool|af1_pool|af2_pool|af3_pool|af4_pool|node_worker_pool.
 
 -export_type([worker_pool/0]).
 
@@ -63,26 +63,23 @@ dscp_pools() ->
     [af1(), af2(), af3(), af4(), be()].
 
 -spec start_link(atom(), pos_integer(), list(), list(), worker_pool())
-                -> {ok, pid()}.
+                    -> {ok, pid()}.
 %% @doc
 %% Start a worker pool, and register under the name PoolType, which should be
 %% a recognised name from type worker_pool()
 start_link(WorkerMod, PoolSize, WorkerArgs, WorkerProps, PoolType)
-  when PoolType == be_pool;
-       PoolType == af1_pool;
-       PoolType == af2_pool;
-       PoolType == af3_pool;
-       PoolType == af4_pool;
-       PoolType == node_worker_pool ->
+    when PoolType == be_pool;
+            PoolType == af1_pool;
+            PoolType == af2_pool;
+            PoolType == af3_pool;
+            PoolType == af4_pool;
+            PoolType == node_worker_pool ->
     {ok, Pid} =
-        riak_core_worker_pool:start_link([WorkerMod,
-                                          PoolSize,
-                                          WorkerArgs,
-                                          WorkerProps],
-                                         ?MODULE),
+        riak_core_worker_pool:start_link(
+            [WorkerMod, PoolSize, WorkerArgs, WorkerProps], ?MODULE),
     register(PoolType, Pid),
     lager:info("Registered worker pool of type ~w and size ~w",
-               [PoolType, PoolSize]),
+                [PoolType, PoolSize]),
     {ok, Pid}.
 
 do_init([WorkerMod, PoolSize, WorkerArgs, WorkerProps]) ->
@@ -108,10 +105,10 @@ stop(Pid, Reason) ->
 
 %% wait for all the workers to finish any current work
 shutdown_pool(Pid, Wait) ->
-	riak_core_worker_pool:shutdown_pool(Pid, Wait).
+    riak_core_worker_pool:shutdown_pool(Pid, Wait).
 
 reply(From, Msg) ->
-	riak_core_vnode:reply(From, Msg).
+    riak_core_vnode:reply(From, Msg).
 
 do_work(Pid, Work, From) ->
-	riak_core_vnode_worker:handle_work(Pid, Work, From).
+    riak_core_vnode_worker:handle_work(Pid, Work, From).

--- a/src/riak_core_node_worker_pool.erl
+++ b/src/riak_core_node_worker_pool.erl
@@ -76,10 +76,11 @@ start_link(WorkerMod, PoolSize, WorkerArgs, WorkerProps, PoolType)
             PoolType == node_worker_pool ->
     {ok, Pid} =
         riak_core_worker_pool:start_link(
-            [WorkerMod, PoolSize, WorkerArgs, WorkerProps], ?MODULE, PoolType),
+            [WorkerMod, PoolSize, WorkerArgs, WorkerProps],
+            ?MODULE,
+            PoolType, 
+            PoolSize),
     register(PoolType, Pid),
-    lager:info("Registered worker pool of type ~w and size ~w",
-                [PoolType, PoolSize]),
     {ok, Pid}.
 
 do_init([WorkerMod, PoolSize, WorkerArgs, WorkerProps]) ->

--- a/src/riak_core_node_worker_pool.erl
+++ b/src/riak_core_node_worker_pool.erl
@@ -76,7 +76,7 @@ start_link(WorkerMod, PoolSize, WorkerArgs, WorkerProps, PoolType)
             PoolType == node_worker_pool ->
     {ok, Pid} =
         riak_core_worker_pool:start_link(
-            [WorkerMod, PoolSize, WorkerArgs, WorkerProps], ?MODULE),
+            [WorkerMod, PoolSize, WorkerArgs, WorkerProps], ?MODULE, PoolType),
     register(PoolType, Pid),
     lager:info("Registered worker pool of type ~w and size ~w",
                 [PoolType, PoolSize]),

--- a/src/riak_core_node_worker_pool.erl
+++ b/src/riak_core_node_worker_pool.erl
@@ -78,8 +78,7 @@ start_link(WorkerMod, PoolSize, WorkerArgs, WorkerProps, PoolType)
         riak_core_worker_pool:start_link(
             [WorkerMod, PoolSize, WorkerArgs, WorkerProps],
             ?MODULE,
-            PoolType, 
-            PoolSize),
+            PoolType),
     register(PoolType, Pid),
     {ok, Pid}.
 

--- a/src/riak_core_node_worker_pool_sup.erl
+++ b/src/riak_core_node_worker_pool_sup.erl
@@ -22,11 +22,11 @@
 
 %% Helper macro for declaring children of supervisor
 -define(CHILD(I, PoolType, Args, Type, Timeout),
-		{PoolType,
-			{I, start_link, Args},
-			permanent, Timeout, Type, [I]}).
+            {PoolType,
+                {I, start_link, Args},
+                permanent, Timeout, Type, [I]}).
 -define(CHILD(I, PoolType, Args, Type),
-		?CHILD(I, PoolType, Args, Type, 5000)).
+            ?CHILD(I, PoolType, Args, Type, 5000)).
 
 -type worker_pool() :: riak_core_node_worker_pool:worker_pool().
 
@@ -53,8 +53,8 @@ start_pool(WorkerMod, PoolSize, WorkerArgs, WorkerProps, QueueType) ->
     end.
 
 pool(WorkerMod, PoolSize, WorkerArgs, WorkerProps, QueueType) ->
-    ?CHILD(riak_core_node_worker_pool,
-           QueueType,
-           [WorkerMod, PoolSize, WorkerArgs, WorkerProps, QueueType],
-           worker).
+        ?CHILD(riak_core_node_worker_pool,
+                QueueType,
+                [WorkerMod, PoolSize, WorkerArgs, WorkerProps, QueueType],
+                worker).
 

--- a/src/riak_core_stat.erl
+++ b/src/riak_core_stat.erl
@@ -139,10 +139,10 @@ handle_cast({update, {worker_pool, vnode_pool}}, State) ->
     exometer_update([prefix(), ?APP, vnode, worker_pool], 1),
     {noreply, State};
 handle_cast({update, {worker_pool, queue_time, Pool, QueueTime}}, State) ->
-    exometer_update([prefix(), ?APP, worker_pool_queue_time, Pool], QueueTime),
+    exometer_update([prefix(), ?APP, worker_pool_queuetime, Pool], QueueTime),
     {noreply, State};
 handle_cast({update, {worker_pool, work_time, Pool, WorkTime}}, State) ->
-    exometer_update([prefix(), ?APP, worker_pool_work_time, Pool], WorkTime),
+    exometer_update([prefix(), ?APP, worker_pool_worktime, Pool], WorkTime),
     {noreply, State};
 handle_cast({update, {worker_pool, Pool}}, State) ->
     exometer_update([prefix(), ?APP, node, worker_pool, Pool], 1),

--- a/src/riak_core_stat.erl
+++ b/src/riak_core_stat.erl
@@ -299,7 +299,7 @@ vnodeq_atom(Service, Desc) ->
 
 -spec nwp_name_atom(atom(), binary()) -> atom().
 nwp_name_atom(QueueName, StatName) ->
-    binary_to_atom(<< <<"core_worker_">>/binary,
+    binary_to_atom(<< <<"worker_">>/binary,
                         (atom_to_binary(QueueName, latin1))/binary,
                         StatName/binary >>,
                     latin1).
@@ -308,8 +308,7 @@ nwp_name_atom(QueueName, StatName) ->
 -ifdef(TEST).
 
 nwp_name_to_atom_test() ->
-    ?assertEqual(core_worker_af1_pool_total,
-                    nwp_name_atom(af1_pool, <<"_total">>)).
+    ?assertEqual(worker_af1_pool_total, nwp_name_atom(af1_pool, <<"_total">>)).
 
 
 %% Check vnodeq aggregation function

--- a/src/riak_core_stat.erl
+++ b/src/riak_core_stat.erl
@@ -141,7 +141,7 @@ handle_cast({update, {worker_pool, vnode_pool}}, State) ->
 handle_cast({update, {worker_pool, queue_time, Pool, QueueTime}}, State) ->
     exometer_update([prefix(), ?APP, worker_pool_queue_time, Pool], QueueTime),
     {noreply, State};
-handle_cast({update, {worker_pool, worker_time, Pool, WorkTime}}, State) ->
+handle_cast({update, {worker_pool, work_time, Pool, WorkTime}}, State) ->
     exometer_update([prefix(), ?APP, worker_pool_work_time, Pool], WorkTime),
     {noreply, State};
 handle_cast({update, {worker_pool, Pool}}, State) ->

--- a/src/riak_core_stat.erl
+++ b/src/riak_core_stat.erl
@@ -138,11 +138,11 @@ handle_call(_Req, _From, State) ->
 handle_cast({update, {worker_pool, vnode_pool}}, State) ->
     exometer_update([prefix(), ?APP, vnode, worker_pool], 1),
     {noreply, State};
-handle_cast({update, {worker_pool, threshold_event, Pool}}, State) ->
-    exometer_update([prefix(), ?APP, worker_pool_threshold_events, Pool], 1),
-    {noreply, State};
 handle_cast({update, {worker_pool, queue_time, Pool, QueueTime}}, State) ->
     exometer_update([prefix(), ?APP, worker_pool_queue_time, Pool], QueueTime),
+    {noreply, State};
+handle_cast({update, {worker_pool, worker_time, Pool, WorkTime}}, State) ->
+    exometer_update([prefix(), ?APP, worker_pool_work_time, Pool], WorkTime),
     {noreply, State};
 handle_cast({update, {worker_pool, Pool}}, State) ->
     exometer_update([prefix(), ?APP, node, worker_pool, Pool], 1),
@@ -211,8 +211,8 @@ nwp_stats() ->
     [nwp_stat(Pool) || Pool <- PoolNames] ++
     
     [nwpqt_stat(Pool) || Pool <- PoolNames] ++
-
-    [nwpte_stat(Pool) || Pool <- PoolNames].
+    
+    [nwpwt_stat(Pool) || Pool <- PoolNames].
 
 nwp_stat(Pool) ->
     {[node, worker_pool, Pool], counter, [],
@@ -223,10 +223,10 @@ nwpqt_stat(Pool) ->
         [{mean  , nwp_name_atom(Pool, <<"_queuetime_mean">>)},
             {max   , nwp_name_atom(Pool, <<"_queuetime_100">>)}]}.
 
-nwpte_stat(Pool) ->
-    {[worker_pool_threshold_events, Pool], spiral, [],
-        [{count, nwp_name_atom(Pool, <<"_threshold_events_total">>)},
-            {one, nwp_name_atom(Pool, <<"_threshold_events">>)}]}.
+nwpwt_stat(Pool) ->
+    {[worker_pool_worktime, Pool], histogram, [],
+        [{mean  , nwp_name_atom(Pool, <<"_worktime_mean">>)},
+            {max   , nwp_name_atom(Pool, <<"_worktime_100">>)}]}.
 
 system_stats() ->
     [

--- a/src/riak_core_stat.erl
+++ b/src/riak_core_stat.erl
@@ -206,16 +206,13 @@ stats() ->
                                       {last, rebalance_delay_last}]} |  nwp_stats()].
 
 nwp_stats() ->
-    PoolNames = [unregistered] ++ riak_core_node_worker_pool:pools(),
-
-    [{[vnode, worker_pool], counter, [],
-            [{value, vnode_worker_pool_total}]}] ++
+    PoolNames = [vnode_pool, unregistered] ++ riak_core_node_worker_pool:pools(),
     
-        [nwp_stat(Pool) || Pool <- PoolNames] ++
-        
-        [nwpqt_stat(Pool) || Pool <- [vnode_pool|PoolNames]] ++
+    [nwp_stat(Pool) || Pool <- PoolNames] ++
+    
+    [nwpqt_stat(Pool) || Pool <- PoolNames] ++
 
-        [nwpte_stat(Pool) || Pool <- [vnode_pool|PoolNames]].
+    [nwpte_stat(Pool) || Pool <- PoolNames].
 
 nwp_stat(Pool) ->
     {[node, worker_pool, Pool], counter, [],

--- a/src/riak_core_stat.erl
+++ b/src/riak_core_stat.erl
@@ -224,7 +224,7 @@ nwp_stats() ->
                 {95    , vnode_worker_pool_checkouts_95},
                 {max   , vnode_worker_pool_checkouts_100}]},
         {[vnode, worker_pool_queue_events], counter, [],
-            [{value, vnode_worker_pool_queue_events}]}] ++
+            [{value, vnode_worker_pool_qevents}]}] ++
 
         [nwp_stat(Pool) || Pool <- PoolNames] ++
         

--- a/src/riak_core_vnode_worker_pool.erl
+++ b/src/riak_core_vnode_worker_pool.erl
@@ -50,7 +50,8 @@ start_link(WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps) ->
     riak_core_worker_pool:start_link(
         [WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps],
             ?MODULE,
-            vnode_pool).
+            vnode_pool,
+            PoolSize div 2).
 	
 handle_work(Pid, Work, From) ->
     riak_core_stat:update({worker_pool, vnode_pool}),

--- a/src/riak_core_vnode_worker_pool.erl
+++ b/src/riak_core_vnode_worker_pool.erl
@@ -50,8 +50,7 @@ start_link(WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps) ->
     riak_core_worker_pool:start_link(
         [WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps],
             ?MODULE,
-            vnode_pool,
-            PoolSize div 2).
+            vnode_pool).
 	
 handle_work(Pid, Work, From) ->
     riak_core_stat:update({worker_pool, vnode_pool}),

--- a/src/riak_core_vnode_worker_pool.erl
+++ b/src/riak_core_vnode_worker_pool.erl
@@ -48,7 +48,9 @@
 
 start_link(WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps) ->
     riak_core_worker_pool:start_link(
-        [WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps], ?MODULE).
+        [WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps],
+            ?MODULE,
+            vnode_pool).
 	
 handle_work(Pid, Work, From) ->
     riak_core_stat:update({worker_pool, vnode_pool}),

--- a/src/riak_core_vnode_worker_pool.erl
+++ b/src/riak_core_vnode_worker_pool.erl
@@ -46,9 +46,7 @@
 %% API
 -export([start_link/5, stop/2, shutdown_pool/2, handle_work/3]).
 
-start_link(WorkerMod,
-			PoolSize, VNodeIndex,
-			WorkerArgs, WorkerProps) ->
+start_link(WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps) ->
     riak_core_worker_pool:start_link(
         [WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps], ?MODULE).
 	

--- a/src/riak_core_vnode_worker_pool.erl
+++ b/src/riak_core_vnode_worker_pool.erl
@@ -49,33 +49,29 @@
 start_link(WorkerMod,
 			PoolSize, VNodeIndex,
 			WorkerArgs, WorkerProps) ->
-	riak_core_worker_pool:start_link([WorkerMod,
-										PoolSize,
-										VNodeIndex,
-										WorkerArgs,
-										WorkerProps],
-										?MODULE).
+    riak_core_worker_pool:start_link(
+        [WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps], ?MODULE).
 	
 handle_work(Pid, Work, From) ->
     riak_core_stat:update({worker_pool, vnode_pool}),
-	riak_core_worker_pool:handle_work(Pid, Work, From).
+    riak_core_worker_pool:handle_work(Pid, Work, From).
 
 stop(Pid, Reason) ->
     riak_core_worker_pool:stop(Pid, Reason).
 
 %% wait for all the workers to finish any current work
 shutdown_pool(Pid, Wait) ->
-	riak_core_worker_pool:shutdown_pool(Pid, Wait).
+    riak_core_worker_pool:shutdown_pool(Pid, Wait).
 
 reply(From, Msg) ->
-	riak_core_vnode:reply(From, Msg).
+    riak_core_vnode:reply(From, Msg).
 
 do_init([WorkerMod, PoolSize, VNodeIndex, WorkerArgs, WorkerProps]) ->
-    poolboy:start_link([{worker_module, riak_core_vnode_worker},
-							{worker_args,
-								[VNodeIndex, WorkerArgs, WorkerProps, self()]},
-							{worker_callback_mod, WorkerMod},
-							{size, PoolSize}, {max_overflow, 0}]).
+    poolboy:start_link([{worker_module, riak_core_vnode_worker}, 
+                            {worker_args, 
+                                [VNodeIndex, WorkerArgs, WorkerProps, self()]}, 
+                            {worker_callback_mod, WorkerMod}, 
+                            {size, PoolSize}, {max_overflow, 0}]).
 
 do_work(Pid, Work, From) ->
-	riak_core_vnode_worker:handle_work(Pid, Work, From).
+    riak_core_vnode_worker:handle_work(Pid, Work, From).

--- a/src/riak_core_worker_pool.erl
+++ b/src/riak_core_worker_pool.erl
@@ -125,9 +125,6 @@ ready({work, Work, From} = Msg,
         #state{pool=Pool, queue=Q, monitors=Monitors} = State) ->
     case poolboy_checkout(Pool, State) of
         {full, State0} ->
-            riak_core_stat:update({worker_pool,
-                                    queue_event,
-                                    State#state.pool_name}),
             {next_state, queueing, State0#state{queue=push_to_queue(Msg, Q)}};
         {Pid, State0} when is_pid(Pid) ->
             NewMonitors =

--- a/src/riak_core_worker_pool.erl
+++ b/src/riak_core_worker_pool.erl
@@ -203,7 +203,7 @@ handle_event(worker_start, StateName,
                         queue=Q,
                         pool_name=PoolName,
                         checkouts=Checkouts0,
-                        monitors=Monitors}=State) ->
+                        monitors=Monitors0}=State) ->
     %% a new worker just started - if we have work pending, try to do it
     case consume_from_queue(Q, State#state.pool_name) of
         {{value, {work, Work, From}}, Rem} ->
@@ -211,12 +211,12 @@ handle_event(worker_start, StateName,
                 full ->
                     {next_state, queueing, State};
                 {Pid, Checkouts} when is_pid(Pid) ->
-                    NewMonitors = monitor_worker(Pid, From, Work, Monitors),
+                    Monitors = monitor_worker(Pid, From, Work, Monitors0),
                     do_work(Pid, Work, From, State#state.callback_mod),
                     {next_state,
                         queueing,
                         State#state{queue=Rem,
-                                        monitors=NewMonitors,
+                                        monitors=Monitors,
                                         checkouts=Checkouts}}
             end;
         {empty, _} ->

--- a/src/riak_core_worker_pool.erl
+++ b/src/riak_core_worker_pool.erl
@@ -313,6 +313,10 @@ poolboy_checkout(Pool, State) ->
         full ->
             {full, State};
         P when is_pid(P) ->
+            riak_core_stat:update({worker_pool,
+                                    queue_time,
+                                    State#state.pool_name,
+                                    0}),
             Checkouts = [{P, os:timestamp()}|State#state.checkouts],
             {P, State#state{checkouts = Checkouts}}
     end.


### PR DESCRIPTION
Add monitoring via riak stats to the worker queues.  Monitor both queue time, and work time.