### PR TITLE
Mas i994 handoffsync

### DIFF
--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -160,7 +160,7 @@ standard_join(Node, Ring, Rejoin, Auto) ->
             Ring6 = maybe_auto_join(Auto, node(), Ring5),
             riak_core_ring_manager:set_my_ring(Ring6),
             ok = riak_core_gossip:send_ring(Node, node()),
-            ok = riak_core_metadata_manager:waitfor_exchange(Node)
+            ok = riak_core_metadata_manager:attempt_exchange(Node)
 
     end.
 

--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -140,25 +140,28 @@ standard_join(Node, Ring, Rejoin, Auto) ->
             {error, different_ring_sizes};
         _ ->
             GossipVsn = riak_core_gossip:gossip_version(),
-            Ring2 = riak_core_ring:add_member(node(), Ring,
-                                              node()),
+            Ring2 =
+                riak_core_ring:add_member(
+                    node(), Ring, node()),
             Ring3 = riak_core_ring:set_owner(Ring2, node()),
             Ring4 =
-                riak_core_ring:update_member_meta(node(),
-                                                  Ring3,
-                                                  node(),
-                                                  gossip_vsn,
-                                                  GossipVsn),
-            ParticipateInCoverage = app_helper:get_env(riak_core,participate_in_coverage),
+                riak_core_ring:update_member_meta(
+                    node(), Ring3, node(), gossip_vsn, GossipVsn),
+            ParticipateInCoverage =
+                app_helper:get_env(riak_core,participate_in_coverage),
             Ring4a =
-                riak_core_ring:update_member_meta(node(),
-                                                  Ring4,
-                                                  node(),
-                                                  participate_in_coverage, ParticipateInCoverage),
+                riak_core_ring:update_member_meta(
+                    node(),
+                    Ring4,
+                    node(),
+                    participate_in_coverage,
+                    ParticipateInCoverage),
             {_, Ring5} = riak_core_capability:update_ring(Ring4a),
             Ring6 = maybe_auto_join(Auto, node(), Ring5),
             riak_core_ring_manager:set_my_ring(Ring6),
-            riak_core_gossip:send_ring(Node, node())
+            ok = riak_core_gossip:send_ring(Node, node()),
+            ok = riak_core_metadata_manager:waitfor_exchange(Node)
+
     end.
 
 maybe_auto_join(false, _Node, Ring) ->

--- a/src/riak_core_handoff_receiver.erl
+++ b/src/riak_core_handoff_receiver.erl
@@ -34,16 +34,17 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
--record(state, {sock :: port() | undefined,
-                peer :: term() | undefined,
-                ssl_opts :: [] | list(),
-                tcp_mod :: atom(),
-                recv_timeout_len :: non_neg_integer(),
-                vnode_timeout_len :: non_neg_integer(),
-                partition :: non_neg_integer() | undefined,
-                vnode_mod = riak_kv_vnode :: module(),
-                vnode :: pid() | undefined,
-                count = 0 :: non_neg_integer()}).
+-record(state, 
+    {sock :: port() | undefined,
+        peer :: term() | undefined,
+        ssl_opts :: [] | list(),
+        tcp_mod :: atom(),
+        recv_timeout_len :: non_neg_integer(),
+        vnode_timeout_len :: non_neg_integer(),
+        partition :: non_neg_integer() | undefined,
+        vnode_mod = riak_kv_vnode :: module(),
+        vnode :: pid() | undefined,
+        count = 0 :: non_neg_integer()}).
 
 %% set the TCP receive timeout to five minutes to be conservative.
 -define(RECV_TIMEOUT, 300000).
@@ -71,48 +72,73 @@ supports_batching() ->
     true.
 
 init([SslOpts]) ->
-    {ok, #state{ssl_opts = SslOpts,
-                tcp_mod  = if SslOpts /= [] -> ssl;
-                              true          -> gen_tcp
-                           end,
-                recv_timeout_len = app_helper:get_env(riak_core, handoff_receive_timeout, ?RECV_TIMEOUT),
-                vnode_timeout_len = app_helper:get_env(riak_core, handoff_receive_vnode_timeout, ?VNODE_TIMEOUT)}}.
+    {ok, 
+        #state{
+            ssl_opts = SslOpts,
+            tcp_mod  =
+                if SslOpts /= [] ->
+                        ssl;
+                    true ->
+                        gen_tcp
+                end,
+            recv_timeout_len =
+                app_helper:get_env(
+                    riak_core, handoff_receive_timeout, ?RECV_TIMEOUT),
+            vnode_timeout_len =
+                app_helper:get_env(
+                    riak_core, handoff_receive_vnode_timeout, ?VNODE_TIMEOUT)
+                }
+    }.
 
