### PR TITLE
ps-like dump of memory usage of processes in riak supervisor tree

### DIFF
--- a/src/riak_core_supps.erl
+++ b/src/riak_core_supps.erl
@@ -1,0 +1,225 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2022 TI Tokyo.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% A ps-like output of process_info items (memory, message_queue_len
+%% etc) of processes under the supervisor trees of principal riak
+%% applications (riak_core, riak_kv, riak_repl and some others).
+%%
+%% The idea for riak_core_supps:q/1 is to be connected to
+%% riak_core_console and exposed as a riak-admin command. It can also
+%% be called directly from an attached remote shell.
+%%
+%% Options:
+%% * `{format, flat|tree}`, selects the output format (default is 'tree');
+%% * `{depth, Depth}`, print children up to Depth level deep (default
+%%    is 1, meaning only top-level sups are included);
+%% * `{filter, Regex}`, filter on process names to use (default is ".+"):
+%%   - if a sup's name matches, all its children are shown;
+%%   - if a sup's name doesn't match, it is only shown if a match is
+%%     found in its children or below;
+%% * `{order_by, ProcessInfoItem}`, sort by this process_info item, or 'none'
+%%    to preserve the order children are created (default is 'memory').
+
+-module(riak_core_supps).
+
+-export([q/1]).
+
+-record(p, {name :: atom() | tuple(),
+            info :: undefined | proplists:proplist(),
+            total_mem = 0 :: non_neg_integer(),
+            type :: worker | supervisor,
+            pid :: pid() | undefined,
+            children = []
+           }
+       ).
+
+sups() ->
+    [riak_core_sup,
+     riak_kv_sup,
+     riak_repl_sup,
+     riak_api_sup,
+     riak_pipe_sup
+    ].
+
+
+
+-spec q(proplists:proplist()) -> ok.
+q(Options0) ->
+    Nodes = [node() | nodes()],
+    Options = extract_options(Options0),
+
+    lists:foreach(
+      fun(Node) ->
+              io:format("============ Node: ~s ===========================\n", [Node]),
+              io:format("~11s\t~5s\t~8s\t~.14s~s\n"
+                        "-------------------------------------------------------------\n",
+                        [mem, mq, ths, pid, process]),
+              print(
+                reformat([get_info(Node, P) || P <- sups()], Options),
+                Options, 0)
+      end, Nodes
+     ),
+    ok.
+
+extract_options(PL) ->
+    Depth =
+        case proplists:get_value(depth, PL, 1) of
+            max ->
+                9999;
+            V ->
+                V
+        end,
+    #{filter => proplists:get_value(filter, PL, ".+"),
+      format => proplists:get_value(format, PL, tree),
+      order_by => proplists:get_value(order_by, PL, memory),
+      depth => Depth
+     }.
+
+
+get_info(Node, Name) ->
+    FF =
+        lists:foldl(
+          fun({SubName, Pid, worker, _MM}, Q) ->
+                  Info = rpc:call(Node, erlang, process_info,
+                                  [Pid, [memory, message_queue_len, messages, total_heap_size]]),
+                  [#p{name = SubName, info = Info, type = worker, pid = Pid,
+                      total_mem = proplists:get_value(memory, Info, 0)} | Q];
+             ({SubName, _Pid, supervisor, _MM}, Q) ->
+                  [get_info(Node, SubName) | Q]
+          end,
+          [],
+          case rpc:call(Node, supervisor, which_children, [Name]) of
+              Children when is_list(Children) ->
+                  Children;
+              _ ->
+                  []
+          end
+         ),
+    #p{name = Name,
+       total_mem = lists:foldl(fun(#p{total_mem = TM}, Q) ->
+                                       Q + TM
+                               end, 0, FF),
+       type = supervisor,
+       children = FF}.
+
+
+print(_p, #{depth := MaxDepth}, Depth) when MaxDepth < Depth ->
+    ok;
+print(PP, Options, Depth) when is_list(PP) ->
+    lists:foreach(fun(P) -> print(P, Options, Depth) end, PP);
+print(#p{name = Name, info = Info, type = worker, pid = Pid},
+      #{filter := Filter}, Depth) ->
+    case re:run(printable(Name), Filter) of
+        nomatch ->
+            skip;
+        _ ->
+            Mem = integer_or_blank(memory, Info),
+            THS = integer_or_blank(total_heap_size, Info),
+            MQ = integer_or_blank(message_queue_len, Info),
+            io:format("~11s\t~5s\t~8s\t~.14s~s~s\n", [Mem, MQ, THS, pid_to_list(Pid), pad(Depth * 2), printable(Name)])
+    end;
+print(#p{name = Name, children = FF, total_mem = Mem} = P,
+      Options = #{filter := Filter}, Depth) ->
+    case has_printable_children(P, Filter) of
+        no ->
+            skip;
+        Yes ->
+            io:format("~11b\t~5s\t~8s\t~14s~s~s (~b)\n",
+                      [Mem, "", "", "", pad(Depth * 2), printable(Name), length(FF)]),
+            lists:foreach(
+              fun(F) -> print(F, Options#{filter => maybe_drop_filter(Yes, Filter)}, Depth + 1) end,
+              FF
+             )
+    end.
+maybe_drop_filter(all, _) -> ".+";
+maybe_drop_filter(yes, Filter) -> Filter.
+
+
+integer_or_blank(F, Info) ->
+    A_ = proplists:get_value(F, Info, ""),
+    [integer_to_list(A_)||is_integer(A_)].
+
+pad(N) ->
+    lists:duplicate(N, $ ).
+
+printable(Name) when is_atom(Name) -> atom_to_list(Name);
+printable(Name) -> io_lib:format("~p", [Name]).
+
+
+has_printable_children(#p{name = Name, type = worker}, Filter) ->
+    case re:run(printable(Name), Filter) of
+        nomatch ->
+            no;
+        _ ->
+            yes
+    end;
+has_printable_children(#p{name = Name, children = FF}, Filter) ->
+    case re:run(printable(Name), Filter) of
+        nomatch ->
+            case lists:any(
+                   fun(P) -> no /= has_printable_children(P, Filter) end,
+                   FF) of
+                true ->
+                    yes;
+                false ->
+                    no
+            end;
+        _ ->
+            all
+    end.
+
+reformat(PP, #{format := tree, order_by := none}) ->
+    PP;
+reformat(PP, #{format := tree, order_by := memory} = Options) ->
+    lists:map(
+      fun(P = #p{children = []}) ->
+              P;
+         (P = #p{children = FF}) ->
+              P#p{children = lists:sort(
+                               fun(#p{total_mem = M1}, #p{total_mem = M2}) ->
+                                       M1 > M2
+                               end,
+                               reformat(FF, Options))}
+      end,
+      PP);
+reformat(#p{children = PP}, Options) ->
+    reformat(PP, Options);
+reformat(PP, #{format := flat, order_by := OrderBy} = Options) ->
+    PP1 =
+        lists:flatten(
+          lists:foldl(
+            fun(#p{type = worker} = P, Q) ->
+                    [P | Q];
+               (#p{type = supervisor, children = FF}, Q) ->
+                    lists:concat([reformat(FF, Options), Q])
+            end,
+            [],
+            PP
+           )
+         ),
+    case OrderBy of
+        none ->
+            PP1;
+        memory ->
+            lists:sort(fun(#p{total_mem = M1}, #p{total_mem = M2}) ->
+                               M1 > M2
+                       end, PP1)
+    end.
+


### PR DESCRIPTION
`riak_core_supps:q(Options)` will print the memory usage, message queue length and total heap size of processes in the supervision tree under several top-level supervisors (riak_core_sup, riak_kv_sup, riak_repl_sup, riak_pipe_sup and riak_api_sup):

```
(riak@127.0.0.1)1> riak_core_supps:q([]).
============ Node: riak@127.0.0.1 ===========================
        mem        mq        ths        pid           process
-------------------------------------------------------------
    4483020                                           riak_core_sup (22)
    3788464                                             riak_core_vnode_sup (128)
     350720                                             riak_core_vnode_proxy_sup (128)
      55184         0       6772        <0.1554.0>      riak_core_ring_events
      55132         0       6772        <0.1555.0>      riak_core_ring_manager
      42116         0       4185        <0.1570.0>      riak_core_vnode_manager
      34356         0       4185        <0.1573.0>      riak_core_claimant
      21944         0       2586        <0.1569.0>      riak_core_node_watcher
      21720                                             riak_core_stat_sup (1)
      21644         0       2586        <0.1571.0>      riak_core_capability
      21564         0       2586        <0.1572.0>      riak_core_gossip
      21564         0       2586        <0.1566.0>      riak_core_broadcast
      13920                                             riak_core_node_worker_pool_sup (5)
       5628                                             riak_core_handoff_sup (4)
       5568                                             riak_core_eventhandler_sup (2)
       3964         0        376        <0.1564.0>      riak_core_metadata_hashtree
       2864         0        233        <0.1559.0>      riak_core_metadata_manager
       2820         0        233        <0.1574.0>      riak_core_table_owner
       2800         0        233        <0.1546.0>      riak_core_dist_mon
       2784         0        233        <0.1568.0>      riak_core_node_watcher_events
       2784         0        233        <0.1543.0>      riak_core_sysmon_minder
       2740                                             riak_core_metadata_evt_sup (1)
       2740         0        233        <0.1542.0>      riak_core_bg_manager
...
```

It can be used from remote shell as a debugging aid; the idea is to hook into riak_core_console and expose it as a riak-admin command. Options are described [here](https://github.com/basho/riak_core/compare/develop...TI-Tokyo:riak_core:hmmr/develop/ps-for-riak-sups?expand=1#diff-a1b658ea99c7472c96422bf9d7261db921ae95f08c2f03bcffeef969c5582573R29-R38).