### PR TITLE
Mas i1121 passringdir

### DIFF
--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -236,6 +236,7 @@ do_write_ringfile(Ring) ->
         Dir ->
             FN = generate_ring_filename(
                 Dir, app_helper:get_env(riak_core, cluster_name)),
+            false = riak_core_ring:check_lastgasp(Ring),
             do_write_ringfile(Ring, FN)
     end.
 
@@ -248,7 +249,6 @@ generate_ring_filename(Dir, ClusterName) ->
 do_write_ringfile(Ring, FN) ->
     ok = filelib:ensure_dir(FN),
     try
-        false = riak_core_ring:check_lastgasp(Ring),
         ok = riak_core_util:replace_file(FN, term_to_binary(Ring))
     catch
         _:Err ->

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -79,7 +79,7 @@
          prune_ringfiles/0,
          read_ringfile/1,
          find_latest_ringfile/0,
-         find_latest_ringfile/1,
+         find_latest_ringfile/2,
          force_update/0,
          generate_ring_filename/2,
          do_write_ringfile/1,
@@ -259,12 +259,12 @@ do_write_ringfile(Ring, FN) ->
 
 %% @spec find_latest_ringfile() -> string()
 find_latest_ringfile() ->
-    find_latest_ringfile(ring_dir()).
+    find_latest_ringfile(
+        ring_dir(), app_helper:get_env(riak_core, cluster_name)).
 
-find_latest_ringfile(Dir) ->
+find_latest_ringfile(Dir, Cluster) ->
     case file:list_dir(Dir) of
         {ok, Filenames} ->
-            Cluster = app_helper:get_env(riak_core, cluster_name),
             Timestamps = [list_to_integer(TS) || {"riak_core_ring", C1, TS} <-
                                                      [list_to_tuple(string:tokens(FN, ".")) || FN <- Filenames],
                                                  C1 =:= Cluster],


### PR DESCRIPTION
Break down the functions required for reip, so that it can be called from riak_kv_console without knowledge of the cluster name or of the ring directory.  This makes it easier to write a reip admin command to be used when riak_core is not loaded with its standard configuration