-handle_call({set_socket, Socket0}, _From, State = #state{ssl_opts = SslOpts}) ->
+handle_call({set_socket, Socket0}, _From, State=#state{ssl_opts = SslOpts}) ->
     SockOpts = [{active, once}, {packet, 4}, {header, 1}],
-    Socket = if SslOpts /= [] ->
-                     {ok, Skt} = ssl_handshake(Socket0, SslOpts, 30*1000),
-                     ok = ssl:setopts(Skt, SockOpts),
-                     Peer = safe_peername(Skt, ssl),
-                     Skt;
-                true ->
-                     ok = inet:setopts(Socket0, SockOpts),
-                     Peer = safe_peername(Socket0, inet),
-                     Socket0
-             end,
+    Socket = 
+        if SslOpts /= [] ->
+                {ok, Skt} = ssl_handshake(Socket0, SslOpts, 30*1000),
+                ok = ssl:setopts(Skt, SockOpts),
+                Peer = safe_peername(Skt, ssl),
+                Skt;
+            true ->
+                ok = inet:setopts(Socket0, SockOpts),
+                Peer = safe_peername(Socket0, inet),
+                Socket0
+        end,
     {reply, ok, State#state { sock = Socket, peer = Peer }}.
 
-handle_info({tcp_closed,_Socket},State=#state{partition=Partition,count=Count,
-                                              peer=Peer}) ->
-    lager:info("Handoff receiver for partition ~p exited after processing ~p"
-                          " objects from ~p", [Partition, Count, Peer]),
+handle_info(
+        {tcp_closed,_Socket},
+        State=#state{partition=Partition, count=Count, peer=Peer}) ->
+    lager:info(
+        "Handoff receiver for partition ~p exited after processing ~p"
+        " objects from ~p",
+        [Partition, Count, Peer]),
     {stop, normal, State};
-handle_info({tcp_error, _Socket, Reason}, State=#state{partition=Partition,count=Count,
-                                                       peer=Peer}) ->
-    lager:info("Handoff receiver for partition ~p exited after processing ~p"
-                          " objects from ~p: TCP error ~p", [Partition, Count, Peer, Reason]),
+handle_info(
+        {tcp_error, _Socket, Reason},
+        State=#state{partition=Partition,count=Count, peer=Peer}) ->
+    lager:info(
+        "Handoff receiver for partition ~p exited after processing ~p"
+        " objects from ~p: TCP error ~p",
+        [Partition, Count, Peer, Reason]),
     {stop, normal, State};
 handle_info({tcp, Socket, Data}, State) ->
     [MsgType|MsgData] = Data,
     case catch(process_message(MsgType, MsgData, State)) of
         {'EXIT', Reason} ->
-            lager:error("Handoff receiver for partition ~p exited abnormally after "
-                                   "processing ~p objects from ~p: ~p", [State#state.partition, State#state.count, State#state.peer, Reason]),
+            lager:error(
+                "Handoff receiver for partition ~p exited abnormally after "
+                "processing ~p objects from ~p: ~p",
+                [State#state.partition,
+                    State#state.count,
+                    State#state.peer, Reason]),
             {stop, normal, State};
         NewState when is_record(NewState, state) ->
-            InetMod = if NewState#state.ssl_opts /= [] -> ssl;
-                         true                          -> inet
-                      end,
+            InetMod = 
+                if NewState#state.ssl_opts /= [] ->
+                        ssl;
+                    true ->
+                        inet
+                end,
             InetMod:setopts(Socket, [{active, once}]),
             {noreply, NewState, State#state.recv_timeout_len}
     end;
@@ -123,27 +149,38 @@ handle_info({ssl_error, Socket, Reason}, State) ->
 handle_info({ssl, Socket, Data}, State) ->
     handle_info({tcp, Socket, Data}, State);
 handle_info(timeout, State) ->
-            lager:error("Handoff receiver for partition ~p timed out after "
-                                   "processing ~p objects from ~p.", [State#state.partition, State#state.count, State#state.peer]),
+    lager:error(
+        "Handoff receiver for partition ~p timed out after "
+        "processing ~p objects from ~p.",
+        [State#state.partition, State#state.count, State#state.peer]),
     {stop, normal, State}.
 
-process_message(?PT_MSG_INIT, MsgData, State=#state{vnode_mod=VNodeMod,
-                                                    peer=Peer}) ->
+process_message(
+        ?PT_MSG_INIT,
+        MsgData,
+        State=#state{vnode_mod=VNodeMod, peer=Peer}) ->
     <<Partition:160/integer>> = MsgData,
-    lager:info("Receiving handoff data for partition ~p:~p from ~p", [VNodeMod, Partition, Peer]),
+    lager:info(
+        "Receiving handoff data for partition ~p:~p from ~p",
+        [VNodeMod, Partition, Peer]),
     {ok, VNode} = riak_core_vnode_master:get_vnode_pid(Partition, VNodeMod),
-    Data = [{mod_src_tgt, {VNodeMod, undefined, Partition}},
-            {vnode_pid, VNode}],
+    Data =
+        [{mod_src_tgt, {VNodeMod, undefined, Partition}}, {vnode_pid, VNode}],
     riak_core_handoff_manager:set_recv_data(self(), Data),
     State#state{partition=Partition, vnode=VNode};
-
 process_message(?PT_MSG_BATCH, MsgData, State) ->
-    lists:foldl(fun(Obj, StateAcc) -> process_message(?PT_MSG_OBJ, Obj, StateAcc) end,
-                State,
-                binary_to_term(MsgData));
-
-process_message(?PT_MSG_OBJ, MsgData, State=#state{vnode=VNode, count=Count,
-                                                   vnode_timeout_len=VNodeTimeout}) ->
+    lists:foldl(
+        fun(Obj, StateAcc) ->
+            process_message(?PT_MSG_OBJ, Obj, StateAcc)
+        end,
+        State,
+        binary_to_term(MsgData));
+process_message(
+        ?PT_MSG_OBJ,
+        MsgData,
+        State =
+            #state{
+                vnode=VNode, count=Count, vnode_timeout_len=VNodeTimeout}) ->
     Msg = {handoff_data, MsgData},
     try gen_fsm:sync_send_all_state_event(VNode, Msg, VNodeTimeout) of
         ok ->
@@ -152,17 +189,20 @@ process_message(?PT_MSG_OBJ, MsgData, State=#state{vnode=VNode, count=Count,
             exit(E)
     catch
         exit:{timeout, _} ->
-            exit({error, {vnode_timeout, VNodeTimeout, size(MsgData),
-                          binary:part(MsgData, {0,min(size(MsgData),128)})}})
+            exit({error, {vnode_timeout, VNodeTimeout, size(MsgData)}})
     end;
-process_message(?PT_MSG_OLDSYNC, MsgData, State=#state{sock=Socket,
-                                                       tcp_mod=TcpMod}) ->
+process_message(
+        ?PT_MSG_OLDSYNC, MsgData, State=#state{sock=Socket, tcp_mod=TcpMod}) ->
+    % Message still required for now, as when upgrading, may have a sender in
+    % the cluster which has not upgraded ... and so will still send OLDSYNC 
     TcpMod:send(Socket, <<?PT_MSG_OLDSYNC:8,"sync">>),
     <<VNodeModBin/binary>> = MsgData,
     VNodeMod = binary_to_atom(VNodeModBin, utf8),
     State#state{vnode_mod=VNodeMod};
-process_message(?PT_MSG_SYNC, _MsgData, State=#state{sock=Socket,
-                                                     tcp_mod=TcpMod}) ->
+process_message(
+        ?PT_MSG_SYNC,
+        _MsgData,
+        State=#state{sock=Socket, tcp_mod=TcpMod}) ->
     TcpMod:send(Socket, <<?PT_MSG_SYNC:8, "sync">>),
     State;
 process_message(?PT_MSG_CONFIGURE, MsgData, State) ->
@@ -185,5 +225,5 @@ safe_peername(Skt, Mod) ->
         {ok, {Host, Port}} ->
             {inet_parse:ntoa(Host), Port};
         _ ->
-            {unknown, unknown}                  % Real info is {Addr, Port}
+            {unknown, unknown} % Real info is {Addr, Port}
     end.

--- a/src/riak_core_handoff_receiver.erl
+++ b/src/riak_core_handoff_receiver.erl
@@ -206,8 +206,10 @@ process_message(
     State;
 process_message(?PT_MSG_CONFIGURE, MsgData, State) ->
     ConfProps = binary_to_term(MsgData),
-    State#state{vnode_mod=proplists:get_value(vnode_mod, ConfProps),
-                partition=proplists:get_value(partition, ConfProps)};
+    % Partition used will be over-written by ?PT_MSG_INIT
+    State#state{
+        vnode_mod=proplists:get_value(vnode_mod, ConfProps),
+        partition=proplists:get_value(partition, ConfProps)};
 process_message(_, _MsgData, State=#state{sock=Socket,
                                           tcp_mod=TcpMod}) ->
     TcpMod:send(Socket, <<255:8,"unknown_msg">>),

--- a/src/riak_core_handoff_receiver.erl
+++ b/src/riak_core_handoff_receiver.erl
@@ -28,9 +28,10 @@
             [{gen_fsm, sync_send_all_state_event, 3}]}).
 
 -export([start_link/0,                          % Don't use SSL
-         start_link/1,                          % SSL options list, empty=no SSL
-         set_socket/2,
-         supports_batching/0]).
+        start_link/1,                          % SSL options list, empty=no SSL
+        set_socket/2,
+        supports_batching/0,
+        get_handoff_timeout/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
@@ -81,9 +82,7 @@ init([SslOpts]) ->
                     true ->
                         gen_tcp
                 end,
-            recv_timeout_len =
-                app_helper:get_env(
-                    riak_core, handoff_receive_timeout, ?RECV_TIMEOUT),
+            recv_timeout_len = get_handoff_timeout(),
             vnode_timeout_len =
                 app_helper:get_env(
                     riak_core, handoff_receive_vnode_timeout, ?VNODE_TIMEOUT)
@@ -227,3 +226,6 @@ safe_peername(Skt, Mod) ->
         _ ->
             {unknown, unknown} % Real info is {Addr, Port}
     end.
+
+get_handoff_timeout() ->
+    app_helper:get_env(riak_core, handoff_receive_timeout, ?RECV_TIMEOUT).

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -130,7 +130,7 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
             end,
 
         VMaster = list_to_atom(atom_to_list(Module) ++ "_master"),
-        Config = [{vnode_mod, VMaster}, {partition, TargetPartition}],
+        Config = [{vnode_mod, Module}, {partition, TargetPartition}],
         ConfigBin = term_to_binary(Config),
         Msg = <<?PT_MSG_CONFIGURE:8, ConfigBin/binary>>,
         ok = TcpMod:send(Socket, Msg),

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -61,8 +61,6 @@
           total_objects        :: non_neg_integer(),
           total_bytes          :: non_neg_integer(),
 
-          use_batching         :: boolean(),
-
           item_queue           :: [binary()],
           item_queue_length    :: non_neg_integer(),
           item_queue_byte_size :: non_neg_integer(),
@@ -82,12 +80,12 @@
 
 start_link(TargetNode, Module, {Type, Opts}, Vnode) ->
     SslOpts = get_handoff_ssl_options(),
-    Pid = spawn_link(fun()->start_fold(TargetNode,
-                                       Module,
-                                       {Type, Opts},
-                                       Vnode,
-                                       SslOpts)
-                     end),
+    Pid = 
+        spawn_link(
+            fun()->
+                start_fold(TargetNode, Module, {Type, Opts}, Vnode, SslOpts)
+            end
+        ),
     {ok, Pid}.
 
 %%%===================================================================
@@ -101,172 +99,180 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
 
     try
         %% Give workers one more chance to abort or get a lock or whatever.
-         FoldOpts = maybe_call_handoff_started(Module, SrcPartition),
+        FoldOpts = maybe_call_handoff_started(Module, SrcPartition),
 
-         Filter = get_filter(Opts),
-         [_Name,Host] = string:tokens(atom_to_list(TargetNode), "@"),
-         {ok, Port} = get_handoff_port(TargetNode),
-         TNHandoffIP =
-            case get_handoff_ip(TargetNode) of
-                error ->
-                    Host;
-                {ok, "0.0.0.0"} ->
-                    Host;
-                {ok, Other} ->
-                    Other
-            end,
-         SockOpts = [binary, {packet, 4}, {header,1}, {active, false}],
-         {Socket, TcpMod} =
-             if SslOpts /= [] ->
-                     {ok, Skt} = ssl:connect(TNHandoffIP, Port, SslOpts ++ SockOpts,
-                                             15000),
-                     {Skt, ssl};
-                true ->
-                     {ok, Skt} = gen_tcp:connect(TNHandoffIP, Port, SockOpts, 15000),
-                     {Skt, gen_tcp}
-             end,
-
-         %% Piggyback the sync command from previous releases to send
-         %% the vnode type across.  If talking to older nodes they'll
-         %% just do a sync, newer nodes will decode the module name.
-         %% After 0.12.0 the calls can be switched to use PT_MSG_SYNC
-         %% and PT_MSG_CONFIGURE
-         VMaster = list_to_atom(atom_to_list(Module) ++ "_master"),
-         ModBin = atom_to_binary(Module, utf8),
-         Msg = <<?PT_MSG_OLDSYNC:8,ModBin/binary>>,
-         ok = TcpMod:send(Socket, Msg),
-
-         RecvTimeout = get_handoff_receive_timeout(),
-
-         AckSyncThreshold = app_helper:get_env(riak_core, handoff_acksync_threshold, 25),
-
-         %% Now that handoff_concurrency applies to both outbound and
-         %% inbound conns there is a chance that the receiver may
-         %% decide to reject the senders attempt to start a handoff.
-         %% In the future this will be part of the actual wire
-         %% protocol but for now the sender must assume that a closed
-         %% socket at this point is a rejection by the receiver to
-         %% enforce handoff_concurrency.
-         case TcpMod:recv(Socket, 0, RecvTimeout) of
-             {ok,[?PT_MSG_OLDSYNC|<<"sync">>]} -> ok;
-             {error, timeout} -> exit({shutdown, timeout});
-             {error, closed} -> exit({shutdown, max_concurrency})
-         end,
-
-         RemoteSupportsBatching = remote_supports_batching(TargetNode),
-
-         lager:info("Starting ~p transfer of ~p from ~p ~p to ~p ~p",
-                    [Type, Module, SrcNode, SrcPartition,
-                     TargetNode, TargetPartition]),
-
-         M = <<?PT_MSG_INIT:8,TargetPartition:160/integer>>,
-         ok = TcpMod:send(Socket, M),
-         StartFoldTime = os:timestamp(),
-         Stats = #ho_stats{interval_end=future_now(get_status_interval())},
-         UnsentAcc0 = get_notsent_acc0(Opts),
-         UnsentFun = get_notsent_fun(Opts),
-
-         Req = riak_core_util:make_fold_req(
-                             fun visit_item/3,
-                             #ho_acc{ack=0,
-                                     error=ok,
-                                     filter=Filter,
-                                     module=Module,
-                                     parent=ParentPid,
-                                     socket=Socket,
-                                     src_target={SrcPartition, TargetPartition},
-                                     stats=Stats,
-                                     tcp_mod=TcpMod,
-
-                                     total_bytes=0,
-                                     total_objects=0,
-
-                                     use_batching=RemoteSupportsBatching,
-
-                                     item_queue=[],
-                                     item_queue_length=0,
-                                     item_queue_byte_size=0,
-
-                                     acksync_threshold=AckSyncThreshold,
-
-                                     type=Type,
-                                     notsent_acc=UnsentAcc0,
-                                     notsent_fun=UnsentFun},
-                             false,
-                             FoldOpts),
-
-         %% IFF the vnode is using an async worker to perform the fold
-         %% then sync_command will return error on vnode crash,
-         %% otherwise it will wait forever but vnode crash will be
-         %% caught by handoff manager.  I know, this is confusing, a
-         %% new handoff system will be written soon enough.
-
-         AccRecord0 = riak_core_vnode_master:sync_command({SrcPartition, SrcNode},
-                                                          Req,
-                                                          VMaster, infinity),
-
-         %% Send any straggler entries remaining in the buffer:
-         AccRecord = send_objects(AccRecord0#ho_acc.item_queue, AccRecord0),
-
-         if AccRecord == {error, vnode_shutdown} ->
-                 ?log_info("because the local vnode was shutdown", []),
-                 throw({be_quiet, error, local_vnode_shutdown_requested});
+        Filter = get_filter(Opts),
+        [_Name,Host] = string:tokens(atom_to_list(TargetNode), "@"),
+        {ok, Port} = get_handoff_port(TargetNode),
+        TNHandoffIP =
+        case get_handoff_ip(TargetNode) of
+            error ->
+                Host;
+            {ok, "0.0.0.0"} ->
+                Host;
+            {ok, Other} ->
+                Other
+        end,
+        SockOpts = [binary, {packet, 4}, {header,1}, {active, false}],
+        {Socket, TcpMod} =
+            if SslOpts /= [] ->
+                {ok, Skt} =
+                    ssl:connect(
+                        TNHandoffIP, Port, SslOpts ++ SockOpts, 15000),
+                {Skt, ssl};
             true ->
-                 ok                     % If not #ho_acc, get badmatch below
-         end,
-         #ho_acc{
-           error=ErrStatus,
-           module=Module,
-           parent=ParentPid,
-           tcp_mod=TcpMod,
-           total_objects=TotalObjects,
-           total_bytes=TotalBytes,
-           stats=FinalStats,
-           acksync_timer=TRef,
-           notsent_acc=NotSentAcc} = AccRecord,
+                {ok, Skt} =
+                gen_tcp:connect(TNHandoffIP, Port, SockOpts, 15000),
+                {Skt, gen_tcp}
+            end,
 
-         _ = timer:cancel(TRef),
-         case ErrStatus of
-             ok ->
-                 %% One last sync to make sure the message has been received.
-                 %% post-0.14 vnodes switch to handoff to forwarding immediately
-                 %% so handoff_complete can only be sent once all of the data is
-                 %% written.  handle_handoff_data is a sync call, so once
-                 %% we receive the sync the remote side will be up to date.
-                 lager:debug("~p ~p Sending final sync",
-                             [SrcPartition, Module]),
-                 ok = TcpMod:send(Socket, <<?PT_MSG_SYNC:8>>),
+        VMaster = list_to_atom(atom_to_list(Module) ++ "_master"),
+        Config = [{vnode_mod, VMaster}, {partition, TargetPartition}],
+        ConfigBin = term_to_binary(Config),
+        Msg = <<?PT_MSG_CONFIGURE:8, ConfigBin/binary>>,
+        ok = TcpMod:send(Socket, Msg),
 
-                 case TcpMod:recv(Socket, 0, RecvTimeout) of
-                     {ok,[?PT_MSG_SYNC|<<"sync">>]} ->
-                         lager:debug("~p ~p Final sync received",
-                                     [SrcPartition, Module]);
-                     {error, timeout} -> exit({shutdown, timeout})
-                 end,
+        RecvTimeout = get_handoff_receive_timeout(),
 
-                 FoldTimeDiff = end_fold_time(StartFoldTime),
-                 ThroughputBytes = TotalBytes/FoldTimeDiff,
+        AckSyncThreshold = app_helper:get_env(riak_core, handoff_acksync_threshold, 25),
 
-                 ok = lager:info("~p transfer of ~p from ~p ~p to ~p ~p"
-                            " completed: sent ~s bytes in ~p of ~p objects"
-                            " in ~.2f seconds (~s/second)",
-                            [Type, Module, SrcNode, SrcPartition, TargetNode, TargetPartition,
-                            riak_core_format:human_size_fmt("~.2f", TotalBytes),
-                             FinalStats#ho_stats.objs, TotalObjects, FoldTimeDiff,
-                             riak_core_format:human_size_fmt("~.2f", ThroughputBytes)]),
-                 case Type of
-                     repair -> ok;
-                     resize -> gen_fsm:send_event(ParentPid, {resize_transfer_complete,
-                                                                       NotSentAcc});
-                     _ -> gen_fsm:send_event(ParentPid, handoff_complete)
-                 end;
-             {error, ErrReason} ->
-                 if ErrReason == timeout ->
-                         exit({shutdown, timeout});
-                    true ->
-                         exit({shutdown, {error, ErrReason}})
-                 end
-         end
+        %% Now that handoff_concurrency applies to both outbound and
+        %% inbound conns there is a chance that the receiver may
+        %% decide to reject the senders attempt to start a handoff.
+        %% In the future this will be part of the actual wire
+        %% protocol but for now the sender must assume that a closed
+        %% socket at this point is a rejection by the receiver to
+        %% enforce handoff_concurrency.
+        case TcpMod:recv(Socket, 0, RecvTimeout) of
+            {ok,[?PT_MSG_SYNC|<<"sync">>]} -> ok;
+            {error, timeout} -> exit({shutdown, timeout});
+            {error, closed} -> exit({shutdown, max_concurrency})
+        end,
+
+        lager:info("Starting ~p transfer of ~p from ~p ~p to ~p ~p",
+                [Type, Module, SrcNode, SrcPartition,
+                    TargetNode, TargetPartition]),
+
+        M = <<?PT_MSG_INIT:8,TargetPartition:160/integer>>,
+        ok = TcpMod:send(Socket, M),
+        StartFoldTime = os:timestamp(),
+        Stats = #ho_stats{interval_end=future_now(get_status_interval())},
+        UnsentAcc0 = get_notsent_acc0(Opts),
+        UnsentFun = get_notsent_fun(Opts),
+
+        Req = 
+            riak_core_util:make_fold_req(
+                fun visit_item/3,
+                #ho_acc{
+                    ack=0,
+                    error=ok,
+                    filter=Filter,
+                    module=Module,
+                    parent=ParentPid,
+                    socket=Socket,
+                    src_target={SrcPartition, TargetPartition},
+                    stats=Stats,
+                    tcp_mod=TcpMod,
+
+                    total_bytes=0,
+                    total_objects=0,
+
+                    item_queue=[],
+                    item_queue_length=0,
+                    item_queue_byte_size=0,
+
+                    acksync_threshold=AckSyncThreshold,
+
+                    type=Type,
+                    notsent_acc=UnsentAcc0,
+                    notsent_fun=UnsentFun},
+                false,
+                FoldOpts),
+
+        %% IFF the vnode is using an async worker to perform the fold
+        %% then sync_command will return error on vnode crash,
+        %% otherwise it will wait forever but vnode crash will be
+        %% caught by handoff manager.  I know, this is confusing, a
+        %% new handoff system will be written soon enough.
+
+        AccRecord0 =
+            riak_core_vnode_master:sync_command(
+                {SrcPartition, SrcNode}, Req, VMaster, infinity),
+
+        %% Send any straggler entries remaining in the buffer:
+        AccRecord = send_objects(AccRecord0#ho_acc.item_queue, AccRecord0),
+
+        if AccRecord == {error, vnode_shutdown} ->
+                ?log_info("because the local vnode was shutdown", []),
+                throw({be_quiet, error, local_vnode_shutdown_requested});
+        true ->
+                ok % If not #ho_acc, get badmatch below
+        end,
+        #ho_acc{
+        error=ErrStatus,
+        module=Module,
+        parent=ParentPid,
+        tcp_mod=TcpMod,
+        total_objects=TotalObjects,
+        total_bytes=TotalBytes,
+        stats=FinalStats,
+        acksync_timer=TRef,
+        notsent_acc=NotSentAcc} = AccRecord,
+
+        _ = timer:cancel(TRef),
+        case ErrStatus of
+            ok ->
+                %% One last sync to make sure the message has been received.
+                %% post-0.14 vnodes switch to handoff to forwarding immediately
+                %% so handoff_complete can only be sent once all of the data is
+                %% written.  handle_handoff_data is a sync call, so once
+                %% we receive the sync the remote side will be up to date.
+                lager:debug(
+                    "~p ~p Sending final sync",
+                    [SrcPartition, Module]),
+                ok = TcpMod:send(Socket, <<?PT_MSG_SYNC:8>>),
+
+                case TcpMod:recv(Socket, 0, RecvTimeout) of
+                    {ok,[?PT_MSG_SYNC|<<"sync">>]} ->
+                        lager:debug(
+                            "~p ~p Final sync received",
+                            [SrcPartition, Module]);
+                    {error, timeout} -> exit({shutdown, timeout})
+                end,
+
+                FoldTimeDiff = end_fold_time(StartFoldTime),
+                ThroughputBytes = TotalBytes/FoldTimeDiff,
+
+                ok = 
+                lager:info(
+                    "~p transfer of ~p from ~p ~p to ~p ~p"
+                    " completed: sent ~s bytes in ~p of ~p objects"
+                    " in ~.2f seconds (~s/second)",
+                    [Type, Module,
+                        SrcNode, SrcPartition,
+                        TargetNode, TargetPartition,
+                    riak_core_format:human_size_fmt(
+                            "~.2f", TotalBytes),
+                        FinalStats#ho_stats.objs, TotalObjects, FoldTimeDiff,
+                        riak_core_format:human_size_fmt(
+                            "~.2f", ThroughputBytes)]),
+                case Type of
+                    repair ->
+                        ok;
+                    resize ->
+                        gen_fsm:send_event(
+                            ParentPid, {resize_transfer_complete, NotSentAcc});
+                    _ ->
+                        gen_fsm:send_event(
+                            ParentPid, handoff_complete)
+                end;
+            {error, ErrReason} ->
+                if ErrReason == timeout ->
+                        exit({shutdown, timeout});
+                true ->
+                        exit({shutdown, {error, ErrReason}})
+                end
+        end
      catch
          exit:{shutdown,max_concurrency} ->
              %% Need to fwd the error so the handoff mgr knows
@@ -323,25 +329,33 @@ visit_item(K, V, Acc0 = #ho_acc{acksync_threshold = AccSyncThreshold}) ->
 visit_item2(_K, _V, Acc=#ho_acc{error={error, _Reason}}) ->
     %% When a TCP/SSL error occurs, #ho_acc.error is set to {error, Reason}.
     throw(Acc);
-visit_item2(K, V, Acc = #ho_acc{ack = _AccSyncThreshold, acksync_threshold = _AccSyncThreshold}) ->
-    #ho_acc{module=Module,
-            socket=Sock,
-            src_target={SrcPartition, TargetPartition},
-            stats=Stats,
-            tcp_mod=TcpMod
-           } = Acc,
+visit_item2(
+        K,
+        V,
+        Acc =
+            #ho_acc{
+                ack = _AccSyncThreshold,
+                acksync_threshold = _AccSyncThreshold}) ->
+    
+    #ho_acc{
+        module=Module,
+        socket=Sock,
+        src_target={SrcPartition, TargetPartition},
+        stats=Stats,
+        tcp_mod=TcpMod} = Acc,
 
     RecvTimeout = get_handoff_receive_timeout(),
-    M = <<?PT_MSG_OLDSYNC:8,"sync">>,
+    M = <<?PT_MSG_SYNC:8, "sync">>,
     NumBytes = byte_size(M),
 
     Stats2 = incr_bytes(Stats, NumBytes),
-    Stats3 = maybe_send_status({Module, SrcPartition, TargetPartition}, Stats2),
+    Stats3 =
+        maybe_send_status({Module, SrcPartition, TargetPartition}, Stats2),
 
     case TcpMod:send(Sock, M) of
         ok ->
             case TcpMod:recv(Sock, 0, RecvTimeout) of
-                {ok,[?PT_MSG_OLDSYNC|<<"sync">>]} ->
+                {ok,[?PT_MSG_SYNC|<<"sync">>]} ->
                     Acc2 = Acc#ho_acc{ack=0, error=ok, stats=Stats3},
                     visit_item2(K, V, Acc2);
                 {error, Reason} ->
@@ -354,7 +368,6 @@ visit_item2(K, V, Acc) ->
     #ho_acc{filter=Filter,
             module=Module,
             total_objects=TotalObjects,
-            use_batching=UseBatching,
             item_queue=ItemQueue,
             item_queue_length=ItemQueueLength,
             item_queue_byte_size=ItemQueueByteSize,
@@ -369,57 +382,33 @@ visit_item2(K, V, Acc) ->
                                   [Bucket, Key]),
                     Acc;
                 BinObj ->
+                    ItemQueue2 = [BinObj | ItemQueue],
+                    ItemQueueLength2 = ItemQueueLength + 1,
+                    ItemQueueByteSize2 = ItemQueueByteSize + byte_size(BinObj),
 
-                    case UseBatching of
-                        true ->
-                            ItemQueue2 = [BinObj | ItemQueue],
-                            ItemQueueLength2 = ItemQueueLength + 1,
-                            ItemQueueByteSize2 = ItemQueueByteSize + byte_size(BinObj),
+                    Acc2 =
+                        Acc#ho_acc{
+                            item_queue_length=ItemQueueLength2,
+                            item_queue_byte_size=ItemQueueByteSize2},
 
-                            Acc2 = Acc#ho_acc{item_queue_length=ItemQueueLength2,
-                                              item_queue_byte_size=ItemQueueByteSize2},
+                    %% Unit size is bytes:
+                    HandoffBatchThreshold =
+                        app_helper:get_env(
+                            riak_core, handoff_batch_threshold, 1024 * 1024),
 
-                            %% Unit size is bytes:
-                            HandoffBatchThreshold = app_helper:get_env(riak_core,
-                                                                       handoff_batch_threshold,
-                                                                       1024*1024),
-
-                            case ItemQueueByteSize2 =< HandoffBatchThreshold of
-                                true  -> Acc2#ho_acc{item_queue=ItemQueue2};
-                                false -> send_objects(ItemQueue2, Acc2)
-                            end;
-                        _ ->
-                            #ho_acc{ack=Ack,
-                                    socket=Sock,
-                                    src_target={SrcPartition, TargetPartition},
-                                    stats=Stats,
-                                    tcp_mod=TcpMod,
-                                    total_objects=TotalObjects,
-                                    total_bytes=TotalBytes} = Acc,
-                            M = <<?PT_MSG_OBJ:8,BinObj/binary>>,
-                            NumBytes = byte_size(M),
-
-                            Stats2 = incr_bytes(incr_objs(Stats), NumBytes),
-                            Stats3 = maybe_send_status({Module, SrcPartition,
-                                                        TargetPartition}, Stats2),
-
-                            case TcpMod:send(Sock, M) of
-                                ok ->
-                                    Acc#ho_acc{ack=Ack+1,
-                                               error=ok,
-                                               stats=Stats3,
-                                               total_bytes=TotalBytes+NumBytes,
-                                               total_objects=TotalObjects+1};
-                                {error, Reason} ->
-                                    Acc#ho_acc{error={error, Reason}, stats=Stats3}
-                            end
+                    case ItemQueueByteSize2 =< HandoffBatchThreshold of
+                        true  ->
+                            Acc2#ho_acc{item_queue=ItemQueue2};
+                        false ->
+                            send_objects(ItemQueue2, Acc2)
                     end
             end;
         false ->
             NewNotSentAcc = handle_not_sent_item(NotSentFun, NotSentAcc, K),
-            Acc#ho_acc{error=ok,
-                       total_objects=TotalObjects+1,
-                       notsent_acc=NewNotSentAcc}
+            Acc#ho_acc{
+                error=ok,
+                total_objects=TotalObjects+1,
+                notsent_acc=NewNotSentAcc}
     end.
 
 handle_not_sent_item(NotSentFun, Acc, Key) when is_function(NotSentFun) ->
@@ -452,7 +441,8 @@ send_objects(ItemsReverseList, Acc) ->
     NumBytes = byte_size(M),
 
     Stats2 = incr_bytes(incr_objs(Stats, NObjects), NumBytes),
-    Stats3 = maybe_send_status({Module, SrcPartition, TargetPartition}, Stats2),
+    Stats3 =
+        maybe_send_status({Module, SrcPartition, TargetPartition}, Stats2),
 
     case TcpMod:send(Sock, M) of
         ok ->
@@ -467,8 +457,12 @@ send_objects(ItemsReverseList, Acc) ->
     end.
 
 get_handoff_ip(Node) when is_atom(Node) ->
-    case riak_core_util:safe_rpc(Node, riak_core_handoff_listener, get_handoff_ip, [],
-                  infinity) of
+    case riak_core_util:safe_rpc(
+            Node,
+            riak_core_handoff_listener,
+            get_handoff_ip,
+            [], 
+            infinity) of
         {badrpc, _} ->
             error;
         Res ->
@@ -476,12 +470,10 @@ get_handoff_ip(Node) when is_atom(Node) ->
     end.
 
 get_handoff_port(Node) when is_atom(Node) ->
-    case catch(riak_core_gen_server:call({riak_core_handoff_listener, Node}, handoff_port, infinity)) of
-        {'EXIT', _}  ->
-            %% Check old location from previous release
-            riak_core_gen_server:call({riak_kv_handoff_listener, Node}, handoff_port, infinity);
-        Other -> Other
-    end.
+    riak_core_gen_server:call(
+        {riak_core_handoff_listener, Node},
+        handoff_port,
+        infinity).
 
 get_handoff_ssl_options() ->
     case app_helper:get_env(riak_core, handoff_ssl_options, []) of
@@ -541,9 +533,6 @@ is_elapsed(TS) ->
 incr_bytes(Stats=#ho_stats{bytes=Bytes}, NumBytes) ->
     Stats#ho_stats{bytes=Bytes + NumBytes}.
 
-incr_objs(Stats) ->
-    incr_objs(Stats, 1).
-
 %% @private
 %%
 %% @doc Increment `Stats' object count by NObjs:
@@ -595,25 +584,6 @@ get_filter(Opts) ->
     end.
 
 %% @private
-%%
-%% @doc check if the handoff reciever will accept batching messages
-%%      otherwise fall back to the slower, object-at-a-time path
-
-remote_supports_batching(Node) ->
-
-    case catch rpc:call(Node, riak_core_handoff_receiver,
-                  supports_batching, []) of
-        true ->
-            lager:debug("remote node supports batching, enabling"),
-            true;
-        _ ->
-            %% whatever the problem here, just revert to the old behavior
-            %% which shouldn't matter too much for any single handoff
-            lager:debug("remote node doesn't support batching"),
-            false
-    end.
-
-%% @private
 %% @doc The optional call to handoff_started/2 allows vnodes
 %% one last chance to abort the handoff process and to supply options
 %% to be passed to the ?FOLD_REQ if not aborted.the function is passed
@@ -630,13 +600,15 @@ maybe_call_handoff_started(Module, SrcPartition) ->
                 {ok, FoldOpts} ->
                     FoldOpts;
                 {error, max_concurrency} ->
-                    %% Handoff of that partition is busy or can't proceed. Stopping with
-                    %% max_concurrency will cause this partition to be retried again later.
+                    %% Handoff of that partition is busy or can't proceed.
+                    %% Stopping with max_concurrency will cause this partition
+                    %% to be retried again later.
                     exit({shutdown, max_concurrency});
                 {error, Error} ->
                     exit({shutdown, Error})
             end;
         false ->
-            %% optional callback not implemented, so we carry on, w/ no addition fold options
+            %% optional callback not implemented, so we carry on, w/ no 
+            %% additional fold options
             []
     end.

--- a/src/riak_core_metadata_manager.erl
+++ b/src/riak_core_metadata_manager.erl
@@ -45,7 +45,8 @@
          merge/2,
          is_stale/1,
          graft/1,
-         exchange/1]).
+         exchange/1,
+         waitfor_exchange/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -309,6 +310,26 @@ exchange(Peer) ->
     case riak_core_metadata_exchange_fsm:start(Peer, Timeout) of
         {ok, Pid} ->
             {ok, Pid};
+        {error, Reason} ->
+            {error, Reason};
+        ignore ->
+            {error, ignore}
+    end.
+
+%% @doc Trigger an exchange and wait for it to complete 
+-spec waitfor_exchange(node()) -> ok | {error, term()}.
+waitfor_exchange(Peer) ->
+    Timeout = app_helper:get_env(riak_core, metadata_exchange_timeout, 60000),
+    case riak_core_metadata_exchange_fsm:start(Peer, self(), Timeout) of
+        {ok, Pid} ->
+            receive
+                complete ->
+                    ok
+            after
+                Timeout ->
+                    lager:warning("timeout on metadata exchange ~w", [Pid]),
+                    {error, timeout}
+            end;
         {error, Reason} ->
             {error, Reason};
         ignore ->


### PR DESCRIPTION
Refactor handoff to avoid TCP RECV error - see https://github.com/basho/riak_core/issues/994.

- Clarify meaning of terms:

  - `handoff_timeout` if the receiver does not respond to a sender message within this period, then the sender should assume the receiver is down and exit the fold.  The sender can exchange sync messages every `handoff_acksync_threshold` batches to ensure that batches do not accumulate at the receiver causing the sender to fail to get a timely response to a future request. 

  - `handoff_receive_timeout`  if the receiver does not receive a message from the sender within this timeout, it will assume that the sender is down and exit the process.  The sender will interrupt the fold if it has not sent a batch in the last `handoff_receive_timeout div 3` to send a sync message as a keepalive to prevent this timeout if it is alive.

- The default value of `handoff_acksync_threshold` is changed to 1 from 25.  At 25 batches, and 250 bytes every object size, a backlog of 100K handoff items could develop at the receiver - requiring a sub-1ms response time for each handoff item to avoid triggering the timeout.  Alternative default of 1 is less likely to see the timeout, at the small cost of an additional sync round-trip per batch.

- A `handoff_batch_threshold_count` has been added to generate a threshold for a batch when this count of objects is reached.  The `handoff_batch_threshold` is also respected (which triggers a batch on size in bytes).  This is to prevent very large batches by count when object sizes are small.

- The ?PT_MSG_OLDSYNC is now properly deprecated.  The receiver will still respond, should a cluster contain a handoff sender still on a previous version, but the sender will now only send the ?PT_MSG_SYNC message.

- Reformatting of code to fit column width.

- Standardise handling of sync messages through `riakc_core_handoff_sender:send_sync/3` function, and now error logs raised at the actual message where an error is received.  The item queue is redacted in the error generated by a throw, so that important details are not obfuscated by a large list of binaries.

- A new log has been added to log progress in sending batches every `handoff_acklog_threshold` batches (default 100).  This allows for progress to be tracked through log indexers, rather than manually by operators calling the `riak admin transfers` command.

- All code for (legacy) non-batched handoff removed.